### PR TITLE
minimal master-change detection

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -49,6 +49,7 @@ public class Maxwell {
 		try ( Connection connection = this.context.getConnectionPool().getConnection() ) {
 			MaxwellMysqlStatus.ensureMysqlState(connection);
 			SchemaStore.ensureMaxwellSchema(connection);
+			SchemaStore.handleMasterChange(connection, context.getServerID());
 
 			if ( this.context.getInitialPosition() != null ) {
 				LOGGER.info("Maxwell is booting, starting at " + this.context.getInitialPosition());

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
@@ -52,7 +52,7 @@ public class SchemaPosition implements Runnable {
 
 	@Override
 	public void run() {
-		while ( true && run.get() ) {
+		while ( run.get() ) {
 			BinlogPosition newPosition = position.get();
 
 			if ( newPosition != null && newPosition.newerThan(storedPosition.get()) ) {

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -362,4 +362,24 @@ public class SchemaStore {
 		}
 	}
 
+	/*
+		for the time being, when we detect other schemas we will simply wipe them down.
+		in the future, this is our moment to pick up where the master left off.
+	*/
+	public static void handleMasterChange(Connection c, Long serverID) throws SQLException {
+		PreparedStatement s = c.prepareStatement(
+				"SELECT id from `maxwell`.`schemas` WHERE server_id != ?"
+		);
+
+		s.setLong(1, serverID);
+		ResultSet rs = s.executeQuery();
+
+		while ( rs.next() ) {
+			Long schemaID = rs.getLong("id");
+			LOGGER.info("maxwell detected schema " + schemaID + " from different server_id.  deleting...");
+			new SchemaStore(c, null, schemaID).destroy();
+		}
+
+		c.createStatement().execute("delete from `maxwell`.`positions` where server_id != " + serverID);
+	}
 }


### PR DESCRIPTION
when we boot up we simply destroy any schemas and positions from other server-ids.  This will keep us from the worst of the master-flip scenarios where we go from master A -> master B -> master A.

@zendesk/rules 