### PR TITLE
Quickstart docs: add server-id to my.cnf

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -7,6 +7,7 @@ Maxwell can only operate if row-based replication is on.
 $ vi my.cnf
 
 [mysqld]
+server-id=1
 log-bin=master
 binlog_format=row
 ```


### PR DESCRIPTION
Avoid this exception:

```
com.google.code.or.net.TransportException: Misconfigured master - server id was not set
    at com.google.code.or.OpenReplicator.dumpBinlog(OpenReplicator.java:264)
    at com.google.code.or.OpenReplicator.start(OpenReplicator.java:94)
    at com.zendesk.maxwell.MaxwellParser.start(MaxwellParser.java:80)
    at com.zendesk.maxwell.MaxwellParser.run(MaxwellParser.java:92)
    at com.zendesk.maxwell.Maxwell.run(Maxwell.java:69)
    at com.zendesk.maxwell.Maxwell.main(Maxwell.java:75)
```

/cc @osheroff @vanchi-zendesk 