### PR TITLE
Add 'commit' to Kafka message key

### DIFF
--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -72,6 +72,9 @@ public class RowMap implements Serializable {
 		g.writeStringField("database", database);
 		g.writeStringField("table", table);
 
+		if ( this.txCommit )
+			g.writeBooleanField("commit", true);
+
 		if (pkColumns.isEmpty()) {
 			g.writeStringField("_uuid", UUID.randomUUID().toString());
 		} else {

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -31,7 +31,7 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 	public void testPrimaryKeyStrings() throws Exception {
 		List<RowMap> list;
 		String input[] = {"insert into minimal set account_id =1, text_field='hello'"};
-		String expectedJSON = "{\"database\":\"shard_1\",\"table\":\"minimal\",\"pk.id\":1,\"pk.text_field\":\"hello\"}";
+		String expectedJSON = "{\"database\":\"shard_1\",\"table\":\"minimal\",\"commit\":true,\"pk.id\":1,\"pk.text_field\":\"hello\"}";
 		list = getRowsForSQL(null, input);
 		assertThat(list.size(), is(1));
 		assertThat(list.get(0).pkToJson(), is(expectedJSON));


### PR DESCRIPTION
Allows filtering from the message key based on a table list or if there is a commit.

During load spikes, our consumer needs to discard a large number of messages. We will be able to reduce the logic required to discard messages (and hopefully speed it up) if we can whitelist a couple of tables along with 'commit' events.

Happy to take suggestions if this is a silly way to do it :)

@osheroff @chausler 