### PR TITLE
flush schema pos on exit

### DIFF
--- a/src/main/java/com/zendesk/maxwell/BinlogPosition.java
+++ b/src/main/java/com/zendesk/maxwell/BinlogPosition.java
@@ -32,4 +32,18 @@ public class BinlogPosition {
 	public String toString() {
 		return "BinlogPosition[" + file + ":" + offset + "]";
 	}
+
+	public boolean newerThan(BinlogPosition other) {
+		if ( other == null )
+			return true;
+
+		int cmp = this.file.compareTo(other.file);
+		if ( cmp > 0 ) {
+			return true;
+		} else if ( cmp == 0 ) {
+			return this.offset > other.offset;
+		} else {
+			return false;
+		}
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -39,6 +39,13 @@ public class Maxwell {
 
 		this.context = new MaxwellContext(this.config);
 
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+			@Override
+			public void run() {
+				context.terminate();
+			}
+		});
+
 		try ( Connection connection = this.context.getConnectionPool().getConnection() ) {
 			MaxwellMysqlStatus.ensureMysqlState(connection);
 			SchemaStore.ensureMaxwellSchema(connection);

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -33,6 +33,10 @@ public class Maxwell {
 
 	private void run(String[] args) throws Exception {
 		this.config = MaxwellConfig.buildConfig("config.properties", args);
+
+		if ( this.config.log_level != null )
+			MaxwellLogging.setLevel(this.config.log_level);
+
 		this.context = new MaxwellContext(this.config);
 
 		try ( Connection connection = this.context.getConnectionPool().getConnection() ) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -25,7 +25,7 @@ public class MaxwellConfig {
 	public String kafkaTopic;
 	public String producerType;
 	public String outputFile;
-
+	public String log_level;
 
 	public MaxwellConfig() {
 		this.kafkaProperties = new Properties();
@@ -40,6 +40,7 @@ public class MaxwellConfig {
 
 	private OptionParser getOptionParser() {
 		OptionParser parser = new OptionParser();
+		parser.accepts( "log_level", "log level, one of DEBUG|INFO|WARN|ERROR" ).withRequiredArg();
 		parser.accepts( "host", "mysql host" ).withRequiredArg();
 		parser.accepts( "user", "mysql username" ).withRequiredArg();
 		parser.accepts( "password", "mysql password" ).withRequiredArg();
@@ -52,12 +53,22 @@ public class MaxwellConfig {
 		return parser;
 	}
 
+	private String parseLogLevel(String level) {
+		level = level.toLowerCase();
+		if ( !( level.equals("debug") || level.equals("info") || level.equals("warn") || level.equals("error")))
+			usage("unknown log level: " + level);
+		return level;
+	}
+
 	private void parseOptions(String [] argv) {
 		OptionSet options = getOptionParser().parse(argv);
 
 		if ( options.has("help") )
 			usage("Help for Maxwell:");
 
+		if ( options.has("log_level")) {
+			this.log_level = parseLogLevel((String) options.valueOf("log_level"));
+		}
 		if ( options.has("host"))
 			this.mysqlHost = (String) options.valueOf("host");
 		if ( options.has("password"))
@@ -93,6 +104,9 @@ public class MaxwellConfig {
 		this.producerType    = p.getProperty("producer");
 		this.outputFile      = p.getProperty("output_file");
 		this.kafkaTopic      = p.getProperty("kafka_topic");
+
+		if ( p.containsKey("log_level") )
+			this.log_level = parseLogLevel(p.getProperty("log_level"));
 
 		for ( Enumeration<Object> e = p.keys(); e.hasMoreElements(); ) {
 			String k = (String) e.nextElement();

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -60,6 +60,10 @@ public class MaxwellContext {
 		this.getSchemaPosition().set(position);
 	}
 
+	public void setInitialPositionSync(BinlogPosition position) throws SQLException {
+		this.getSchemaPosition().setSync(position);
+	}
+
 	public Long getServerID() throws SQLException {
 		if ( this.serverID != null)
 			return this.serverID;
@@ -85,4 +89,5 @@ public class MaxwellContext {
 			return new StdoutProducer(this);
 		}
 	}
+
 }

--- a/src/main/java/com/zendesk/maxwell/MaxwellLogging.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellLogging.java
@@ -1,0 +1,17 @@
+package com.zendesk.maxwell;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+
+public class MaxwellLogging {
+	public static void setLevel(String level) {
+		LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+		Configuration config = ctx.getConfiguration();
+		LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+		loggerConfig.setLevel(Level.valueOf(level));
+		ctx.updateLoggers();  // This causes all Loggers to refetch information from their LoggerConfig.
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -193,6 +193,7 @@ public class MaxwellParser {
 			try ( Connection c = this.context.getConnectionPool().getConnection() ) {
 				new SchemaStore(c, schema, p).save();
 			}
+			this.context.setInitialPositionSync(p);
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
@@ -101,11 +101,10 @@ public class SchemaPosition implements Runnable {
 	public void setSync(BinlogPosition p) {
 		LOGGER.debug("syncing binlog position: " + p);
 		position.set(p);
-		thread.interrupt();
 		while ( true ) {
+			thread.interrupt();
 			BinlogPosition s = storedPosition.get();
 			if ( p.newerThan(s) ) {
-				System.out.println("sleeping, waiting... ");
 				try { Thread.sleep(50); } catch (InterruptedException e) { }
 			} else {
 				break;


### PR DESCRIPTION
Also:
- we add a setInitialPositionSync that lets us know for sure the position is flushed by the time the call returns; we use this when processing schema changes.  
- add log_level command line option

@vanchi-zendesk 

