### PR TITLE
4 bugfixes around shutdown

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -68,12 +68,12 @@ public class Maxwell {
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 			@Override
 			public void run() {
-				context.terminate();
 				try {
 					p.stop();
 				} catch (TimeoutException e) {
 					System.err.println("Timed out trying to shutdown maxwell parser thread.");
 				}
+				context.terminate();
 			}
 		});
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -35,7 +35,6 @@ public class MaxwellContext {
 	public void terminate() {
 		if ( this.schemaPosition != null ) {
 			this.schemaPosition.stop();
-			this.schemaPosition = null;
 		}
 		this.connectionPool.release();
 	}

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -99,11 +99,8 @@ public class MaxwellParser {
 			throw new TimeoutException("Maxwell's main parser thread didn't die after " + timeoutMS + "ms.");
 	}
 
-	public void run() throws Exception {
+	private void doRun() throws Exception {
 		MaxwellAbstractRowsEvent event;
-
-		this.start();
-		this.runState = RunState.RUNNING;
 
 		while ( this.runState == RunState.RUNNING ) {
 			event = getEvent();
@@ -134,6 +131,17 @@ public class MaxwellParser {
 		}
 
 		this.runState = RunState.STOPPED;
+	}
+
+	public void run() throws Exception {
+		this.start();
+		this.runState = RunState.RUNNING;
+
+		try {
+			doRun();
+		} finally {
+			this.runState = RunState.STOPPED;
+		}
 	}
 
 	private boolean skipEvent(MaxwellAbstractRowsEvent event) {

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
@@ -66,8 +66,9 @@ public class SchemaPosition implements Runnable {
 			} catch (InterruptedException e) { }
 		}
 
-		if ( this.exception != null )
+		if ( exception == null ) {
 			store(position.get());
+		}
 	}
 
 


### PR DESCRIPTION
apparently all the shutdown code sucked.   

-  don't set runState to STOPPED until we shutdown the replicator too
-  terminate context thread *after* stopping main thread -- we were missing the last position update
- the parser thread should always set runState to STOPPED, even in the case of an exception
- fix inverted null check in context thread shutdown

@zendesk/rules 

NOTE: this branch is targeting ben/exit_softer.  merge manually.


