### PR TITLE
apparently it's OK to name your primary keys.

### DIFF
--- a/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
+++ b/src/main/antlr4/com/zendesk/maxwell/schema/ddl/mysql.g4
@@ -117,7 +117,7 @@ index_type_1:
 	index_or_key index_name? index_type? index_column_list index_options*;
 
 index_type_pk:
-	index_constraint? PRIMARY KEY index_type? index_column_list index_options*;
+	index_constraint? PRIMARY KEY (index_type | index_name)* index_column_list index_options*;
 
 index_type_3:	
 	index_constraint? UNIQUE index_or_key index_name? index_type? index_column_list index_options*;

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -1,13 +1,11 @@
 package com.zendesk.maxwell.schema.ddl;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
+import org.antlr.v4.runtime.misc.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -393,5 +391,13 @@ public class DDLParserTest {
 
 		create = parseCreate("CREATE TABLE `foo` (id varchar(1) character set 'foo' NOT NULL)");
 		assertThat(create.columns.get(0).encoding, is("foo"));
+	}
+
+	@Test
+	public void testCreateTableNamedPrimaryKey() {
+		/* not documented, but accepted and ignored to name the primary key. */
+		TableCreate create = parseCreate("CREATE TABLE db (foo char(60) binary DEFAULT '' NOT NULL, PRIMARY KEY Host (foo,Db,User))");
+		assertThat(create, is(notNullValue()));
+		assertThat(create.pks.size(), is(3));
 	}
 }


### PR DESCRIPTION
The name is stored exactly nowhere, but the mysql parser is nothing if not liberal.

@bfabry  @zendesk/rules 