### PR TITLE
use a 50 MB buffer by default

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -64,6 +64,8 @@ public class MaxwellParser {
 		this.replicator.setPassword(ctx.getConfig().mysqlPassword);
 		this.replicator.setPort(ctx.getConfig().mysqlPort);
 
+		this.replicator.setLevel2BufferSize(50 * 1024 * 1024);
+
 		this.producer = producer;
 
 		this.context = ctx;


### PR DESCRIPTION
we're overflowing some buffer with ultra-large row events.  I can't be certain that it's this one (can't seem to repro locally, faithfully), but this seems the most likely.

@zendesk/rules