### PR TITLE
TRUNCATE [table_name] is apparently valid syntax too

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
@@ -36,7 +36,7 @@ public abstract class SchemaChange {
 		SQL_BLACKLIST.add(Pattern.compile("^SET\\s+PASSWORD", Pattern.CASE_INSENSITIVE));
 		SQL_BLACKLIST.add(Pattern.compile("^(CREATE|DROP|RENAME)\\s+USER", Pattern.CASE_INSENSITIVE));
 
-		SQL_BLACKLIST.add(Pattern.compile("^TRUNCATE\\s+TABLE", Pattern.CASE_INSENSITIVE));
+		SQL_BLACKLIST.add(Pattern.compile("^TRUNCATE\\s+", Pattern.CASE_INSENSITIVE));
 	}
 
 	private static boolean matchesBlacklist(String sql) {


### PR DESCRIPTION
@zendesk/rules 