### PR TITLE
Maxwell must crash when its position thread stops.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -48,6 +48,7 @@ public class MaxwellContext {
 		return this.schemaPosition;
 	}
 
+
 	public BinlogPosition getInitialPosition() throws FileNotFoundException, IOException, SQLException {
 		if ( this.initialPosition != null )
 			return this.initialPosition;
@@ -62,6 +63,16 @@ public class MaxwellContext {
 
 	public void setInitialPositionSync(BinlogPosition position) throws SQLException {
 		this.getSchemaPosition().setSync(position);
+	}
+
+	public void ensurePositionThread() throws SQLException {
+		if ( this.schemaPosition == null )
+			return;
+
+		SQLException e = this.schemaPosition.getException();
+		if ( e != null ) {
+			throw (e);
+		}
 	}
 
 	public Long getServerID() throws SQLException {

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -97,13 +97,13 @@ public class MaxwellParser {
 				replicator.start();
 			}
 
+			context.ensurePositionThread();
+
 			if ( event == null )
 				continue;
 
 			if ( !skipEvent(event)) {
 				producer.push(event);
-				// TODO:  we need to tell the producer to only store a stop-event on table-maps; otherwise we can end up
-				// in the middle of multiple row events, which is a bug.
 			}
 
 			replicator.setBinlogFileName(event.getBinlogFilename());
@@ -277,7 +277,7 @@ public class MaxwellParser {
 	}
 
 	private void processQueryEvent(QueryEvent event) throws SchemaSyncError, SQLException, IOException {
-		// get encoding of the alter event somehow; or just fuck it.
+		// get encoding of the alter event somehow? or just fuck it.
 		String dbName = event.getDatabaseName().toString();
 		String sql = event.getSql().toString();
 


### PR DESCRIPTION
In the event of a master cutover, Maxwell would previously amble
blithely along its way with a totally dead position-store thread until
it called SchemaPosition#setSync() and crashed.

Now we are much more aggressive at crashing when the position thread
crashes -- the most common case for ZD is that the master it is pointing
to is read-only.

@zendesk/rules 