### PR TITLE
Refactor thread loop

### DIFF
--- a/bin/maxwell
+++ b/bin/maxwell
@@ -17,5 +17,5 @@ fi
 
 export LANG="en_US.UTF-8"
 
-exec $JAVA -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
+exec $JAVA -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
     	<artifactId>dbpool</artifactId>
     	<version>7.0-jdk7</version>
     </dependency>
+    <dependency>
+        <groupId>com.djdch.log4j</groupId>
+        <artifactId>log4j-staticshutdown</artifactId>
+        <version>1.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -70,7 +70,7 @@ public class Maxwell {
 			@Override
 			public void run() {
 				try {
-					p.stop();
+					p.stopLoop();
 				} catch (TimeoutException e) {
 					System.err.println("Timed out trying to shutdown maxwell parser thread.");
 				}
@@ -79,7 +79,7 @@ public class Maxwell {
 			}
 		});
 
-		p.run();
+		p.runLoop();
 
 	}
 

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.TimeoutException;
 
+import com.djdch.log4j.StaticShutdownCallbackRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +75,7 @@ public class Maxwell {
 					System.err.println("Timed out trying to shutdown maxwell parser thread.");
 				}
 				context.terminate();
+				StaticShutdownCallbackRegistry.invoke();
 			}
 		});
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellDeleteRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellDeleteRowsEvent.java
@@ -3,7 +3,6 @@ package com.zendesk.maxwell;
 import java.util.Iterator;
 import java.util.List;
 
-import com.google.code.or.binlog.impl.event.AbstractRowEvent;
 import com.google.code.or.binlog.impl.event.DeleteRowsEvent;
 import com.google.code.or.binlog.impl.event.DeleteRowsEventV2;
 import com.google.code.or.common.glossary.Row;

