### PR TITLE
Fix potential NPE in TableDrop

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
@@ -21,10 +21,10 @@ public class TableDrop extends SchemaChange {
 		Database d = newSchema.findDatabase(this.dbName);
 
 		// it's perfectly legal to say drop table if exists `random_garbage_db`.`random_garbage_table`
-		if ( d == null && ifExists)
-			return newSchema;
-
-		Table t = d.findTable(this.tableName);
+		Table t = null;
+		if (d != null) {
+			t = d.findTable(this.tableName);
+		} 
 
 		if ( t == null ) {
 			if ( ifExists ) { // DROP TABLE IF NOT EXISTS ; ignore missing tables


### PR DESCRIPTION
I suspect that this will not get through a working MySQL server, but if we've just tested the database for being null, calling a method on it is quite dangerous.

This code will still return "newSchema" if d == null && ifExists, but will use the existing return.

Incidentally, is there any difference between returning originalSchema or newSchema in this case? Should we return originalSchema if nothing's changed?