### PR TITLE
handle COMMIT QUERY_EVENTs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.zendesk</groupId>
   <artifactId>maxwell</artifactId>
-  <version>0.10.0-RC4</version>
+  <version>0.11.0-PRE1</version>
   <packaging>jar</packaging>
 
   <name>maxwell</name>

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -188,7 +188,7 @@ public class MaxwellParser {
 				case MySQLConstants.QUERY_EVENT:
 					QueryEvent qe = (QueryEvent) v4Event;
 
-					if ( qe.getSql().toString() == "COMMIT" ) {
+					if ( qe.getSql().toString().equals("COMMIT") ) {
 						// some storage engines(?) will output a "COMMIT" QUERY_EVENT instead of a XID_EVENT.
 						// not sure exactly how to trigger this.
 						if ( !list.isEmpty() )

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -187,10 +187,17 @@ public class MaxwellParser {
 					break;
 				case MySQLConstants.QUERY_EVENT:
 					QueryEvent qe = (QueryEvent) v4Event;
-					// TODO: need to handle this case.
-					// The MySQL guys say some storage engines will output a "COMMIT" QUERY_EVENT at the
-					// end of the stream.
-					throw new RuntimeException("Unhandled QueryEvent: " + qe);
+
+					if ( qe.getSql().toString() == "COMMIT" ) {
+						// some storage engines(?) will output a "COMMIT" QUERY_EVENT instead of a XID_EVENT.
+						// not sure exactly how to trigger this.
+						if ( !list.isEmpty() )
+							list.getLast().setTXCommit();
+
+						return list;
+					} else {
+						throw new RuntimeException("Unhandled QueryEvent: " + qe);
+					}
 				case MySQLConstants.XID_EVENT:
 					XidEvent xe = (XidEvent) v4Event;
 					for ( MaxwellAbstractRowsEvent e : list )


### PR DESCRIPTION
@zendesk/rules @bfabry @baxter @chausler 

managed to even get a repro of this behavior.  Note that this means events using myISAM will have `commit: true` but no `xid`.  I don't think this matters much for your use case.

