### PR TITLE
Change mv to cp, rm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /app
 WORKDIR /app
 
 RUN curl -sLo - https://github.com/zendesk/maxwell/releases/download/v0.13.1/maxwell-0.13.1.tar.gz | tar zxvf -
-RUN mv maxwell-*/* .
+RUN cp -r maxwell-*/* . && rm -rf maxwell-*
 
 ADD REVISION /
 


### PR DESCRIPTION
I was trying to build an image with 0.13.1 and kept getting several errors like:

```
mv: cannot create hard link './lib/antlr4-runtime-4.5.jar' to './docs/jacoco': Operation not permitted
```

It looks like [this is happening](http://superuser.com/questions/839662/mv-creates-a-hard-link-instead-of-move-or-rename-file-or-directory), but we couldn't find any evidence.

Changing to `cp` seemed to do the job.

@jeffreytheobald @osheroff 