### PR TITLE
add "SchemaScavenger" thread

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -79,6 +79,7 @@ public class Maxwell {
 			}
 		});
 
+		this.context.start();
 		p.runLoop();
 
 	}

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeoutException;
 import com.zendesk.maxwell.producer.*;
 import com.zendesk.maxwell.schema.SchemaPosition;
 
+import com.zendesk.maxwell.schema.SchemaScavenger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import snaq.db.ConnectionPool;
@@ -35,6 +36,11 @@ public class MaxwellContext {
 
 	public ConnectionPool getConnectionPool() {
 		return this.connectionPool;
+	}
+
+	public void start() {
+		SchemaScavenger s = new SchemaScavenger(this.connectionPool);
+		new Thread(s).start();
 	}
 
 	public void terminate() {

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaScavenger.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaScavenger.java
@@ -1,0 +1,92 @@
+package com.zendesk.maxwell.schema;
+
+import com.zendesk.maxwell.RunLoopProcess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import snaq.db.ConnectionPool;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SchemaScavenger extends RunLoopProcess implements Runnable {
+	static final Logger LOGGER = LoggerFactory.getLogger(SchemaStore.class);
+	private static final int MAX_ROWS_PER_SECOND = 500;
+	private final ConnectionPool connectionPool;
+
+	public SchemaScavenger(ConnectionPool pool) {
+		this.connectionPool = pool;
+	}
+
+	private List<Long> getDeletedSchemas() throws SQLException {
+		ArrayList<Long> list = new ArrayList<>();
+		try ( Connection connection = connectionPool.getConnection() ) {
+			ResultSet rs = connection.createStatement().executeQuery("select id from `maxwell`.`schemas` where deleted = 1");
+
+			while ( rs.next() ) {
+				list.add(rs.getLong("id"));
+			}
+		}
+
+		return list;
+	}
+
+	private long deleteRows(Long id, String tName, Long maxToDelete) throws SQLException {
+		try ( Connection connection = connectionPool.getConnection() ) {
+			long nDeleted = connection.createStatement().executeUpdate(
+				"DELETE FROM maxwell." + tName +
+					" WHERE schema_id = " + id +
+					" LIMIT " + maxToDelete
+			);
+			if (nDeleted > 0) {
+				LOGGER.debug("deleted " + nDeleted + " rows from maxwell." + tName + " schema: " + id);
+			}
+			return nDeleted;
+		}
+	}
+
+	private void deleteSchema(Long id) throws SQLException {
+		try ( Connection connection = connectionPool.getConnection() ) {
+			connection.createStatement().execute("delete from `maxwell`.`schemas` where id = " + id);
+		}
+	}
+
+	public void deleteBatch(long toDelete) throws SQLException {
+		String[] tables = { "columns", "tables", "databases" };
+
+		List<Long> schemaIds = getDeletedSchemas();
+
+		for ( Long id : schemaIds) {
+			boolean finishedDelete = false;
+
+			while ( toDelete > 0 && !finishedDelete ) {
+				for ( String tName : tables ) {
+					long deleted = deleteRows(id, tName, toDelete);
+
+					if (tName.equals("databases") && deleted < toDelete) {
+						deleteSchema(id);
+						finishedDelete = true;
+					}
+					toDelete -= deleted;
+				}
+			}
+		}
+	}
+
+	@Override
+	protected void work() throws Exception {
+		deleteBatch(MAX_ROWS_PER_SECOND);
+		try { Thread.sleep(1000); } catch ( InterruptedException e ) {}
+	}
+
+	@Override
+	public void run() {
+		try {
+			runLoop();
+		} catch ( Exception e ) {
+			LOGGER.error("SchemaScavenger thread aborting after exception: " + e);
+		}
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
+++ b/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
@@ -79,15 +79,7 @@ public class AbstractMaxwellTest {
 		generateBinlogEvents();
 	}
 
-	protected List<MaxwellAbstractRowsEvent>getRowsForSQL(MaxwellFilter filter, String queries[], String before[]) throws Exception {
-		BinlogPosition start = BinlogPosition.capture(server.getConnection());
-		SchemaCapturer capturer = new SchemaCapturer(server.getConnection());
-
-
-		if ( before != null ) {
-			server.executeList(Arrays.asList(before));
-		}
-
+	protected MaxwellContext buildContext() {
 		MaxwellConfig config = new MaxwellConfig();
 
 		config.mysqlHost = "127.0.0.1";
@@ -95,7 +87,18 @@ public class AbstractMaxwellTest {
 		config.mysqlUser = "maxwell";
 		config.mysqlPassword = "maxwell";
 
-		MaxwellContext context = new MaxwellContext(config);
+		return new MaxwellContext(config);
+	}
+
+	protected List<MaxwellAbstractRowsEvent>getRowsForSQL(MaxwellFilter filter, String queries[], String before[]) throws Exception {
+		BinlogPosition start = BinlogPosition.capture(server.getConnection());
+		SchemaCapturer capturer = new SchemaCapturer(server.getConnection());
+
+		if ( before != null ) {
+			server.executeList(Arrays.asList(before));
+		}
+
+		MaxwellContext context = buildContext();
 
 		Schema initialSchema = capturer.capture();
 

--- a/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
@@ -67,7 +67,7 @@ public class SchemaScavengerTest extends AbstractMaxwellTest {
 	public void testDeleteAllRows() throws Exception {
 		Long initialCount = countSchemaRows();
 		this.schemaStore.delete();
-		for ( int i = 0 ; i < 20 ; i++ )
+		for ( int i = 0 ; i < (initialCount / 5 + 1) ; i++ )
 			scavenger.deleteBatch(5);
 
 		assertThat(countSchemaRows(), is(0L));

--- a/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
@@ -1,0 +1,77 @@
+package com.zendesk.maxwell;
+
+import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaCapturer;
+import com.zendesk.maxwell.schema.SchemaScavenger;
+import com.zendesk.maxwell.schema.SchemaStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Created by ben on 10/12/15.
+ */
+public class SchemaScavengerTest extends AbstractMaxwellTest {
+	String schemaSQL[] = {
+		"CREATE TABLE shard_1.latin1 (id int(11), str1 varchar(255), str2 varchar(255) character set 'utf8') charset = 'latin1'",
+		"CREATE TABLE shard_1.enums (id int(11), enum_col enum('foo', 'bar', 'baz'))",
+		"CREATE TABLE shard_1.pks (id int(11), col2 varchar(255), col3 datetime, PRIMARY KEY(col2, col3, id))"
+	};
+	private Schema schema;
+	private BinlogPosition binlogPosition;
+	private SchemaStore schemaStore;
+	private SchemaScavenger scavenger;
+
+	@Before
+	public void setUp() throws Exception {
+		server.executeList(schemaSQL);
+		this.schema = new SchemaCapturer(server.getConnection()).capture();
+		this.binlogPosition = BinlogPosition.capture(server.getConnection());
+
+		this.scavenger = new SchemaScavenger(buildContext().getConnectionPool());
+
+		this.schemaStore = new SchemaStore(server.getConnection(), MysqlIsolatedServer.SERVER_ID, this.schema, binlogPosition);
+		this.schemaStore.save();
+	}
+
+	private Long getCount(String sql) throws SQLException {
+		ResultSet rs = server.getConnection().createStatement().executeQuery(sql);
+		rs.next();
+		return rs.getLong(1);
+	}
+
+	private Long countSchemaRows() throws SQLException {
+		String sql = "select sum(cnt) as cnt from ( " +
+			"select count(*) as cnt from maxwell.columns UNION " +
+			"select count(*) as cnt from maxwell.tables UNION " +
+			"select count(*) as cnt from maxwell.databases) as u";
+
+		return getCount(sql);
+	}
+
+	@Test
+	public void testDeleteSomeRows() throws Exception {
+		Long initialCount = countSchemaRows();
+		this.schemaStore.delete();
+		scavenger.deleteBatch(2);
+		assertThat(countSchemaRows(), is(initialCount - 2));
+		assertThat(getCount("select count(*) from maxwell.schemas"), is(1L));
+	}
+
+	@Test
+	public void testDeleteAllRows() throws Exception {
+		Long initialCount = countSchemaRows();
+		this.schemaStore.delete();
+		for ( int i = 0 ; i < 20 ; i++ )
+			scavenger.deleteBatch(5);
+
+		assertThat(countSchemaRows(), is(0L));
+		assertThat(getCount("select count(*) from maxwell.schemas"), is(0L));
+
+	}
+}


### PR DESCRIPTION
this is a lazy-delete thread that checks for logically deleted entries in maxwell.schemas and physically DELETEs them, 500 rows at a time.

@zendesk/rules 