### PR TITLE
Deal with invalid datetimes 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
     	<groupId>com.zendesk</groupId>
     	<artifactId>open-replicator</artifactId>
-    	<version>1.1.3</version>
+    	<version>1.2.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
@@ -15,6 +15,7 @@ import com.google.code.or.binlog.BinlogEventV4Header;
 import com.google.code.or.binlog.impl.event.AbstractRowEvent;
 import com.google.code.or.common.glossary.Column;
 import com.google.code.or.common.glossary.Row;
+import com.google.code.or.common.glossary.column.DatetimeColumn;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
@@ -179,6 +180,7 @@ public abstract class MaxwellAbstractRowsEvent extends AbstractRowEvent {
 	// the equivalent of "asJSON" -- convert the row to an array of
 	// hashes
 	public RowMap jsonMap() {
+		Object value;
 		RowMap rowMap = new RowMap();
 
 		rowMap.setRowType(getType());
@@ -193,7 +195,11 @@ public abstract class MaxwellAbstractRowsEvent extends AbstractRowEvent {
 				Column c = colIter.next();
 				ColumnDef d = defIter.next();
 
-				Object value = c.getValue();
+				if ( c instanceof DatetimeColumn )
+					value = ((DatetimeColumn) c).getLongValue();
+				else
+					value = c.getValue();
+
 				if ( value != null )
 					value = d.asJSON(value);
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -36,13 +36,27 @@ public class DateTimeColumnDef extends ColumnDef {
 	}
 
 	private String formatValue(Object value) {
-		if ( value instanceof Date )
+		if ( value instanceof Long && getType().equals("datetime") )
+			return formatLong((Long) value);
+		else if ( value instanceof Date )
 			return getDateTimeFormatter().format((Date) value);
 		else if ( value instanceof Timestamp )
 			return getDateTimeFormatter().format((Timestamp) value);
 		else
 			return "";
 	}
+
+	private String formatLong(Long value) {
+		final int second = (int)(value % 100); value /= 100;
+		final int minute = (int)(value % 100); value /= 100;
+		final int hour = (int)(value % 100); value /= 100;
+		final int day = (int)(value % 100); value /= 100;
+		final int month = (int)(value % 100);
+		final int year = (int)(value / 100);
+
+		return String.format("%04d-%02d-%02d %02d:%02d:%02d",  year, month, day, hour, minute, second);
+	}
+
 
 	@Override
 	public String toSQL(Object value) {

--- a/src/test/java/com/zendesk/maxwell/MysqlParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlParserTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -181,7 +182,8 @@ public class MysqlParserTest extends AbstractMaxwellTest {
 		}
 	}
 
-	private void runJSONTestFile(File file) throws Exception {
+	private void runJSONTestFile(String fname) throws Exception {
+		File file = new File(fname);
 		ArrayList<JSONObject> jsonAsserts = new ArrayList<>();
 		ArrayList<String> inputSQL  = new ArrayList<>();
 		BufferedReader reader = new BufferedReader(new FileReader(file));
@@ -203,15 +205,34 @@ public class MysqlParserTest extends AbstractMaxwellTest {
 
 	    runJSONTest(inputSQL, jsonAsserts);
 	}
+
 	@Test
-	public void testRunJSONTests() throws Exception {
-
-		for ( File file: new File(getSQLDir() + "/json").listFiles()) {
-			if ( !file.getName().startsWith("test"))
-				continue;
-
-			runJSONTestFile(file);
-		}
+	public void testRunMainJSONTest() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_1j");
 	}
 
+	@Test
+	public void testCreateLikeJSON() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_create_like");
+	}
+
+	@Test
+	public void testEnumJSON() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_enum");
+	}
+
+	@Test
+	public void testLatin1JSON() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_latin1");
+	}
+
+	@Test
+	public void testSetJSON() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_set");
+	}
+
+	@Test
+	public void testZeroCreatedAtJSON() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_zero_created_at");
+	}
 }

--- a/src/test/resources/sql/json/test_zero_created_at
+++ b/src/test/resources/sql/json/test_zero_created_at
@@ -1,7 +1,7 @@
 CREATE DATABASE `cdb`
 create table `cdb`.`ca` ( id int(11) auto_increment not null primary key, datecol datetime NOT NULL default 0, ch varchar(255));
 insert into cdb.ca set ch='a';
--> {"table": "ca", "type": "insert", "data": [ {"ch": "a", "datecol": "0000-00-00 00:00:00"} ] }
-insert into cdb.ca set ch='a', datecol = '0000-00-00 00:00:01';
--> {"table": "ca", "type": "insert", "data": [ {"ch": "a", "datecol": "0003-00-00 00:00:01"} ] }
+-> {"table": "ca", "type": "insert", "data": [ {"id": 1, "ch": "a", "datecol": "0000-00-00 00:00:00"} ] }
+insert into cdb.ca set ch='a', datecol = '0003-00-00 00:00:01';
+-> {"table": "ca", "type": "insert", "data": [ {"id": 2, "ch": "a", "datecol": "0003-00-00 00:00:01"} ] }
 

--- a/src/test/resources/sql/json/test_zero_created_at
+++ b/src/test/resources/sql/json/test_zero_created_at
@@ -1,0 +1,7 @@
+CREATE DATABASE `cdb`
+create table `cdb`.`ca` ( id int(11) auto_increment not null primary key, datecol datetime NOT NULL default 0, ch varchar(255));
+insert into cdb.ca set ch='a';
+-> {"table": "ca", "type": "insert", "data": [ {"ch": "a", "datecol": "0000-00-00 00:00:00"} ] }
+insert into cdb.ca set ch='a', datecol = '0000-00-00 00:00:01';
+-> {"table": "ca", "type": "insert", "data": [ {"ch": "a", "datecol": "0003-00-00 00:00:01"} ] }
+


### PR DESCRIPTION
Mysql allows us to store invalid datetimes; the most common of these is '0000-00-00 00:00:00'.  In standard open-replicator, we try to bring this into a java datetime, which then *sorta* fails.  In 1.2.0 of open-replicator we preserve the underlying mysql value as a long so that we can cast it back into its original value.  And then here we use that original value instead of the parsed datetime.

mysql is ugly.

@vanchi-zendesk 