### PR TITLE
bunch of fixes around replication positioning.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -29,7 +29,7 @@ public class Maxwell {
 		SchemaStore store = new SchemaStore(connection, this.context.getServerID(), this.schema, pos);
 		store.save();
 
-		this.context.setInitialPosition(pos);
+		this.context.setPosition(pos);
 	}
 
 	private void run(String[] argv) throws Exception {

--- a/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
@@ -102,6 +102,10 @@ public abstract class MaxwellAbstractRowsEvent extends AbstractRowEvent {
 		this.txCommit = true;
 	}
 
+	public boolean isTXCommit() {
+		return txCommit;
+	}
+
 
 	@Override
 	public String toString() {

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -56,11 +56,16 @@ public class MaxwellContext {
 		return this.initialPosition;
 	}
 
-	public void setInitialPosition(BinlogPosition position) throws SQLException {
+	public void setPosition(MaxwellAbstractRowsEvent e) throws SQLException {
+		if ( e.isTXCommit() ) {
+			this.setPosition(e.getNextBinlogPosition());
+		}
+	}
+	public void setPosition(BinlogPosition position) throws SQLException {
 		this.getSchemaPosition().set(position);
 	}
 
-	public void setInitialPositionSync(BinlogPosition position) throws SQLException {
+	public void setPositionSync(BinlogPosition position) throws SQLException {
 		this.getSchemaPosition().setSync(position);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/StdoutProducer.java
+++ b/src/main/java/com/zendesk/maxwell/StdoutProducer.java
@@ -12,6 +12,6 @@ public class StdoutProducer extends AbstractProducer {
 		for ( String json : e.toJSONStrings() ) {
 			System.out.println(json);
 		}
-		this.context.setInitialPosition(e.getNextBinlogPosition());
+		this.context.setPosition(e);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/FileProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/FileProducer.java
@@ -24,6 +24,7 @@ public class FileProducer extends AbstractProducer {
 			this.fileWriter.write('\n');
 			this.fileWriter.flush();
 		}
-		context.setInitialPosition(e.getNextBinlogPosition());
+
+		context.setPosition(e);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -45,7 +45,7 @@ class KafkaCallback implements Callback {
 					LOGGER.debug("");
 				}
 				if ( this.lastRowInEvent ) {
-					context.setInitialPosition(event.getNextBinlogPosition());
+					context.setPosition(event);
 				}
 			} catch (SQLException e1) {
 				e1.printStackTrace();
@@ -60,13 +60,16 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 		"metadata.fetch.timeout.ms", 5000
 	};
 	private final KafkaProducer<byte[], byte[]> kafka;
-	private final String topic;
+	private String topic;
 	private final int numPartitions;
 
 	public MaxwellKafkaProducer(MaxwellContext context, Properties kafkaProperties, String kafkaTopic) {
 		super(context);
 
-		topic = (kafkaTopic == null) ? "maxwell": kafkaTopic;
+		this.topic = kafkaTopic;
+		if ( this.topic == null ) {
+			this.topic = "maxwell";
+		}
 
 		this.setDefaults(kafkaProperties);
 		this.kafka = new KafkaProducer<>(kafkaProperties, new ByteArraySerializer(), new ByteArraySerializer());


### PR DESCRIPTION
1. rename setInitialPosition() -> setPosition
2. only store our position into mysql if the event has the "commit"
   flag.  This will prevent us from ending up stopped in the middle of a
   transaction, which in some cases caused us to miss a table-map event,
   and thusly miss rows.
3. make sure the replicator thread is running, even inside
   getTransactionEvents() -- the replicator thread was getting
   disconnected from out from under us, leading to a process that would
   never make progress.
4. always setup the replicator's position after processing an event.
   ensure that if we need to restart the thread it'll always be in the
   right place.

I think I really need to refactor the MaxwellParser class.  It's huge.

@zendesk/rules 