### PR TITLE
try to improve test reliability with getEvents()

### DIFF
--- a/src/main/java/com/zendesk/maxwell/EventConsumer.java
+++ b/src/main/java/com/zendesk/maxwell/EventConsumer.java
@@ -1,0 +1,5 @@
+package com.zendesk.maxwell;
+
+public class EventConsumer {
+	void consume(MaxwellAbstractRowsEvent e) {}
+}

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -202,7 +202,7 @@ public class MaxwellParser {
 					max_tries--;
 					continue;
 				} else {
-					System.out.println("maxwell didn't reach the position requested.");
+					LOGGER.error("maxwell didn't reach the position requested.");
 					return;
 				}
 			}

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -163,7 +163,7 @@ public class MaxwellParser {
 
 	}
 
-	public MaxwellAbstractRowsEvent getEvent(boolean stopAtNextTableMap) throws Exception {
+	public MaxwellAbstractRowsEvent getEvent() throws Exception {
         BinlogEventV4 v4Event;
         MaxwellAbstractRowsEvent event;
 		while (true) {
@@ -185,9 +185,6 @@ public class MaxwellParser {
 					return event;
 				break;
 			case MySQLConstants.TABLE_MAP_EVENT:
-				if ( stopAtNextTableMap)
-					return null;
-
 				tableCache.processEvent(this.schema, (TableMapEvent) v4Event);
 				break;
 			case MySQLConstants.QUERY_EVENT:
@@ -196,8 +193,22 @@ public class MaxwellParser {
 		}
 	}
 
-	public MaxwellAbstractRowsEvent getEvent() throws Exception {
-		return getEvent(false);
+	public void getEvents(EventConsumer c, BinlogPosition endPosition) throws Exception {
+		int max_tries = 10;
+		while ( true ) {
+			MaxwellAbstractRowsEvent e = getEvent();
+			if (e == null) {
+				if (max_tries > 0) {
+					max_tries--;
+					continue;
+				} else
+					return;
+			}
+			c.consume(e);
+
+			if ( eventBinlogPosition(e).newerThan(endPosition) )
+				return;
+		}
 	}
 
 	private void processQueryEvent(QueryEvent event) throws SchemaSyncError, SQLException, IOException {
@@ -252,6 +263,7 @@ public class MaxwellParser {
 	public void setFilter(MaxwellFilter filter) {
 		this.filter = filter;
 	}
+
 }
 
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -201,8 +201,10 @@ public class MaxwellParser {
 				if (max_tries > 0) {
 					max_tries--;
 					continue;
-				} else
+				} else {
+					System.out.println("maxwell didn't reach the position requested.");
 					return;
+				}
 			}
 			c.consume(e);
 

--- a/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
+++ b/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
@@ -93,23 +93,28 @@ public class AbstractMaxwellTest {
 
 		p.setFilter(filter);
 
-        server.executeList(Arrays.asList(queries));
+		server.executeList(Arrays.asList(queries));
 
-        p.start();
+		BinlogPosition endPosition = BinlogPosition.capture(server.getConnection());
 
-		ArrayList<MaxwellAbstractRowsEvent> list = new ArrayList<>();
-        MaxwellAbstractRowsEvent e;
+		p.start();
 
-        while ( (e = p.getEvent()) != null ) {
-			if ( !e.getTable().getDatabase().getName().equals("maxwell")) {
-				list.add(e);
+		final ArrayList<MaxwellAbstractRowsEvent> list = new ArrayList<>();
+		MaxwellAbstractRowsEvent e;
+
+		p.getEvents(new EventConsumer() {
+			@Override
+			void consume(MaxwellAbstractRowsEvent e) {
+				if (!e.getTable().getDatabase().getName().equals("maxwell")) {
+					list.add(e);
+				}
 			}
-        }
+		}, endPosition);
 
-        p.stop();
-        context.terminate();
+		p.stop();
+		context.terminate();
 
-        return list;
+		return list;
 	}
 
 	protected List<MaxwellAbstractRowsEvent>getRowsForSQL(MaxwellFilter filter, String queries[]) throws Exception {

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -1,5 +1,9 @@
 package com.zendesk.maxwell;
 
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,6 +21,7 @@ public class MysqlIsolatedServer {
 	private String baseDir;
 	private int port;
 
+	static final Logger LOGGER = LoggerFactory.getLogger(MysqlIsolatedServer.class);
 	public void boot() throws IOException, SQLException {
         final String dir = System.getProperty("user.dir");
 
@@ -24,6 +29,7 @@ public class MysqlIsolatedServer {
 												"--", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1");
 		Map<String, String> env = pb.environment();
 
+		LOGGER.debug("Booting server: " + StringUtils.join(pb.command(), " "));
 		env.put("PATH", env.get("PATH") + ":/opt/local/bin");
 
 		Process p = pb.start();


### PR DESCRIPTION
we now wait until the parser has consumed all of the events that we generate in the test suite.  Hopefully this fixes travis' reliability.

@zendesk/rules 