### PR TITLE
Fix server_id bug

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -25,7 +25,7 @@ public class Maxwell {
 		this.schema = capturer.capture();
 
 		BinlogPosition pos = BinlogPosition.capture(connection);
-		SchemaStore store = new SchemaStore(connection, this.schema, pos);
+		SchemaStore store = new SchemaStore(connection, this.context.getServerID(), this.schema, pos);
 		store.save();
 
 		this.context.setInitialPosition(pos);
@@ -52,7 +52,7 @@ public class Maxwell {
 
 			if ( this.context.getInitialPosition() != null ) {
 				LOGGER.info("Maxwell is booting, starting at " + this.context.getInitialPosition());
-				SchemaStore store = SchemaStore.restore(connection, this.context.getInitialPosition());
+				SchemaStore store = SchemaStore.restore(connection, this.context.getServerID(), this.context.getInitialPosition());
 				this.schema = store.getSchema();
 			} else {
 				initFirstRun(connection);

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -219,7 +219,7 @@ public class MaxwellParser {
 			BinlogPosition p = eventBinlogPosition(event);
 			LOGGER.info("storing schema @" + p + " after applying \"" + sql.replace('\n',' ') + "\"");
 			try ( Connection c = this.context.getConnectionPool().getConnection() ) {
-				new SchemaStore(c, schema, p).save();
+				new SchemaStore(c, this.context.getServerID(), schema, p).save();
 			}
 			this.context.setInitialPositionSync(p);
 		}

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -13,15 +13,15 @@ import java.util.List;
 import java.util.Map;
 
 public class MysqlIsolatedServer {
-	private Connection connection;
-	private String baseDir;
+	public static final Long SERVER_ID = 123123L;
+	private Connection connection; private String baseDir;
 	private int port;
 
 	public void boot() throws IOException, SQLException {
         final String dir = System.getProperty("user.dir");
 
 		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/mysql_isolated_server/bin/boot_isolated_mysql_server",
-												"--", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1");
+												"--", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1", "--server_id=" + SERVER_ID);
 		Map<String, String> env = pb.environment();
 
 		env.put("PATH", env.get("PATH") + ":/opt/local/bin");

--- a/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
@@ -1,18 +1,17 @@
 package com.zendesk.maxwell;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.*;
 
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaCapturer;
@@ -36,14 +35,14 @@ public class SchemaStoreTest extends AbstractMaxwellTest {
 		server.executeList(schemaSQL);
 		this.schema = new SchemaCapturer(server.getConnection()).capture();
 		this.binlogPosition = BinlogPosition.capture(server.getConnection());
-		this.schemaStore = new SchemaStore(server.getConnection(), this.schema, binlogPosition);
+		this.schemaStore = new SchemaStore(server.getConnection(), MysqlIsolatedServer.SERVER_ID, this.schema, binlogPosition);
 	}
 
 	@Test
 	public void testSave() throws SQLException, IOException, SchemaSyncError {
 		this.schemaStore.save();
 
-		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(), binlogPosition);
+		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(), MysqlIsolatedServer.SERVER_ID, binlogPosition);
 		List<String> diff = this.schema.diff(restoredSchema.getSchema(), "captured schema", "restored schema");
 		assertThat(StringUtils.join(diff, "\n"), diff.size(), is(0));
 	}
@@ -52,7 +51,7 @@ public class SchemaStoreTest extends AbstractMaxwellTest {
 	public void testRestorePK() throws Exception {
 		this.schemaStore.save();
 
-		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(), binlogPosition);
+		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(), MysqlIsolatedServer.SERVER_ID, binlogPosition);
 		Table t = restoredSchema.getSchema().findDatabase("shard_1").findTable("pks");
 
 		assertThat(t.getPKList(), is(not(nullValue())));
@@ -60,5 +59,22 @@ public class SchemaStoreTest extends AbstractMaxwellTest {
 		assertThat(t.getPKList().get(0), is("col2"));
 		assertThat(t.getPKList().get(1), is("col3"));
 		assertThat(t.getPKList().get(2), is("id"));
+	}
+
+	@Test
+	public void testUpgradeToFixServerIDBug() throws Exception {
+		// create a couple of schemas
+		this.schemaStore.save();
+		Long badSchemaID = this.schemaStore.getSchemaID();
+
+		// throw into old state
+		String updateSQL[] = {"UPDATE maxwell.schemas set server_id = 1"};
+		server.executeList(updateSQL);
+
+		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(), server.SERVER_ID, binlogPosition);
+
+		assertThat(restoredSchema.getSchema().equals(this.schemaStore.getSchema()), is(true));
+		assertThat(restoredSchema.getSchemaID(), is(badSchemaID + 1));
+
 	}
 }


### PR DESCRIPTION
maxwell had a bug in which schemas were always saved with server_id == 1 -- meaning someone could switch server_ids out from underneath us without us knowing.  bad news!  this fixes.

note that this means if the master flips, we will end up re-capturing the schema.  that's ok for now.

@zendesk/rules 