### PR TITLE
Fix for #134 - duplicate tables being created.

### DIFF
--- a/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
+++ b/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
@@ -27,7 +27,7 @@ create_table:
       | create_like_tbl
     );
     
-create_table_preamble: CREATE TEMPORARY? TABLE (IF NOT EXISTS)? table_name;
+create_table_preamble: CREATE TEMPORARY? TABLE if_not_exists? table_name;
 create_specifications: '(' create_specification (',' create_specification)* ')'; 
 
 create_specification: 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
@@ -185,8 +185,9 @@ public class MysqlParserListener extends mysqlBaseListener {
 	public void exitCreate_table_preamble(Create_table_preambleContext ctx) {
 		String dbName = getDB(ctx.table_name());
 		String tblName = getTable(ctx.table_name());
+		boolean ifNotExists = ctx.if_not_exists() != null;
 
-		TableCreate createStatement = new TableCreate(dbName, tblName);
+		TableCreate createStatement = new TableCreate(dbName, tblName, ifNotExists);
 		this.tableName = createStatement.tableName;
 
 		this.schemaChanges.add(createStatement);

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
@@ -35,6 +35,10 @@ public class TableCreate extends SchemaChange {
 		if ( likeDB != null && likeTable != null ) {
 			applyCreateLike(newSchema, d);
 		} else {
+			Table existingTable = d.findTable(this.tableName);
+			if (existingTable != null) {
+				return originalSchema;
+			}
 			Table t = d.buildTable(this.tableName, this.encoding, this.columns, this.pks);
 			t.setDefaultColumnEncodings();
 		}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
@@ -16,10 +16,12 @@ public class TableCreate extends SchemaChange {
 
 	public String likeDB;
 	public String likeTable;
+	private final boolean ifNotExists;
 
-	public TableCreate (String dbName, String tableName) {
+	public TableCreate (String dbName, String tableName, boolean ifNotExists) {
 		this.dbName = dbName;
 		this.tableName = tableName;
+		this.ifNotExists = ifNotExists;
 		this.columns = new ArrayList<>();
 		this.pks = new ArrayList<>();
 	}
@@ -37,7 +39,11 @@ public class TableCreate extends SchemaChange {
 		} else {
 			Table existingTable = d.findTable(this.tableName);
 			if (existingTable != null) {
-				return originalSchema;
+				if (ifNotExists) {
+					return originalSchema;
+				} else {
+					throw new SchemaSyncError("Unexpectedly asked to create existing table " + this.tableName);
+				}
 			}
 			Table t = d.buildTable(this.tableName, this.encoding, this.columns, this.pks);
 			t.setDefaultColumnEncodings();

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -111,7 +111,7 @@ public class DDLIntegrationTest extends AbstractMaxwellTest {
 	public void testCreateIfNotExists() throws Exception {
 		String sql[] = {
 				"create TABLE IF NOT EXISTS `duplicateTable` (id int(11) unsigned primary KEY)",
-				"create TABLE IF NOT EXISTS `duplicateTable` (id int(11) unsigned primary KEY)",
+				"create TABLE IF NOT EXISTS `duplicateTable` ( str varchar(255) )",
 		};
 
 		testIntegration(sql);

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -106,6 +106,17 @@ public class DDLIntegrationTest extends AbstractMaxwellTest {
 		testIntegration(sql);
 	}
 
+
+	@Test
+	public void testCreateIfNotExists() throws Exception {
+		String sql[] = {
+				"create TABLE IF NOT EXISTS `duplicateTable` (id int(11) unsigned primary KEY)",
+				"create TABLE IF NOT EXISTS `duplicateTable` (id int(11) unsigned primary KEY)",
+		};
+
+		testIntegration(sql);
+	}
+
 	@Test
 	public void testDatabaseEncoding() throws SQLException, SchemaSyncError, IOException {
 		String sql[] = {


### PR DESCRIPTION
If the CREATE ... IF NOT EXISTS ran on the upstream server, then we wont already know it. If it failed, or didn't create the table, then leave the schema alone.