### PR TITLE
ignore the BINARY flag in string column creation

### DIFF
--- a/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
+++ b/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
@@ -27,7 +27,6 @@ create_table:
       | create_like_tbl
     );
     
-// TODO: support if-not-exists
 create_table_preamble: CREATE TEMPORARY? TABLE (IF NOT EXISTS)? table_name;
 create_specifications: '(' create_specification (',' create_specification)* ')'; 
 

--- a/src/main/antlr4/imports/column_definitions.g4
+++ b/src/main/antlr4/imports/column_definitions.g4
@@ -38,8 +38,10 @@ signed_type: // we need the UNSIGNED flag here
 string_type: // getting the encoding here 
 	  col_type=(CHAR | VARCHAR)
 	           length?
+	           BINARY?
 	           charset_def?
-    | col_type=(TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT) 
+    | col_type=(TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT)
+    			BINARY?
   		        charset_def?
 	  ;
 

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -358,4 +358,9 @@ public class DDLParserTest {
 		assertThat(changes.size(), is(1));
 	}
 
+	@Test
+	public void testBinaryChar() {
+		List<SchemaChange> changes = parse("CREATE TABLE `foo` ( `id` char(16) BINARY character set 'utf8' )");
+		assertThat(changes.size(), is(1));
+	}
 }


### PR DESCRIPTION
a quick spelunk into the mysql source code shows that this flag only
affects the collation of the column.  We don't give even the slightest
care about that, so we'll parse and ignore it.

@zendesk/rules 