--- a/src/main/java/com/zendesk/maxwell/MaxwellParser.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellParser.java
@@ -41,9 +41,6 @@ public class MaxwellParser {
 	private final MaxwellContext context;
 	private final AbstractProducer producer;
 
-	private enum RunState { STOPPED, RUNNING, REQUEST_STOP };
-	private volatile RunState runState;
-
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellParser.class);
 
 	public MaxwellParser(Schema currentSchema, AbstractProducer producer, MaxwellContext ctx, BinlogPosition start) throws Exception {
@@ -79,24 +76,6 @@ public class MaxwellParser {
 
 	public void start() throws Exception {
 		this.replicator.start();
-	}
-
-	public void stop() throws TimeoutException {
-		stop(5000);
-	}
-
-	public void stop(long timeoutMS) throws TimeoutException {
-		// note: we use stderr in this function as it's LOGGER.err() oftentimes
-		// won't flush in time, and we lose the messages.
-		long left = 0;
-		this.runState = RunState.REQUEST_STOP;
-
-		for (left = timeoutMS; left > 0 && this.runState == RunState.REQUEST_STOP; left -= 100)
-			try { Thread.sleep(100); } catch (InterruptedException e) {
-		}
-
-		if( this.runState != RunState.STOPPED )
-			throw new TimeoutException("Maxwell's main parser thread didn't die after " + timeoutMS + "ms.");
 	}
 
 	private void ensureReplicatorThread() throws Exception {

--- a/src/main/java/com/zendesk/maxwell/RunLoopProcess.java
+++ b/src/main/java/com/zendesk/maxwell/RunLoopProcess.java
@@ -2,10 +2,7 @@ package com.zendesk.maxwell;
 
 import java.util.concurrent.TimeoutException;
 
-/**
- * Created by ben on 10/1/15.
- */
-public class RunLoopProcess {
+abstract public class RunLoopProcess {
 	private enum RunState { STOPPED, RUNNING, REQUEST_STOP };
 	private volatile RunState runState;
 
@@ -13,41 +10,45 @@ public class RunLoopProcess {
 		this.runState = RunState.STOPPED;
 	}
 
-	public boolean start() throws Exception {
+	protected void requestStop() {
+		this.runState = RunState.REQUEST_STOP;
+	}
+
+	public boolean runLoop() throws Exception {
 		if ( this.runState != RunState.STOPPED )
 			return false;
 
+		this.beforeStart();
+
+		this.runState = RunState.RUNNING;
+
 		try {
-			this.beforeStart();
-
-			this.runState = RunState.RUNNING;
-
-			while (this.runState == RunState.RUNNING) {
+			while (this.runState == RunState.RUNNING)
 				work();
-			}
 
 			this.beforeStop();
 		} finally {
 			this.runState = RunState.STOPPED;
 		}
+
+		return true;
 	}
 
-	private abstract void work() throws Exception;
-	public void beforeStart() throws Exception { }
-	public void beforeStop() throws Exception { }
+	protected abstract void work() throws Exception;
+	protected void beforeStart() throws Exception { }
+	protected void beforeStop() throws Exception { }
 
-
-	public void stop() throws TimeoutException {
-		stop(5000);
+	public void stopLoop() throws TimeoutException {
+		stopLoop(5000);
 	}
 
-	public void stop(long timeoutMS) throws TimeoutException {
-		// note: we use stderr in this function as it's LOGGER.err() oftentimes
-		// won't flush in time, and we lose the messages.
-		long left = 0;
+	public void stopLoop(long timeoutMS) throws TimeoutException {
+		if ( this.runState == RunState.STOPPED )
+			return;
 
+		this.requestStop();
 
-		for (left = timeoutMS; left > 0 && this.runState == RunState.REQUEST_STOP; left -= 100)
+		for (long left = timeoutMS; left > 0 && this.runState == RunState.REQUEST_STOP; left -= 100)
 			try { Thread.sleep(100); } catch (InterruptedException e) { }
 
 		if( this.runState != RunState.STOPPED )

--- a/src/main/java/com/zendesk/maxwell/RunLoopProcess.java
+++ b/src/main/java/com/zendesk/maxwell/RunLoopProcess.java
@@ -1,0 +1,56 @@
+package com.zendesk.maxwell;
+
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Created by ben on 10/1/15.
+ */
+public class RunLoopProcess {
+	private enum RunState { STOPPED, RUNNING, REQUEST_STOP };
+	private volatile RunState runState;
+
+	public RunLoopProcess() {
+		this.runState = RunState.STOPPED;
+	}
+
+	public boolean start() throws Exception {
+		if ( this.runState != RunState.STOPPED )
+			return false;
+
+		try {
+			this.beforeStart();
+
+			this.runState = RunState.RUNNING;
+
+			while (this.runState == RunState.RUNNING) {
+				work();
+			}
+
+			this.beforeStop();
+		} finally {
+			this.runState = RunState.STOPPED;
+		}
+	}
+
+	private abstract void work() throws Exception;
+	public void beforeStart() throws Exception { }
+	public void beforeStop() throws Exception { }
+
+
+	public void stop() throws TimeoutException {
+		stop(5000);
+	}
+
+	public void stop(long timeoutMS) throws TimeoutException {
+		// note: we use stderr in this function as it's LOGGER.err() oftentimes
+		// won't flush in time, and we lose the messages.
+		long left = 0;
+
+
+		for (left = timeoutMS; left > 0 && this.runState == RunState.REQUEST_STOP; left -= 100)
+			try { Thread.sleep(100); } catch (InterruptedException e) { }
+
+		if( this.runState != RunState.STOPPED )
+			throw new TimeoutException("Timed out trying to stop processed after " + timeoutMS + "ms.");
+	}
+}


### PR DESCRIPTION
both `MaxwellParser` and `SchemaPosition` were doing the same thing, running in a loop and stoppable from the outside.  Here we refactor them to use the same code. 

as with all refactor PRs, this one is pretty ugly, and probably best viewed with ?w=1

@zendesk/rules 