### PR TITLE
Minor change to fix defect using == instead of .equals and clear warnings

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -60,9 +60,18 @@ public class MaxwellFilter {
 			if ( c == null )
 				return false;
 
-			if ( (Integer) c.getValue() != entry.getValue() ) {
+			if ( c.getValue() == entry.getValue() ) {
+				continue; // null or same instance
+			}
+
+			if ( c.getValue() == null || entry.getValue() == null ) {
+				return false; // one side is null
+			}
+
+			if ( !c.getValue().equals(entry.getValue())) {
 				return false;
 			}
+
 		}
 		return true;
 	}


### PR DESCRIPTION
The row filters don't appear to be hooked up, but they were only passing tests because auto-boxing integers returns the same Integer instance for small numbers.