### PR TITLE
Fix broken image on GitHub page

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@ stat emitters.
 <script>
   jQuery(document).ready(function () {
     jQuery("#maxwell-header").append(
-      jQuery("<img alt='The Daemon, maybe' src='/img/cyberiad_1.jpg' style='float: left; height: 300px; padding-right: 30px;'>")
+      jQuery("<img alt='The Daemon, maybe' src='./img/cyberiad_1.jpg' style='float: left; height: 300px; padding-right: 30px;'>")
 
     )
   });


### PR DESCRIPTION
`/img/cyberiad_1.jpg` => `https://zendesk.github.io/img/cyberiad_1.jpg`

Should be relative like the rest of the urls in the page.