### PR TITLE
fix support for table creation options inside ALTERs

### DIFF
--- a/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
+++ b/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
@@ -23,7 +23,7 @@ create_database:
 create_table: 
     create_table_preamble 
     (
-      ( create_specifications table_creation_options* )
+        create_specifications ( table_creation_option ','? )*
       | create_like_tbl
     );
     
@@ -45,12 +45,13 @@ drop_table_options: (RESTRICT | CASCADE);
 rename_table: RENAME TABLE rename_table_spec (',' rename_table_spec)*;
 rename_table_spec: table_name TO table_name;
 
-alter_table: alter_table_preamble alter_specifications (engine_statement)?;
+alter_table: alter_table_preamble alter_specifications;
 
 alter_table_preamble: ALTER alter_flags? TABLE table_name;
 alter_flags: (ONLINE | OFFLINE | IGNORE);
 
 alter_specifications: alter_specification (',' alter_specification)*;
+
 alter_specification: add_column
                      | add_column_parens
                      | change_column
@@ -61,6 +62,7 @@ alter_specification: add_column
                      | alter_rename_table
                      | convert_to_character_set
                      | default_character_set
+                     | table_creation_option+
                      ; 
                    
 add_column: ADD COLUMN? column_definition col_position?;

--- a/src/main/antlr4/imports/table_creation_options.g4
+++ b/src/main/antlr4/imports/table_creation_options.g4
@@ -1,7 +1,7 @@
 grammar table_creation_options;
 import mysql_literal_tokens, mysql_idents;
 
-table_creation_options:
+table_creation_option:
 	  creation_engine
 	| creation_auto_increment
 	| creation_avg_row_length

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -165,29 +165,33 @@ public class DDLParserTest {
 	@Test
 	public void testParsingSomeAlters() {
 		String testSQL[] = {
-	       "alter table t add index `foo` using btree (`a`, `cd`) key_block_size=123",
-	       "alter table t add key bar (d)",
-	       "alter table t add constraint `foo` primary key using btree (id)",
-	       "alter table t add primary key (`id`)",
-	       "alter table t add constraint unique key (`id`)",
-	       "alter table t add fulltext key (`id`)",
-	       "alter table t add spatial key (`id`)",
-	       "alter table t alter column `foo` SET DEFAULT 112312",
-	       "alter table t alter column `foo` SET DEFAULT 1.2",
-	       "alter table t alter column `foo` SET DEFAULT 'foo'",
-	       "alter table t alter column `foo` drop default",
-	       "alter table t CHARACTER SET latin1 COLLATE = 'utf8'",
-	       "alter table t DROP PRIMARY KEY",
-	       "alter table t drop index `foo`",
-	       "alter table t disable keys",
-	       "alter table t enable keys",
-	       "alter table t order by `foor`, bar",
-	       "alter table tester add index (whatever(20), `f,` (2))"
+			"alter table t add index `foo` using btree (`a`, `cd`) key_block_size=123",
+			"alter table t add key bar (d)",
+			"alter table t add constraint `foo` primary key using btree (id)",
+			"alter table t add primary key (`id`)",
+			"alter table t add constraint unique key (`id`)",
+			"alter table t add fulltext key (`id`)",
+			"alter table t add spatial key (`id`)",
+			"alter table t alter column `foo` SET DEFAULT 112312",
+			"alter table t alter column `foo` SET DEFAULT 1.2",
+			"alter table t alter column `foo` SET DEFAULT 'foo'",
+			"alter table t alter column `foo` drop default",
+			"alter table t CHARACTER SET latin1 COLLATE = 'utf8'",
+			"alter table t DROP PRIMARY KEY",
+			"alter table t drop index `foo`",
+			"alter table t disable keys",
+			"alter table t enable keys",
+			"alter table t order by `foor`, bar",
+			"alter table tester add index (whatever(20), `f,` (2))",
+			"create table t ( id int ) engine = innodb, auto_increment = 5",
+			"alter table t engine=innodb",
+			"alter table t auto_increment =5",
+			"alter table t add column `foo` int, auto_increment = 5 engine=innodb, modify column bar int"
 		};
 
 		for ( String s : testSQL ) {
-			TableAlter a = parseAlter(s);
-			assertThat("Expected " + s + "to parse", a, not(nullValue()));
+			SchemaChange parsed = parse(s).get(0);
+			assertThat("Expected " + s + "to parse", parsed, not(nullValue()));
 		}
 
 	}


### PR DESCRIPTION
they can come at any position, not just the end, and don't need to be separated by commas!

yay.

fixes https://github.com/zendesk/maxwell/issues/112

@zendesk/rules 