### PR TITLE
Fix table name in error message for create table

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
@@ -50,7 +50,7 @@ public class TableCreate extends SchemaChange {
 
 		Table sourceTable = sourceDB.findTable(likeTable);
 		if ( sourceTable == null )
-			throw new SchemaSyncError("Couldn't find table " + likeDB + "." + sourceTable);
+			throw new SchemaSyncError("Couldn't find table " + likeDB + "." + likeTable);
 
 		Table t = sourceTable.copy();
 		t.rename(this.tableName);


### PR DESCRIPTION
sourceTable is always null, and doesn't have a toString method. This should be the name of the table that was looked up.