### PR TITLE
some Time fixes / improvements

### DIFF
--- a/src/main/antlr4/imports/column_definitions.g4
+++ b/src/main/antlr4/imports/column_definitions.g4
@@ -19,8 +19,8 @@ data_type:
 	
 // all from http://dev.mysql.com/doc/refman/5.1/en/create-table.html
 generic_type:
-	  col_type=(BIT | BINARY | YEAR) length? column_options*
-	| col_type=(DATE | TIME | TIMESTAMP | DATETIME | TINYBLOB | MEDIUMBLOB | LONGBLOB | BLOB |  BOOLEAN | BOOL ) column_options*
+	  col_type=(BIT | BINARY | YEAR | TIME | TIMESTAMP | DATETIME) length? column_options*
+	| col_type=(DATE | TINYBLOB | MEDIUMBLOB | LONGBLOB | BLOB |  BOOLEAN | BOOL ) column_options*
 	| col_type=VARBINARY length column_options*
 	;
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
@@ -20,4 +20,8 @@ public class TimeColumnDef extends ColumnDef {
 		return "'" + String.valueOf(t) + "'";
 	}
 
+	@Override
+	public Object asJSON(Object value) {
+		return String.valueOf((Time) value);
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -300,7 +300,7 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testZeroCreatedAtJSON() throws Exception {
-		if ( server.getVersion().equals("5.5") ) // 5.6 not yet supported.
+		if ( server.getVersion().equals("5.5") ) // 5.6 not yet supported for this test
 			runJSONTestFile(getSQLDir() + "/json/test_zero_created_at");
 	}
 
@@ -322,5 +322,11 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 	@Test
 	public void testBignum() throws Exception {
 		runJSONTestFile(getSQLDir() + "/json/test_bignum");
+	}
+
+	@Test
+	public void testTime() throws Exception {
+		if ( server.getVersion().equals("5.6") )
+			runJSONTestFile(getSQLDir() + "/json/test_time");
 	}
 }

--- a/src/test/resources/sql/json/test_1j
+++ b/src/test/resources/sql/json/test_1j
@@ -30,5 +30,6 @@ delete from test_table;
 -> {"database": "test_db_1", "table": "test_table", "type": "delete", "data": {"id": 2, "textcol": "test_col_2"} }
 -> {"database": "test_db_1", "table": "test_table", "type": "delete", "data": {"id": 3, "textcol": "test_col_2", "datecol": "1979-10-01 00:00:00"} }
 
+
 DROP DATABASE `test_db_1`;
 

--- a/src/test/resources/sql/json/test_time
+++ b/src/test/resources/sql/json/test_time
@@ -1,0 +1,12 @@
+create database timedb
+use timedb
+
+set global time_zone = '-0:00';
+
+CREATE TABLE tt ( t time(6), dt datetime(3), ts timestamp(4) NULL );
+
+insert into tt set t = '12:23:33.222', dt = '2012-01-01 22:32:34.222';
+
+# TODO: support fractional times properly!
+-> { "database": "timedb", "table": "tt", "type": "insert", "data": {"t": "12:23:33", "dt": "2012-01-01 22:32:34" } }
+


### PR DESCRIPTION
- Support millisecond precisions in at least the schema (it not the output).
- Stop crashing when we see a TIME column

Addresses #166