### PR TITLE
transition to "onetimeserver" utility 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "java/mysql_isolated_server"]
-	path = src/test/mysql_isolated_server
-	url = https://github.com/osheroff/mysql_isolated_server.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ before_script:
   - gem install mysql2
 language: java
 rvm: 1.9.3
+env:
+  - MYSQL_VERSION=5.5
+  - MYSQL_VERSION=5.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <h3 id="maxwell-header" style="margin-top: -10px; font-weight: bold">Maxwell = Mysql + Kafka</h3>
 
-
 This is Maxwell's daemon, an application that reads MySQL binlogs and writes row updates to Kafka as JSON.
 It's playing in the same space as [mypipe](https://github.com/mardambey/mypipe) and [databus](http://data.linkedin.com/projects/databus),
 but differentiates itself with these features:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <h3 id="maxwell-header" style="margin-top: -10px; font-weight: bold">Maxwell = Mysql + Kafka</h3>
 
+
 This is Maxwell's daemon, an application that reads MySQL binlogs and writes row updates to Kafka as JSON.
 It's playing in the same space as [mypipe](https://github.com/mardambey/mypipe) and [databus](http://data.linkedin.com/projects/databus),
 but differentiates itself with these features:

--- a/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
+++ b/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
@@ -27,6 +28,11 @@ public class AbstractMaxwellTest {
 		server.boot();
 
 		SchemaStore.ensureMaxwellSchema(server.getConnection());
+	}
+
+	@AfterClass
+	public static void teardownServer() {
+		server.shutDown();
 	}
 
 	public String getSQLDir() {

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -290,7 +290,8 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testZeroCreatedAtJSON() throws Exception {
-		runJSONTestFile(getSQLDir() + "/json/test_zero_created_at");
+		if ( server.getVersion() == "5.5" ) // 5.6 not yet supported.
+			runJSONTestFile(getSQLDir() + "/json/test_zero_created_at");
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -28,11 +28,7 @@ public class MysqlIsolatedServer {
 	public void boot() throws IOException, SQLException, InterruptedException {
         final String dir = System.getProperty("user.dir");
 
-		String mysqlVersion = System.getenv("MYSQL_VERSION");
-		if ( mysqlVersion == null )
-			mysqlVersion = "5.5";
-
-		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/onetimeserver", "--debug", "--mysql-version=" + mysqlVersion,
+		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/onetimeserver", "--debug", "--mysql-version=" + this.getVersion(),
 												"--log-bin=master", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1", "--server_id=" + SERVER_ID);
 		LOGGER.debug("booting onetimeserver: " + StringUtils.join(pb.command(), " "));
 		Process p = pb.start();
@@ -102,5 +98,11 @@ public class MysqlIsolatedServer {
 		try {
 			Runtime.getRuntime().exec("kill " + this.serverPid);
 		} catch ( IOException e ) {}
+	}
+
+	public String getVersion() {
+		String mysqlVersion = System.getenv("MYSQL_VERSION");
+		return mysqlVersion == null ? "5.5" : mysqlVersion;
+
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -1,6 +1,8 @@
 package com.zendesk.maxwell;
 
 import org.apache.commons.lang.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,52 +24,36 @@ public class MysqlIsolatedServer {
 	private int port;
 
 	static final Logger LOGGER = LoggerFactory.getLogger(MysqlIsolatedServer.class);
-	public void boot() throws IOException, SQLException {
+	public void boot() throws IOException, SQLException, InterruptedException {
         final String dir = System.getProperty("user.dir");
 
-		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/mysql_isolated_server/bin/boot_isolated_mysql_server",
-												"--", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1", "--server_id=" + SERVER_ID);
-		Map<String, String> env = pb.environment();
+		String mysqlVersion = System.getenv("MYSQL_VERSION");
+		if ( mysqlVersion == null )
+			mysqlVersion = "5.5";
 
-		LOGGER.debug("Booting server: " + StringUtils.join(pb.command(), " "));
-		env.put("PATH", env.get("PATH") + ":/opt/local/bin");
-
+		ProcessBuilder pb = new ProcessBuilder(dir + "/src/test/onetimeserver", "--mysql-version=" + mysqlVersion,
+												"--log-bin=master", "--binlog_format=row", "--innodb_flush_log_at_trx_commit=1", "--server_id=" + SERVER_ID);
+		LOGGER.debug("booting onetimeserver: " + StringUtils.join(pb.command(), " "));
 		Process p = pb.start();
-		InputStream pStdout = p.getInputStream();
+		BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
 
-		BufferedReader reader = new BufferedReader(new InputStreamReader(pStdout));
-
-		ArrayList<String> mysqlOut = new ArrayList<>();
-
-		while ( true ) {
-			String s = reader.readLine();
-			if ( s == null || s.equals("UP.") )
-				break;
-			mysqlOut.add(s);
+		p.waitFor();
+		String json = reader.readLine();
+		String outputFile = null;
+		try {
+			JSONObject output = new JSONObject(json);
+			this.port = output.getInt("port");
+			outputFile = output.getString("output");
+		} catch ( JSONException e ) {
+			LOGGER.error("got exception while parsing " + json, e);
+			throw(e);
 		}
 
-		if ( mysqlOut.size() == 0 ) {
-			String errLine;
-			BufferedReader stderrReader = new BufferedReader(new InputStreamReader(p.getErrorStream()));
-
-			while ( (errLine = stderrReader.readLine()) != null )
-				System.out.println("mysql isolated error: " + errLine);
-		}
-
-
-		String[] tmpDirSplit = mysqlOut.get(0).split(": ");
-
-		this.baseDir = tmpDirSplit[tmpDirSplit.length - 1];
-
-		String[] portSplit = mysqlOut.get(1).split(": ");
-		String port = portSplit[portSplit.length - 1];
-		System.out.println("Booted mysql server on port: " + port);
-
-		this.port = Integer.valueOf(port);
 
 		this.connection = DriverManager.getConnection("jdbc:mysql://127.0.0.1:" + port + "/mysql", "root", "");
 		this.connection.createStatement().executeUpdate("GRANT REPLICATION SLAVE on *.* to 'maxwell'@'127.0.0.1' IDENTIFIED BY 'maxwell'");
 		this.connection.createStatement().executeUpdate("GRANT ALL on `maxwell`.* to 'maxwell'@'127.0.0.1'");
+		LOGGER.debug("booted at port " + this.port + ", outputting to file " + outputFile);
 	}
 
 	public Connection getConnection() {
@@ -85,10 +71,6 @@ public class MysqlIsolatedServer {
 
 	public void executeList(String[] schemaSQL) throws SQLException {
 		executeList(Arrays.asList(schemaSQL));
-	}
-
-	public String getBaseDir() {
-		return baseDir;
 	}
 
 	public int getPort() {

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -22,6 +22,7 @@ public class MysqlIsolatedServer {
 	public static final Long SERVER_ID = 123123L;
 	private Connection connection; private String baseDir;
 	private int port;
+	private int serverPid;
 
 	static final Logger LOGGER = LoggerFactory.getLogger(MysqlIsolatedServer.class);
 	public void boot() throws IOException, SQLException, InterruptedException {
@@ -43,6 +44,7 @@ public class MysqlIsolatedServer {
 		try {
 			JSONObject output = new JSONObject(json);
 			this.port = output.getInt("port");
+			this.serverPid = output.getInt("server_pid");
 			outputFile = output.getString("output");
 		} catch ( JSONException e ) {
 			LOGGER.error("got exception while parsing " + json, e);
@@ -75,5 +77,11 @@ public class MysqlIsolatedServer {
 
 	public int getPort() {
 		return port;
+	}
+
+	public void shutDown() {
+		try {
+			Runtime.getRuntime().exec("kill " + this.serverPid);
+		} catch ( IOException e ) {}
 	}
 }

--- a/src/test/onetimeserver
+++ b/src/test/onetimeserver
@@ -63,4 +63,4 @@ then
   chmod +x $CACHE_DIR/onetimeserver-go
 fi
 
-exec $CACHE_DIR/wrapper $MYSQL_VERSION -ppid $PPID -type mysql -- $EXTRA_ARGS
+exec $CACHE_DIR/wrapper $DEBUG $MYSQL_VERSION -ppid $PPID -type mysql -- $EXTRA_ARGS

--- a/src/test/onetimeserver
+++ b/src/test/onetimeserver
@@ -5,6 +5,7 @@ PLATFORM=${_PLATFORM/ /-}
 
 OS=`uname -s | tr '[:upper:]' '[:lower:]'`
 
+THIS_URL="https://raw.githubusercontent.com/osheroff/onetimeserver/master/onetimeserver"
 WRAPPER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver/master/wrapper/wrapper.c"
 ONETIMESERVER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver-binaries/master/onetimeserver-go/$OS/onetimeserver-go"
 CACHE_DIR=$HOME/.onetimeserver/$PLATFORM
@@ -19,7 +20,8 @@ do
   case $1 in
     update)
       rm -Rf $CACHE_DIR/*
-      echo "cache cleared, next run will update"
+      curl "$THIS_URL" > $0
+      echo "onetimeserver updated"
       exit
       ;;
     --mysql-version=*)

--- a/src/test/onetimeserver
+++ b/src/test/onetimeserver
@@ -53,14 +53,29 @@ cd $CACHE_DIR
 
 if ! [ -f $CACHE_DIR/wrapper ]
 then
+  if [ "$DEBUG" == "-debug" ]
+  then
+    echo "downloading and compiling wrapper from $WRAPPER_URL" 1>&2
+  fi
+
   curl -s "$WRAPPER_URL" > $CACHE_DIR/wrapper.c
   gcc -g -O2 $CACHE_DIR/wrapper.c -o $CACHE_DIR/wrapper
 fi
 
 if ! [ -f $CACHE_DIR/onetimeserver-go ]
 then
+  if [ "$DEBUG" == "-debug" ]
+  then
+    echo "downloading main util from $ONETIMESERVER_URL" 1>&2
+  fi
+
   curl -s $ONETIMESERVER_URL > $CACHE_DIR/onetimeserver-go
   chmod +x $CACHE_DIR/onetimeserver-go
+fi
+
+if [ "$DEBUG" == "-debug" ]
+then
+  echo "exec: " $CACHE_DIR/wrapper $DEBUG $MYSQL_VERSION -ppid $PPID -type mysql -- $EXTRA_ARGS 1>&2
 fi
 
 exec $CACHE_DIR/wrapper $DEBUG $MYSQL_VERSION -ppid $PPID -type mysql -- $EXTRA_ARGS

--- a/src/test/onetimeserver
+++ b/src/test/onetimeserver
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+_PLATFORM=`uname -sm`
+PLATFORM=${_PLATFORM/ /-}
+
+OS=`uname -s | tr '[:upper:]' '[:lower:]'`
+
+WRAPPER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver/master/wrapper/wrapper.c"
+ONETIMESERVER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver-binaries/master/onetimeserver-go/$OS/onetimeserver-go"
+CACHE_DIR=$HOME/.onetimeserver/$PLATFORM
+
+function usage() {
+  echo "usage: onetimeserver [--mysql-version=VERSION|-m VERSION] [-v|--verbose] [mysql_args...]"
+  echo "       onetimeserver update"
+}
+
+while [[ $# > 0 ]]
+do
+  case $1 in
+    update)
+      rm -Rf $CACHE_DIR/*
+      echo "cache cleared, next run will update"
+      exit
+      ;;
+    --mysql-version=*)
+      MYSQL_VERSION="-mysql-version ${1#*=}"
+      ;;
+    -m)
+      shift
+      MYSQL_VERSION="-mysql-version $1"
+      ;;
+    -d|--debug)
+      DEBUG="-debug"
+      ;;
+    -h|--help)
+      usage
+      exit
+      ;;
+    *)
+      EXTRA_ARGS="$EXTRA_ARGS $1"
+      ;;
+  esac
+  shift
+
+done
+
+mkdir -p $CACHE_DIR
+
+
+cd $CACHE_DIR
+
+if ! [ -f $CACHE_DIR/wrapper ]
+then
+  curl -s "$WRAPPER_URL" > $CACHE_DIR/wrapper.c
+  gcc -g -O2 $CACHE_DIR/wrapper.c -o $CACHE_DIR/wrapper
+fi
+
+if ! [ -f $CACHE_DIR/onetimeserver-go ]
+then
+  curl -s $ONETIMESERVER_URL > $CACHE_DIR/onetimeserver-go
+  chmod +x $CACHE_DIR/onetimeserver-go
+fi
+
+exec $CACHE_DIR/wrapper $MYSQL_VERSION -ppid $PPID -type mysql -- $EXTRA_ARGS


### PR DESCRIPTION
I've been working on a golang replacement for mysql_isolated_server here: https://github.com/osheroff/onetimeserver.  

it bootstraps all of its own binaries, so we win being able to test maxwell under multiple versions of mysql.  

@zendesk/rules 