### PR TITLE
Soft delete schemas

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -48,7 +48,10 @@ public class Maxwell {
 
 		try ( Connection connection = this.context.getConnectionPool().getConnection() ) {
 			MaxwellMysqlStatus.ensureMysqlState(connection);
+
 			SchemaStore.ensureMaxwellSchema(connection);
+			SchemaStore.upgradeSchemaStoreSchema(connection);
+
 			SchemaStore.handleMasterChange(connection, context.getServerID());
 
 			if ( this.context.getInitialPosition() != null ) {

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -49,6 +49,7 @@ public class Maxwell {
 		try ( Connection connection = this.context.getConnectionPool().getConnection() ) {
 			MaxwellMysqlStatus.ensureMysqlState(connection);
 			SchemaStore.ensureMaxwellSchema(connection);
+			SchemaStore.handleMasterChange(connection, context.getServerID());
 
 			if ( this.context.getInitialPosition() != null ) {
 				LOGGER.info("Maxwell is booting, starting at " + this.context.getInitialPosition());

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -9,9 +9,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -301,7 +299,8 @@ public class SchemaStore {
 		LOGGER.debug("looking to restore schema at target position " + targetPosition);
 		PreparedStatement s = connection.prepareStatement(
 			"SELECT * from `maxwell`.`schemas` "
-			+ "WHERE ((binlog_file < ?) OR (binlog_file = ? and binlog_position <= ?)) AND server_id = ? "
+			+ "WHERE deleted = 0 "
+			+ "AND ((binlog_file < ?) OR (binlog_file = ? and binlog_position <= ?)) AND server_id = ? "
 			+ "ORDER BY id desc limit 1");
 
 		s.setString(1, targetPosition.getFile());
@@ -324,10 +323,20 @@ public class SchemaStore {
 		this.schema = s;
 	}
 
-	public void destroy() throws SQLException {
+	private void ensureSchemaID() {
 		if ( this.schema_id == null ) {
 			throw new RuntimeException("Can't destroy uninitialized schema!");
 		}
+	}
+
+	public void delete() throws SQLException {
+		ensureSchemaID();
+
+		connection.createStatement().execute("update `maxwell`.`schemas` set deleted = 1 where id = " + schema_id);
+	}
+
+	public void destroy() throws SQLException {
+		ensureSchemaID();
 
 		String[] tables = { "databases", "tables", "columns" };
 
@@ -357,7 +366,7 @@ public class SchemaStore {
 
 		Long toDelete = currentSchemaId - maxSchemas; // start with the highest numbered ID to delete, work downwards until we run out
 		while ( toDelete > 0 && schemaExists(toDelete) ) {
-			new SchemaStore(connection, serverID, toDelete).destroy();
+			new SchemaStore(connection, serverID, toDelete).delete();
 			toDelete--;
 		}
 	}
@@ -368,7 +377,7 @@ public class SchemaStore {
 	*/
 	public static void handleMasterChange(Connection c, Long serverID) throws SQLException {
 		PreparedStatement s = c.prepareStatement(
-				"SELECT id from `maxwell`.`schemas` WHERE server_id != ?"
+				"SELECT id from `maxwell`.`schemas` WHERE server_id != ? and deleted = 0"
 		);
 
 		s.setLong(1, serverID);
@@ -377,9 +386,30 @@ public class SchemaStore {
 		while ( rs.next() ) {
 			Long schemaID = rs.getLong("id");
 			LOGGER.info("maxwell detected schema " + schemaID + " from different server_id.  deleting...");
-			new SchemaStore(c, null, schemaID).destroy();
+			new SchemaStore(c, null, schemaID).delete();
 		}
 
 		c.createStatement().execute("delete from `maxwell`.`positions` where server_id != " + serverID);
+	}
+
+	private static Map<String, String> getTableColumns(String table, Connection c) throws SQLException {
+		HashMap<String, String> map = new HashMap<>();
+
+		ResultSet rs = c.createStatement().executeQuery("show columns from `maxwell`.`" + table + "`");
+		while (rs.next()) {
+			map.put(rs.getString("Field"), rs.getString("Type"));
+		}
+		return map;
+	}
+
+	private static void performAlter(Connection c, String sql) throws SQLException {
+		LOGGER.info("Maxwell is upgrading its own schema...");
+		LOGGER.info(sql);
+		c.createStatement().execute(sql);
+	}
+
+	public static void upgradeSchemaStoreSchema(Connection c) throws SQLException {
+		if ( !getTableColumns("schemas", c).containsKey("deleted") )
+			performAlter(c, "alter table maxwell.schemas add column deleted tinyint(1) not null default 0");
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -362,4 +362,24 @@ public class SchemaStore {
 		}
 	}
 
+	/*
+		for the time being, when we detect other schemas we will simply wipe them down.
+		in the future, this is our moment to pick up where the master left off.
+	*/
+	public static void handleMasterChange(Connection c, Long serverID) throws SQLException {
+		PreparedStatement s = c.prepareStatement(
+				"SELECT id from `maxwell`.`schemas` WHERE server_id != ?"
+		);
+
+		s.setLong(1, serverID);
+		ResultSet rs = s.executeQuery();
+
+		while ( rs.next() ) {
+			Long schemaID = rs.getLong("id");
+			LOGGER.info("maxwell detected schema " + schemaID + " from different server_id.  deleting...");
+			new SchemaStore(c, null, schemaID).destroy();
+		}
+
+		c.createStatement().execute("delete from `maxwell`.`positions` where server_id != " + serverID);
+	}
 }

--- a/src/main/resources/sql/maxwell_schema.sql
+++ b/src/main/resources/sql/maxwell_schema.sql
@@ -3,9 +3,10 @@ CREATE DATABASE IF NOT EXISTS `maxwell`;
 CREATE TABLE IF NOT EXISTS `maxwell`.`schemas` (
   id int unsigned auto_increment NOT NULL primary key,
   binlog_file varchar(255),
-	binlog_position int unsigned,
+  binlog_position int unsigned,
   server_id int unsigned,
-  encoding varchar(255)
+  encoding varchar(255),
+  deleted tinyint(1) not null default 0
 );
 
 CREATE TABLE IF NOT EXISTS `maxwell`.`databases` (

--- a/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
@@ -90,7 +90,8 @@ public class SchemaStoreTest extends AbstractMaxwellTest {
 		SchemaStore.handleMasterChange(server.getConnection(), 123456L);
 
 		ResultSet rs = server.getConnection().createStatement().executeQuery("SELECT * from `maxwell`.`schemas`");
-		assertThat(rs.next(), is(false));
+		assertThat(rs.next(), is(true));
+		assertThat(rs.getBoolean("deleted"), is(true));
 
 		rs = server.getConnection().createStatement().executeQuery("SELECT * from `maxwell`.`positions`");
 		assertThat(rs.next(), is(false));


### PR DESCRIPTION
This should get us to where we are safely and quickly removing a downed master's old schemas.  Will follow up with a set of commits in which we scavenge and slowly delete the old rows from the DB.

@zendesk/rules 