### PR TITLE
Revert "minimal master-change detection"

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -49,7 +49,6 @@ public class Maxwell {
 		try ( Connection connection = this.context.getConnectionPool().getConnection() ) {
 			MaxwellMysqlStatus.ensureMysqlState(connection);
 			SchemaStore.ensureMaxwellSchema(connection);
-			SchemaStore.handleMasterChange(connection, context.getServerID());
 
 			if ( this.context.getInitialPosition() != null ) {
 				LOGGER.info("Maxwell is booting, starting at " + this.context.getInitialPosition());

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -362,24 +362,4 @@ public class SchemaStore {
 		}
 	}
 
-	/*
-		for the time being, when we detect other schemas we will simply wipe them down.
-		in the future, this is our moment to pick up where the master left off.
-	*/
-	public static void handleMasterChange(Connection c, Long serverID) throws SQLException {
-		PreparedStatement s = c.prepareStatement(
-				"SELECT id from `maxwell`.`schemas` WHERE server_id != ?"
-		);
-
-		s.setLong(1, serverID);
-		ResultSet rs = s.executeQuery();
-
-		while ( rs.next() ) {
-			Long schemaID = rs.getLong("id");
-			LOGGER.info("maxwell detected schema " + schemaID + " from different server_id.  deleting...");
-			new SchemaStore(c, null, schemaID).destroy();
-		}
-
-		c.createStatement().execute("delete from `maxwell`.`positions` where server_id != " + serverID);
-	}
 }

--- a/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -77,22 +76,5 @@ public class SchemaStoreTest extends AbstractMaxwellTest {
 		assertThat(restoredSchema.getSchema().equals(this.schemaStore.getSchema()), is(true));
 		assertThat(restoredSchema.getSchemaID(), is(badSchemaID + 1));
 
-	}
-
-	@Test
-	public void testMasterChange() throws Exception {
-		this.schema = new SchemaCapturer(server.getConnection()).capture();
-		this.binlogPosition = BinlogPosition.capture(server.getConnection());
-		this.schemaStore = new SchemaStore(server.getConnection(), 5551234L, this.schema, binlogPosition);
-
-		this.schemaStore.save();
-
-		SchemaStore.handleMasterChange(server.getConnection(), 123456L);
-
-		ResultSet rs = server.getConnection().createStatement().executeQuery("SELECT * from `maxwell`.`schemas`");
-		assertThat(rs.next(), is(false));
-
-		rs = server.getConnection().createStatement().executeQuery("SELECT * from `maxwell`.`positions`");
-		assertThat(rs.next(), is(false));
 	}
 }


### PR DESCRIPTION
This reverts commit 82fcbd4eee4807ffeeda1671b63083ac10f21714.

Too much pressure on the replication chain really.  Will bring this back once we have soft deletion + slow scavenging.

@zendesk/rules 