### PR TITLE
position independence for CHARACTER SET, COLLATION

### DIFF
--- a/src/main/antlr4/imports/column_definitions.g4
+++ b/src/main/antlr4/imports/column_definitions.g4
@@ -5,7 +5,6 @@ import mysql_literal_tokens, mysql_idents;
 column_definition:
 	col_name=name
 	data_type 
-	column_options*
 	;
 
 col_position: FIRST | (AFTER id);
@@ -18,11 +17,11 @@ data_type:
 	;
 
 	
-// from http://dev.mysql.com/doc/refman/5.1/en/create-table.html
-generic_type: // types from which we're going to ignore any flags/length 
-	  col_type=(BIT | BINARY | YEAR) length?
-	| col_type=(DATE | TIME | TIMESTAMP | DATETIME | TINYBLOB | MEDIUMBLOB | LONGBLOB | BLOB |  BOOLEAN | BOOL )
-	| col_type=VARBINARY length
+// all from http://dev.mysql.com/doc/refman/5.1/en/create-table.html
+generic_type:
+	  col_type=(BIT | BINARY | YEAR) length? column_options*
+	| col_type=(DATE | TIME | TIMESTAMP | DATETIME | TINYBLOB | MEDIUMBLOB | LONGBLOB | BLOB |  BOOLEAN | BOOL ) column_options*
+	| col_type=VARBINARY length column_options*
 	;
 
 
@@ -30,25 +29,27 @@ signed_type: // we need the UNSIGNED flag here
       col_type=(TINYINT | INT1 | SMALLINT | INT2 | MEDIUMINT | INT3 | INT | INTEGER | INT4 | BIGINT | INT8 )
                 length? 
                 int_flags*
+                column_options*
     | col_type=(REAL | DOUBLE | FLOAT | DECIMAL | NUMERIC)
     		    decimal_length?
-			    int_flags*
+    		    int_flags*
+    		    column_options*
     ;
 
 string_type: // getting the encoding here 
 	  col_type=(CHAR | VARCHAR)
 	           length?
 	           BINARY?
-	           charset_def?
+	           (charset_def | column_options)*
     | col_type=(TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT)
-    			BINARY?
-  		        charset_def?
+               BINARY?
+               (charset_def | column_options)*
 	  ;
 
 enumerated_type:
 	  col_type=(ENUM | SET)
 	  '(' enumerated_values ')'
-	  charset_def? 
+	   (charset_def | column_options)*
 	  ;
 
 

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -381,4 +381,13 @@ public class DDLParserTest {
 		List<SchemaChange> changes = parse("CREATE TABLE `foo` ( `id` char(16) BINARY character set 'utf8' )");
 		assertThat(changes.size(), is(1));
 	}
+
+	@Test
+	public void testCharsetPositionIndependence() {
+		TableCreate create = parseCreate("CREATE TABLE `foo` (id varchar(1) NOT NULL character set 'foo')");
+		assertThat(create.columns.get(0).encoding, is("foo"));
+
+		create = parseCreate("CREATE TABLE `foo` (id varchar(1) character set 'foo' NOT NULL)");
+		assertThat(create.columns.get(0).encoding, is("foo"));
+	}
 }


### PR DESCRIPTION
as it turns out CHARACTER SET and COLLATION may appear in any order in
column options, not just before the generic options (like UNISIGNED and
ZEROFILL do for numeric columns).

fixes https://github.com/zendesk/maxwell/issues/93

@zendesk/rules @Komnomnomnom