### PR TITLE
bump open-replicator to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
     	<groupId>com.zendesk</groupId>
     	<artifactId>open-replicator</artifactId>
-    	<version>1.2.2</version>
+    	<version>1.2.3</version>
     </dependency>
     <dependency>
     	<groupId>net.sf.jopt-simple</groupId>

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -20,7 +20,8 @@ public class MysqlIsolatedServer {
 	public void boot() throws IOException, SQLException {
         final String dir = System.getProperty("user.dir");
 
-		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/mysql_isolated_server/bin/boot_isolated_mysql_server", "--", "--binlog_format=row");
+		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/mysql_isolated_server/bin/boot_isolated_mysql_server",
+												"--", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1");
 		Map<String, String> env = pb.environment();
 
 		env.put("PATH", env.get("PATH") + ":/opt/local/bin");


### PR DESCRIPTION
this allows OR to handle rows greater than 16mb.

@zendesk/rules 