### PR TITLE
parse mysql-escaped style nested comments

### DIFF
--- a/src/main/antlr4/imports/mysql_idents.g4
+++ b/src/main/antlr4/imports/mysql_idents.g4
@@ -9,7 +9,11 @@ string: (IDENT | STRING_LITERAL);
 integer: INTEGER_LITERAL;
 charset_name: (IDENT | STRING_LITERAL | QUOTED_IDENT);
 
-SQL_COMMENT: '/*' (.)*? '*/' -> skip;
+SQL_UPGRADE_COMMENT: '/*!' [0-9]* -> skip;
+SQL_UPGRADE_ENDCOMMENT: '*/' -> skip;
+
+SQL_COMMENT: '/*' ~'!' (.)*? '*/' -> skip;
+
 SQL_LINE_COMMENT: ('#' | '--') (~'\n')* ('\n' | EOF) -> skip;
 
 STRING_LITERAL: TICK ('\\\'' | '\'\'' | ~('\''))* TICK;

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
@@ -16,7 +16,7 @@ public class TableCreate extends SchemaChange {
 
 	public String likeDB;
 	public String likeTable;
-	private final boolean ifNotExists;
+	public final boolean ifNotExists;
 
 	public TableCreate (String dbName, String tableName, boolean ifNotExists) {
 		this.dbName = dbName;

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -400,4 +400,14 @@ public class DDLParserTest {
 		assertThat(create, is(notNullValue()));
 		assertThat(create.pks.size(), is(3));
 	}
+
+	@Test
+	public void testCommentsThatAreNotComments() {
+		TableCreate create = parseCreate("CREATE TABLE /*! IF NOT EXISTS */ foo (id int primary key)");
+		assertThat(create, is(notNullValue()));
+		assertThat(create.ifNotExists, is(true));
+
+
+
+	}
 }


### PR DESCRIPTION
Parses and honors SQL fragments inside `/*! ... */` blocks.  

Technically we really should put some parsing code in for the maximum mysql version that we support, 
but this will do until things fall down further...

Addresses #158 




