### PR TITLE
force Maxwell into running under a utf8 locale

### DIFF
--- a/bin/maxwell
+++ b/bin/maxwell
@@ -15,5 +15,7 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
+export LANG="en_US.UTF-8"
+
 exec $JAVA -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
 


### PR DESCRIPTION
otherwise java is mangling strings.  I suppose there's something I'm doing wrong, but this will fix the thing.

@vanchi-zendesk 