### PR TITLE
Support db columns with ascii encoding

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -41,7 +41,7 @@ public class StringColumnDef extends ColumnDef {
 		switch(encoding) {
 		case "utf8": case "utf8mb4":
 			return Charset.forName("UTF-8");
-		case "latin1":
+		case "latin1": case "ascii":
 			return Charset.forName("ISO-8859-1");
 		default:
 			return null;

--- a/src/test/java/com/zendesk/maxwell/ColumnDefTest.java
+++ b/src/test/java/com/zendesk/maxwell/ColumnDefTest.java
@@ -119,6 +119,18 @@ public class ColumnDefTest {
 	}
 
 	@Test
+	public void TestAsciiString() {
+		byte input[] = new byte[4];
+		input[0] = Byte.valueOf((byte) 126);
+		input[1] = Byte.valueOf((byte) 126);
+		input[2] = Byte.valueOf((byte) 126);
+		input[3] = Byte.valueOf((byte) 126);
+
+		ColumnDef d = ColumnDef.build("foo", "bar", "ascii", "varchar", 1, false, null);
+		assertThat((String) d.asJSON(input), is("~~~~"));
+	}
+
+	@Test
 	public void TestStringAsJSON() {
 		byte input[] = new byte[4];
 		input[0] = Byte.valueOf((byte) 169);


### PR DESCRIPTION
Avoid exceptions like:

```
java.lang.NullPointerException: charset
	at java.lang.String.<init>(String.java:451)
	at java.lang.String.<init>(String.java:505)
	at com.zendesk.maxwell.schema.columndef.StringColumnDef.asJSON(StringColumnDef.java:54)
	at com.zendesk.maxwell.MaxwellAbstractRowsEvent.jsonMaps(MaxwellAbstractRowsEvent.java:219)
	at com.zendesk.maxwell.MaxwellAbstractRowsEvent.toJSONStrings(MaxwellAbstractRowsEvent.java:241)
	at com.zendesk.maxwell.StdoutProducer.push(StdoutProducer.java:12)
	at com.zendesk.maxwell.MaxwellParser.run(MaxwellParser.java:100)
	at com.zendesk.maxwell.Maxwell.run(Maxwell.java:69)
	at com.zendesk.maxwell.Maxwell.main(Maxwell.java:75)
```

/cc @osheroff @vanchi-zendesk 