### PR TITLE
cast column names to lower case

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -55,18 +55,21 @@ public class Table {
 	}
 
 	public int findColumnIndex(String name) {
+		String lcName = name.toLowerCase();
 		initColumnOffsetMap();
 
-		if ( this.columnOffsetMap.containsKey(name) ) {
-			return this.columnOffsetMap.get(name);
+		if ( this.columnOffsetMap.containsKey(lcName) ) {
+			return this.columnOffsetMap.get(lcName);
 		} else {
 			return -1;
 		}
 	}
 
 	private ColumnDef findColumn(String name) {
+		String lcName = name.toLowerCase();
+
 		for (ColumnDef c : columnList )  {
-			if ( c.getName().equals(name) )
+			if ( c.getName().equals(lcName) )
 				return c;
 		}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -11,7 +11,7 @@ public abstract class ColumnDef {
 
 	public ColumnDef(String tableName, String name, String type, int pos) {
 		this.tableName = tableName;
-		this.name = name;
+		this.name = name.toLowerCase();
 		this.type = type;
 		this.pos = pos;
 		this.signed = false;

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -249,4 +249,9 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 	public void testZeroCreatedAtJSON() throws Exception {
 		runJSONTestFile(getSQLDir() + "/json/test_zero_created_at");
 	}
+
+	@Test
+	public void testCaseSensitivity() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_case_insensitive");
+	}
 }

--- a/src/test/resources/sql/json/test_case_insensitive
+++ b/src/test/resources/sql/json/test_case_insensitive
@@ -1,0 +1,5 @@
+create database case_db;
+use case_db;
+create table case_db.test_case(ID int(10) unsigned not null auto_increment primary key, BAR_FIELD varchar(255));
+insert into test_case set bar_field='bar';
+  -> {database:"case_db", table: "test_case", type: "insert", data: {"id": 1, bar_field: "bar"}}


### PR DESCRIPTION
@zendesk/rules turns out table and db names have all sorts of arcane bullshit based on the system you're on, but column names are *always* case insensitive.

