### PR TITLE
add BIT column support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
     	<groupId>com.zendesk</groupId>
     	<artifactId>open-replicator</artifactId>
-    	<version>1.3.0</version>
+    	<version>1.3.2</version>
     </dependency>
     <dependency>
     	<groupId>net.sf.jopt-simple</groupId>

--- a/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.google.code.or.common.glossary.column.BitColumn;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 
@@ -257,10 +258,11 @@ public abstract class MaxwellAbstractRowsEvent extends AbstractRowEvent {
 				Column c = colIter.next();
 				ColumnDef d = defIter.next();
 
-				if ( c instanceof DatetimeColumn )
+				if (c instanceof DatetimeColumn) {
 					value = ((DatetimeColumn) c).getLongValue();
-				else
+				} else {
 					value = c.getValue();
+				}
 
 				if ( value != null )
 					value = d.asJSON(value);

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
@@ -1,0 +1,50 @@
+package com.zendesk.maxwell.schema.columndef;
+
+import com.google.code.or.common.util.MySQLConstants;
+
+import java.math.BigInteger;
+
+public class BitColumnDef extends ColumnDef {
+	public BitColumnDef(String tableName, String name, String type, int pos) {
+		super(tableName, name, type, pos);
+	}
+
+	@Override
+	public boolean matchesMysqlType(int type) {
+		return type == MySQLConstants.TYPE_BIT;
+	}
+
+	@Override
+	public Object asJSON(Object value) {
+		byte[] bytes = (byte[]) value;
+		if ( bytes.length == 8 && ((bytes[7] & 0xFF) > 127) ) {
+			return bytesToBigInteger(bytes);
+		} else {
+			return bytesToLong(bytes);
+		}
+	}
+
+	private BigInteger bytesToBigInteger(byte[] bytes) {
+		BigInteger res = BigInteger.ZERO;
+
+		for (int i = 0; i < bytes.length; i++) {
+			res = res.add(BigInteger.valueOf(bytes[i] & 0xFF).shiftLeft(i * 8));
+		}
+
+		return res;
+	}
+
+	private Long bytesToLong(byte[] bytes) {
+		long res = 0;
+
+		for (int i = 0; i < bytes.length; i++)
+			res += ((bytes[i] & 0xFF) << ( i * 8 ));
+
+		return res;
+	}
+
+	@Override
+	public String toSQL(Object value) {
+		return asJSON(value).toString();
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -79,6 +79,8 @@ public abstract class ColumnDef {
 			return new EnumColumnDef(tableName, name, type, pos, enumValues);
 		case "set":
 			return new SetColumnDef(tableName, name, type, pos, enumValues);
+		case "bit":
+			return new BitColumnDef(tableName, name, type, pos);
 		default:
 			throw new IllegalArgumentException("unsupported column type " + type);
 		}

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -303,4 +303,14 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 	public void testBlob() throws Exception {
 		runJSONTestFile(getSQLDir() + "/json/test_blob");
 	}
+
+	@Test
+	public void testBit() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_bit");
+	}
+
+	@Test
+	public void testBignum() throws Exception {
+		runJSONTestFile(getSQLDir() + "/json/test_bignum");
+	}
 }

--- a/src/test/resources/sql/json/test_bignum
+++ b/src/test/resources/sql/json/test_bignum
@@ -1,0 +1,5 @@
+create database long_db;
+use long_db;
+create table test_long(id int(10) unsigned not null auto_increment primary key, long_field BIGINT(20) UNSIGNED);
+insert into test_long set long_field= 18446744073709551615 ;
+  -> {database:"long_db", table: "test_long", type: "insert", data: {"id": 1, long_field: 18446744073709551615} }

--- a/src/test/resources/sql/json/test_bit
+++ b/src/test/resources/sql/json/test_bit
@@ -1,0 +1,28 @@
+create database bit_db;
+use bit_db;
+create table test_bit(id int(10) unsigned not null auto_increment primary key, bit_field bit(64));
+insert into test_bit set bit_field=b'00011';
+  -> {database:"bit_db", table: "test_bit", type: "insert", data: {"id": 1, bit_field: 3} }
+insert into test_bit set bit_field=b'111111';
+  -> {database:"bit_db", table: "test_bit", type: "insert", data: {"id": 2, bit_field: 63} }
+insert into test_bit set bit_field=409832983;
+  -> {database:"bit_db", table: "test_bit", type: "insert", data: {"id": 3, bit_field: 409832983} }
+insert into test_bit set bit_field=18446744073709551615;
+  -> {database:"bit_db", table: "test_bit", type: "insert", data: {"id": 4, bit_field: 18446744073709551615} }
+insert into test_bit set bit_field=5461;
+  -> {database:"bit_db", table: "test_bit", type: "insert", data: {"id": 5, bit_field: 5461} }
+
+create table test_bit2 (id int(10) unsigned not null auto_increment primary key, bit_field bit(8));
+
+insert into test_bit2 set bit_field=b'00011';
+  -> {database:"bit_db", table: "test_bit2", type: "insert", data: {"id": 1, bit_field: 3} }
+
+create table test_bit3 (id int(10) unsigned not null auto_increment primary key, bit_field bit(16));
+
+insert into test_bit3 set bit_field=13929;
+  -> {database:"bit_db", table: "test_bit3", type: "insert", data: {"id": 1, bit_field: 13929} }
+
+create table test_bit4 (id int(10) unsigned not null auto_increment primary key, bit_field bit(24));
+
+insert into test_bit4 set bit_field=b'111000111000111001010110';
+  -> {database:"bit_db", table: "test_bit4", type: "insert", data: {"id": 1, bit_field: 14913110} }


### PR DESCRIPTION
we export bit columns back as numeric values.  Note that we need to pick
up a new version of open-replicator, as the old one had a bug around
parsing longer BIT columns.

@zendesk/rules 