### PR TITLE
Overflow large transactions to disk

### DIFF
--- a/src/main/java/com/zendesk/maxwell/BinlogPosition.java
+++ b/src/main/java/com/zendesk/maxwell/BinlogPosition.java
@@ -1,10 +1,11 @@
 package com.zendesk.maxwell;
 
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class BinlogPosition {
+public class BinlogPosition implements Serializable {
 	private final long offset;
 	private final String file;
 

--- a/src/main/java/com/zendesk/maxwell/EventConsumer.java
+++ b/src/main/java/com/zendesk/maxwell/EventConsumer.java
@@ -1,5 +1,0 @@
-package com.zendesk.maxwell;
-
-public class EventConsumer {
-	void consume(MaxwellAbstractRowsEvent e) {}
-}

--- a/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellAbstractRowsEvent.java
@@ -208,7 +208,6 @@ public abstract class MaxwellAbstractRowsEvent extends AbstractRowEvent {
 					getDatabase().getName(),
 					getTable().getName(),
 					getHeader().getTimestamp() / 1000,
-					getXid(),
 					table.getPKList(),
 					this.getNextBinlogPosition());
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -9,7 +9,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import com.google.code.or.binlog.impl.event.*;
-import com.zendesk.maxwell.util.ListWithDiskBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -191,8 +191,8 @@ public class MaxwellReplicator extends RunLoopProcess {
 					String sql = qe.getSql().toString();
 
 					if ( sql.equals("COMMIT") ) {
-						// some storage engines(?) will output a "COMMIT" QUERY_EVENT instead of a XID_EVENT.
-						// not sure exactly how to trigger this.
+						// MyISAM will output a "COMMIT" QUERY_EVENT instead of a XID_EVENT.
+						// There's no transaction ID but we can still set "commit: true"
 						if ( !buffer.isEmpty() )
 							buffer.getLast().setTXCommit();
 

--- a/src/main/java/com/zendesk/maxwell/RowConsumer.java
+++ b/src/main/java/com/zendesk/maxwell/RowConsumer.java
@@ -1,0 +1,5 @@
+package com.zendesk.maxwell;
+
+public class RowConsumer {
+	void consume(RowMap r) {}
+}

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -7,20 +7,22 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-public class RowMap {
+public class RowMap implements Serializable {
 	static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 
 	private final String rowType;
 	private final String database;
 	private final String table;
 	private final Long timestamp;
-	private final Long xid;
 	private final BinlogPosition nextPosition;
+
+	private Long xid;
 	private boolean txCommit;
 
 	private final HashMap<String, Object> data;
@@ -52,12 +54,11 @@ public class RowMap {
 				}
 			};
 
-	public RowMap(String type, String database, String table, Long timestamp, Long xid, List<String> pkColumns, BinlogPosition nextPosition) {
+	public RowMap(String type, String database, String table, Long timestamp, List<String> pkColumns, BinlogPosition nextPosition) {
 		this.rowType = type;
 		this.database = database;
 		this.table = table;
 		this.timestamp = timestamp;
-		this.xid = xid;
 		this.data = new HashMap<>();
 		this.nextPosition = nextPosition;
 		this.pkColumns = pkColumns;
@@ -153,6 +154,14 @@ public class RowMap {
 		return nextPosition;
 	}
 
+	public Long getXid() {
+		return xid;
+	}
+
+	public void setXid(Long xid) {
+		this.xid = xid;
+	}
+
 	public void setTXCommit() {
 		this.txCommit = true;
 	}
@@ -163,5 +172,13 @@ public class RowMap {
 
 	public String getDatabase() {
 		return database;
+	}
+
+	public String getTable() {
+		return table;
+	}
+
+	public Long getTimestamp() {
+		return timestamp;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/RowMapBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/RowMapBuffer.java
@@ -1,0 +1,23 @@
+package com.zendesk.maxwell;
+
+import com.zendesk.maxwell.util.ListWithDiskBuffer;
+
+import java.io.IOException;
+
+public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
+	private Long xid;
+
+	public RowMapBuffer(long maxInMemoryElements) throws IOException {
+		super(maxInMemoryElements);
+	}
+
+	public RowMap removeFirst() throws IOException, ClassNotFoundException {
+		RowMap r = super.removeFirst();
+		r.setXid(this.xid);
+		return r;
+	}
+
+	public void setXid(Long xid) {
+		this.xid = xid;
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -44,7 +44,7 @@ public class ListWithDiskBuffer<T extends Serializable> {
 	}
 
 	public boolean isEmpty() {
-		return this.size() > 0;
+		return this.size() == 0;
 	}
 
 	public T getLast() {

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -1,0 +1,76 @@
+package com.zendesk.maxwell.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.*;
+
+/*
+   a wrapper class for a linked list that will keep N tail elements
+   in memory, spilling its head onto disk as needed.
+ */
+public class ListWithDiskBuffer<T extends Serializable> {
+	static final Logger LOGGER = LoggerFactory.getLogger(ListWithDiskBuffer.class);
+	private final long maxInMemoryElements;
+	private final LinkedList<T> list;
+	private long elementsInFile = 0;
+	private File file;
+	private ObjectInputStream is;
+	private ObjectOutputStream os;
+
+	public ListWithDiskBuffer(long maxInMemoryElements) throws IOException {
+		this.maxInMemoryElements = maxInMemoryElements;
+		list = new LinkedList<>();
+	}
+
+	public void add(T element) throws IOException {
+		list.add(element);
+
+		while (this.list.size() > maxInMemoryElements) {
+			if ( file == null ) {
+				file = File.createTempFile("maxwell", "events");
+				file.deleteOnExit();
+				os = new ObjectOutputStream(new FileOutputStream(file));
+				is = new ObjectInputStream(new FileInputStream(file));
+			}
+
+			if ( elementsInFile == 0 )
+				LOGGER.debug("Overflowed in-memory buffer, spilling over into " + file);
+
+			os.writeObject(this.list.removeFirst());
+			elementsInFile++;
+		}
+	}
+
+	public boolean isEmpty() {
+		return (elementsInFile == 0) && this.list.size() == 0;
+	}
+
+	public T getLast() {
+		return list.getLast();
+	}
+
+	public T removeFirst() throws IOException, ClassNotFoundException {
+		if ( elementsInFile > 0 && is != null ) {
+			T element = (T) is.readObject();
+			elementsInFile--;
+			return element;
+		} else {
+			return list.removeFirst();
+		}
+	}
+
+	public Long size() {
+		return list.size() + elementsInFile;
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		try {
+			file.delete();
+		} finally {
+			super.finalize();
+		}
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -44,7 +44,7 @@ public class ListWithDiskBuffer<T extends Serializable> {
 	}
 
 	public boolean isEmpty() {
-		return (elementsInFile == 0) && this.list.size() == 0;
+		return this.size() > 0;
 	}
 
 	public T getLast() {
@@ -63,6 +63,10 @@ public class ListWithDiskBuffer<T extends Serializable> {
 
 	public Long size() {
 		return list.size() + elementsInFile;
+	}
+
+	public Long inMemorySize() {
+		return Long.valueOf(list.size());
 	}
 
 	@Override

--- a/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
+++ b/src/test/java/com/zendesk/maxwell/AbstractMaxwellTest.java
@@ -90,7 +90,7 @@ public class AbstractMaxwellTest {
 		return new MaxwellContext(config);
 	}
 
-	protected List<MaxwellAbstractRowsEvent>getRowsForSQL(MaxwellFilter filter, String queries[], String before[]) throws Exception {
+	protected List<RowMap>getRowsForSQL(MaxwellFilter filter, String queries[], String before[]) throws Exception {
 		BinlogPosition start = BinlogPosition.capture(server.getConnection());
 		SchemaCapturer capturer = new SchemaCapturer(server.getConnection());
 
@@ -111,14 +111,13 @@ public class AbstractMaxwellTest {
 		p.setFilter(filter);
 
 
-		final ArrayList<MaxwellAbstractRowsEvent> list = new ArrayList<>();
-		MaxwellAbstractRowsEvent e;
+		final ArrayList<RowMap> list = new ArrayList<>();
 
-		p.getEvents(new EventConsumer() {
+		p.getEvents(new RowConsumer() {
 			@Override
-			void consume(MaxwellAbstractRowsEvent e) {
-				if (!e.getTable().getDatabase().getName().equals("maxwell")) {
-					list.add(e);
+			void consume(RowMap r) {
+				if (!r.getDatabase().equals("maxwell")) {
+					list.add(r);
 				}
 			}
 		});
@@ -128,7 +127,7 @@ public class AbstractMaxwellTest {
 		return list;
 	}
 
-	protected List<MaxwellAbstractRowsEvent>getRowsForSQL(MaxwellFilter filter, String queries[]) throws Exception {
+	protected List<RowMap>getRowsForSQL(MaxwellFilter filter, String queries[]) throws Exception {
 		return getRowsForSQL(filter, queries, null);
 	}
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -106,7 +106,6 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testExcludeDB() throws Exception {
-		MaxwellAbstractRowsEvent e;
 		List<RowMap> list;
 
 		MaxwellFilter filter = new MaxwellFilter();
@@ -119,7 +118,6 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testIncludeTable() throws Exception {
-		MaxwellAbstractRowsEvent e;
 		List<RowMap> list;
 
 		MaxwellFilter filter = new MaxwellFilter();
@@ -134,7 +132,6 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testExcludeTable() throws Exception {
-		MaxwellAbstractRowsEvent e;
 		List<RowMap> list;
 
 		MaxwellFilter filter = new MaxwellFilter();
@@ -157,7 +154,6 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testAlterTable() throws Exception {
-		MaxwellAbstractRowsEvent e;
 		List<RowMap> list;
 
 		list = getRowsForSQL(null, testAlterSQL, null);

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -21,26 +21,25 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testGetEvent() throws Exception {
-		List<MaxwellAbstractRowsEvent> list;
-		String input[] = {"insert into minimal set account_id =1, text_field='hello'"};
+		List<RowMap> list;
+		String input[] = {"insert into minimal set account_id = 1, text_field='hello'"};
 		list = getRowsForSQL(null, input);
 		assertThat(list.size(), is(1));
-		assertThat(list.get(0).toSQL(), is("REPLACE INTO `minimal` (`id`, `account_id`, `text_field`) VALUES (1,1,'hello')"));
 	}
 
 	@Test
 	public void testPrimaryKeyStrings() throws Exception {
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 		String input[] = {"insert into minimal set account_id =1, text_field='hello'"};
 		String expectedJSON = "{\"database\":\"shard_1\",\"table\":\"minimal\",\"pk.id\":1,\"pk.text_field\":\"hello\"}";
 		list = getRowsForSQL(null, input);
 		assertThat(list.size(), is(1));
-		assertThat(StringUtils.join(list.get(0).getPKStrings(), ""), is(expectedJSON));
+		assertThat(list.get(0).pkToJson(), is(expectedJSON));
 	}
 
 	@Test
 	public void testRowFilter() throws Exception {
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 		String input[] = {"insert into minimal set account_id = 1000, text_field='hello'",
 						  "insert into minimal set account_id = 2000, text_field='goodbye'"};
 
@@ -48,14 +47,16 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 		assertThat(list.size(), is(2));
 
 		MaxwellFilter filter = new MaxwellFilter();
+
 		@SuppressWarnings("UnnecessaryBoxing")
 		Integer filterValue = new Integer(2000); // make sure we're using a different instance of the filter value
+
 		filter.addRowConstraint("account_id", filterValue);
 
 		list = getRowsForSQL(filter, input);
 		assertThat(list.size(), is(1));
 
-		RowMap jsonMap = list.get(0).jsonMaps().get(0);
+		RowMap jsonMap = list.get(0);
 
 		assertThat((Long) jsonMap.getData("account_id"), is(2000L));
 		assertThat((String) jsonMap.getData("text_field"), is("goodbye"));
@@ -63,7 +64,7 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testRowFilterOnNonExistentFields() throws Exception {
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 		String input[] = {"insert into minimal set account_id = 1000, text_field='hello'",
 						  "insert into minimal set account_id = 2000, text_field='goodbye'"};
 
@@ -86,40 +87,40 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testIncludeDB() throws Exception {
-		MaxwellAbstractRowsEvent e;
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
+		RowMap r;
 
 		MaxwellFilter filter = new MaxwellFilter();
 
 		list = getRowsForSQL(filter, insertSQL, createDBs);
 		assertThat(list.size(), is(2));
-		e = list.get(0);
-		assertThat(e.getTable().getName(), is("bars"));
+
+		r = list.get(0);
+		assertThat(r.getTable(), is("bars"));
 
 		filter.includeDatabase("shard_1");
 		list = getRowsForSQL(filter, insertSQL);
 		assertThat(list.size(), is(1));
-		assertThat(list.get(0).getTable().getName(), is("minimal"));
+		assertThat(list.get(0).getTable(), is("minimal"));
 	}
 
 	@Test
 	public void testExcludeDB() throws Exception {
 		MaxwellAbstractRowsEvent e;
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 
 		MaxwellFilter filter = new MaxwellFilter();
 		filter.excludeDatabase("shard_1");
 		list = getRowsForSQL(filter, insertSQL, createDBs);
 		assertThat(list.size(), is(1));
 
-		e = list.get(0);
-		assertThat(e.getTable().getName(), is("bars"));
+		assertThat(list.get(0).getTable(), is("bars"));
 	}
 
 	@Test
 	public void testIncludeTable() throws Exception {
 		MaxwellAbstractRowsEvent e;
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 
 		MaxwellFilter filter = new MaxwellFilter();
 		filter.includeTable("minimal");
@@ -128,14 +129,13 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 		assertThat(list.size(), is(1));
 
-		e = list.get(0);
-		assertThat(e.getTable().getName(), is("minimal"));
+		assertThat(list.get(0).getTable(), is("minimal"));
 	}
 
 	@Test
 	public void testExcludeTable() throws Exception {
 		MaxwellAbstractRowsEvent e;
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 
 		MaxwellFilter filter = new MaxwellFilter();
 		filter.excludeTable("minimal");
@@ -144,8 +144,7 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 		assertThat(list.size(), is(1));
 
-		e = list.get(0);
-		assertThat(e.getTable().getName(), is("bars"));
+		assertThat(list.get(0).getTable(), is("bars"));
 	}
 
 	String testAlterSQL[] = {
@@ -159,12 +158,11 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 	@Test
 	public void testAlterTable() throws Exception {
 		MaxwellAbstractRowsEvent e;
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 
 		list = getRowsForSQL(null, testAlterSQL, null);
 
-		e = list.get(0);
-		assertThat(e.getTable().getName(), is("minimal"));
+		assertThat(list.get(0).getTable(), is("minimal"));
 	}
 
 	String testTransactions[] = {
@@ -179,63 +177,59 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 
 	@Test
 	public void testTransactionID() throws Exception {
-		List<MaxwellAbstractRowsEvent> list;
+		List<RowMap> list;
 
 		try {
 			server.getConnection().setAutoCommit(false);
 			list = getRowsForSQL(null, testTransactions, null);
 
-			ArrayList<Map<String, Object>> objects = new ArrayList<>();
-			for (MaxwellAbstractRowsEvent e : list) {
-				for ( String s : e.toJSONStrings() ) {
-					Map<String, Object> m = new ObjectMapper().readValue(s, MAP_STRING_OBJECT_REF);
-					assertTrue(m.containsKey("xid"));
-					objects.add(m);
-				}
+			assertEquals(4, list.size());
+			for ( RowMap r : list ) {
+				assertNotNull(r.getXid());
 			}
-			assertEquals(4, objects.size());
 
-			assertEquals(objects.get(0).get("xid"), objects.get(1).get("xid"));
-			assertFalse(objects.get(0).containsKey("commit"));
-			assertTrue(objects.get(1).containsKey("commit"));
+			assertEquals(list.get(0).getXid(), list.get(1).getXid());
+			assertFalse(list.get(0).isTXCommit());
+			assertTrue(list.get(1).isTXCommit());
 
-			assertFalse(objects.get(2).containsKey("commit"));
-			assertTrue(objects.get(3).containsKey("commit"));
+			assertFalse(list.get(2).isTXCommit());
+			assertTrue(list.get(3).isTXCommit());
 		} finally {
 			server.getConnection().setAutoCommit(true);
 		}
 	}
 
 
-	private void runJSONTest(List<String> sql, List<Map<String, Object>> assertJSON) throws Exception {
+	private void runJSONTest(List<String> sql, List<Map<String, Object>> expectedJSON) throws Exception {
 		ObjectMapper mapper = new ObjectMapper();
 		List<Map<String, Object>> eventJSON = new ArrayList<>();
 		List<Map<String, Object>> matched = new ArrayList<>();
-		List<MaxwellAbstractRowsEvent> events = getRowsForSQL(null, sql.toArray(new String[sql.size()]));
+		List<RowMap> rows = getRowsForSQL(null, sql.toArray(new String[sql.size()]));
 
-		for ( MaxwellAbstractRowsEvent e : events ) {
-			for ( String s : e.toJSONStrings() ) {
-				Map<String, Object> r = mapper.readValue(s, MAP_STRING_OBJECT_REF);
-				r.remove("ts");
-				r.remove("xid");
-				r.remove("commit");
+		for ( RowMap r : rows ) {
+			String s = r.toJSON();
 
-				eventJSON.add(r);
+			Map<String, Object> outputMap = mapper.readValue(s, MAP_STRING_OBJECT_REF);
 
-				for ( Map<String, Object> b : assertJSON ) {
-					if ( r.equals(b) )
-						matched.add(b);
-				}
+			outputMap.remove("ts");
+			outputMap.remove("xid");
+			outputMap.remove("commit");
+
+			eventJSON.add(outputMap);
+
+			for ( Map<String, Object> b : expectedJSON ) {
+				if ( outputMap.equals(b) )
+					matched.add(b);
 			}
 		}
 
 		for ( Map j : matched ) {
-			assertJSON.remove(j);
+			expectedJSON.remove(j);
 		}
 
-		if ( assertJSON.size() > 0 ) {
+		if ( expectedJSON.size() > 0 ) {
 			String msg = "Did not find: \n" +
-						 StringUtils.join(assertJSON.iterator(), "\n") +
+						 StringUtils.join(expectedJSON.iterator(), "\n") +
 						 "\n\n in : " +
 						 StringUtils.join(eventJSON.iterator(), "\n");
 			assertThat(msg, false, is(true));

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -161,6 +161,19 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 		assertThat(list.get(0).getTable(), is("minimal"));
 	}
 
+	@Test
+	public void testMyISAMCommit() throws Exception {
+		String sql[] = {
+				"CREATE TABLE myisam_test ( id int ) engine=myisam",
+				"insert into myisam_test (id) values (1), (2), (3)"
+
+		};
+
+		List<RowMap> list = getRowsForSQL(null, sql, null);
+		assertThat(list.size(), is(3));
+		assertThat(list.get(2).isTXCommit(), is(true));
+	}
+
 	String testTransactions[] = {
 			"BEGIN",
 			"insert into minimal set account_id = 1, text_field = 's'",

--- a/src/test/java/com/zendesk/maxwell/RowMapBufferTest.java
+++ b/src/test/java/com/zendesk/maxwell/RowMapBufferTest.java
@@ -18,6 +18,7 @@ public class RowMapBufferTest {
 		buffer.add(new RowMap("insert", "foo", "bar", 3L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));
 
 		assertThat(buffer.size(), is(3L));
+		assertThat(buffer.inMemorySize(), is(2L));
 
 		assertThat(buffer.removeFirst().getTimestamp(), is(1L));
 		assertThat(buffer.removeFirst().getTimestamp(), is(2L));

--- a/src/test/java/com/zendesk/maxwell/RowMapBufferTest.java
+++ b/src/test/java/com/zendesk/maxwell/RowMapBufferTest.java
@@ -1,0 +1,26 @@
+package com.zendesk.maxwell;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RowMapBufferTest {
+	@Test
+	public void TestOverflowToDisk() throws Exception {
+		RowMapBuffer buffer = new RowMapBuffer(2);
+
+		RowMap r;
+		buffer.add(new RowMap("insert", "foo", "bar", 1L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));
+		buffer.add(new RowMap("insert", "foo", "bar", 2L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));
+		buffer.add(new RowMap("insert", "foo", "bar", 3L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));
+
+		assertThat(buffer.size(), is(3L));
+
+		assertThat(buffer.removeFirst().getTimestamp(), is(1L));
+		assertThat(buffer.removeFirst().getTimestamp(), is(2L));
+		assertThat(buffer.removeFirst().getTimestamp(), is(3L));
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
+++ b/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
@@ -23,15 +23,20 @@ public class TestMaxwellReplicator extends MaxwellReplicator {
 		this.stopAt = stop;
 	}
 
-	public void getEvents(EventConsumer c) throws Exception {
+	public void getEvents(RowConsumer consumer) throws Exception {
 		int max_tries = 100;
 		shouldStop = false;
 
 		this.replicator.start();
 
-		while ( !shouldStop ) {
-			MaxwellAbstractRowsEvent e = getEvent();
-			if (e == null) {
+		while ( true ) {
+			RowMap r = getRow();
+			if (r == null) {
+				if ( shouldStop ) {
+					hardStop();
+					return;
+				}
+
 				if (max_tries > 0) {
 					max_tries--;
 					continue;
@@ -40,10 +45,8 @@ public class TestMaxwellReplicator extends MaxwellReplicator {
 					return;
 				}
 			}
-			c.consume(e);
+			consumer.consume(r);
 		}
-
-		hardStop();
 	}
 
 	private void hardStop() throws Exception {


### PR DESCRIPTION
And for the last act, we have the actual feature:  serialize RowMap rows to disk in a data structure that keeps N elements in memory and then starts spooling out to disk.

we run at about 1/10th the speed after spooling to disk, so making the memory buffer big "enough" is important.  If I knew how to reflect on java's max-heap size I'd make it some multiple of that, maybe.

@zendesk/rules 