### PR TITLE
Degrade sql inside of a transaction to a warning

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -187,16 +187,19 @@ public class MaxwellParser {
 					break;
 				case MySQLConstants.QUERY_EVENT:
 					QueryEvent qe = (QueryEvent) v4Event;
+					String sql = qe.getSql().toString();
 
-					if ( qe.getSql().toString().equals("COMMIT") ) {
+					if ( sql.equals("COMMIT") ) {
 						// some storage engines(?) will output a "COMMIT" QUERY_EVENT instead of a XID_EVENT.
 						// not sure exactly how to trigger this.
 						if ( !list.isEmpty() )
 							list.getLast().setTXCommit();
 
 						return list;
+					} else if ( sql.toUpperCase().startsWith("SAVEPOINT")) {
+						LOGGER.info("Ignoring SAVEPOINT in transaction: " + qe);
 					} else {
-						throw new RuntimeException("Unhandled QueryEvent: " + qe);
+						LOGGER.warn("Unhandled QueryEvent inside transaction: " + qe);
 					}
 				case MySQLConstants.XID_EVENT:
 					XidEvent xe = (XidEvent) v4Event;


### PR DESCRIPTION
mysql will apparently put a SAVEPOINT inside of its binlogs.  go figure!

@zendesk/rules @bfabry 