### PR TITLE
Support binlog_row_image=MINIMAL

### DIFF
--- a/docs/docs/compat.md
+++ b/docs/docs/compat.md
@@ -9,7 +9,17 @@
 ### Unsupported
 
 - Mysql 5.7 is untested with Maxwell, and in particular GTID replication is unsupported as of yet.
-- `binlog_row_image=MINIMAL` is not supported and will break Maxwell in a variety of amusing ways.
+
+### binlog_row_image=MINIMAL
+
+As of 0.17.0, Maxwell supports binlog_row_image=MINIMAL, but it may not be what you want.  It will differ
+from normal Maxwell operation in that:
+
+- INSERT statements will no longer output a column's default value
+- UPDATE statements will be incomplete; Maxwell outputs as much of the row as given in the binlogs,
+  but `data` will only include what is needed to perform the update (generally, id columns and changed columns).
+  The `old` section may or may not be included, depending on the nature of the update.
+- DELETE statements will be incomplete; generally they will only include the primary key.
 
 ### Master recovery
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
     	<groupId>com.zendesk</groupId>
     	<artifactId>open-replicator</artifactId>
-    	<version>1.3.2</version>
+    	<version>1.3.6</version>
     </dependency>
     <dependency>
     	<groupId>net.sf.jopt-simple</groupId>

--- a/src/main/java/com/zendesk/maxwell/ColumnWithDefinition.java
+++ b/src/main/java/com/zendesk/maxwell/ColumnWithDefinition.java
@@ -1,0 +1,30 @@
+package com.zendesk.maxwell;
+
+import com.google.code.or.common.glossary.Column;
+import com.google.code.or.common.glossary.column.DatetimeColumn;
+import com.zendesk.maxwell.schema.columndef.ColumnDef;
+
+public class ColumnWithDefinition {
+	public Column column;
+	public ColumnDef definition;
+
+	public ColumnWithDefinition(Column column, ColumnDef definition) {
+		this.column = column;
+		this.definition = definition;
+	}
+
+	private Object valueForJSON() {
+		if (column instanceof DatetimeColumn)
+			return ((DatetimeColumn) column).getLongValue();
+		return column.getValue();
+	}
+
+	public Object asJSON() {
+		Object value = valueForJSON();
+		if ( value == null )
+			return null;
+
+		return definition.asJSON(value);
+	}
+}
+

--- a/src/main/java/com/zendesk/maxwell/ColumnWithDefinitionList.java
+++ b/src/main/java/com/zendesk/maxwell/ColumnWithDefinitionList.java
@@ -43,6 +43,8 @@ public class ColumnWithDefinitionList implements Iterable<ColumnWithDefinition> 
 			return columnIterator.hasNext();
 		}
 
+		@Override
+		public void remove() { throw new UnsupportedOperationException(); }
 
 		@Override
 		public ColumnWithDefinition next() {

--- a/src/main/java/com/zendesk/maxwell/ColumnWithDefinitionList.java
+++ b/src/main/java/com/zendesk/maxwell/ColumnWithDefinitionList.java
@@ -1,0 +1,62 @@
+package com.zendesk.maxwell;
+
+import com.google.code.or.common.glossary.Column;
+import com.google.code.or.common.glossary.Row;
+import com.google.code.or.common.glossary.column.BitColumn;
+import com.zendesk.maxwell.schema.Table;
+import com.zendesk.maxwell.schema.columndef.ColumnDef;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class ColumnWithDefinitionList implements Iterable<ColumnWithDefinition> {
+	private final Table table;
+	private final Row row;
+	private final BitColumn usedColumns;
+
+	public ColumnWithDefinitionList(Table table, Row row, BitColumn usedColumns) {
+		this.table = table;
+		this.row = row;
+		this.usedColumns = usedColumns;
+	}
+
+	@Override
+	public Iterator<ColumnWithDefinition> iterator() {
+		return new ColumnWithDefinitionIterator(table, row, usedColumns);
+	}
+
+	class ColumnWithDefinitionIterator implements Iterator<ColumnWithDefinition> {
+		private final BitColumn usedColumns;
+		private final Iterator<Column> columnIterator;
+		private final List<ColumnDef> columnDefList;
+		private int index;
+
+		public ColumnWithDefinitionIterator(Table table, Row row, BitColumn usedColumns) {
+			this.columnDefList = table.getColumnList();
+			this.columnIterator = row.getColumns().iterator();
+			this.usedColumns = usedColumns;
+			this.index = 0;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return columnIterator.hasNext();
+		}
+
+
+		@Override
+		public ColumnWithDefinition next() {
+			while ( index < usedColumns.getLength() ) {
+				if ( usedColumns.get(index) ) {
+					ColumnWithDefinition cd = new ColumnWithDefinition(columnIterator.next(), columnDefList.get(index));
+					index++;
+					return cd;
+				} else
+					index++;
+			}
+			return null;
+		}
+	}
+
+}
+

--- a/src/main/java/com/zendesk/maxwell/MaxwellDeleteRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellDeleteRowsEvent.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.google.code.or.binlog.impl.event.DeleteRowsEvent;
 import com.google.code.or.binlog.impl.event.DeleteRowsEventV2;
 import com.google.code.or.common.glossary.Row;
+import com.google.code.or.common.glossary.column.BitColumn;
 import com.zendesk.maxwell.schema.Table;
 
 public class MaxwellDeleteRowsEvent extends MaxwellAbstractRowsEvent {
@@ -59,6 +60,11 @@ public class MaxwellDeleteRowsEvent extends MaxwellAbstractRowsEvent {
 		}
 		s.append(")");
 		return s.toString();
+	}
+
+	@Override
+	protected BitColumn getUsedColumns() {
+		return event.getUsedColumns();
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlStatus.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlStatus.java
@@ -1,10 +1,14 @@
 package com.zendesk.maxwell;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class MaxwellMysqlStatus {
+	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellMysqlStatus.class);
 	private Connection connection;
 
 	public MaxwellMysqlStatus(Connection c) {
@@ -45,8 +49,10 @@ public class MaxwellMysqlStatus {
 		if ( rowImageFormat == null ) // only present in mysql 5.6+
 			return;
 
-		if ( !rowImageFormat.equals("FULL"))
-			throw new MaxwellCompatibilityError("binlog_row_image must be FULL.");
+		if ( rowImageFormat.equals("MINIMAL") ) {
+			LOGGER.warn("Warning: binlog_row_image is set to MINIMAL.  This may not be what you want.");
+			LOGGER.warn("See http://maxwells-daemon.io/compat for more information.");
+		}
 	}
 
 	public static void ensureMysqlState(Connection c) throws SQLException, MaxwellCompatibilityError {

--- a/src/main/java/com/zendesk/maxwell/MaxwellUpdateRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellUpdateRowsEvent.java
@@ -91,7 +91,14 @@ public class MaxwellUpdateRowsEvent extends MaxwellAbstractRowsEvent {
 				Object beforeValue = cd.asJSON();
 
 				if (!rowMap.hasData(name)) {
-					// running in MINIMAL binlog row image mode.  Fill in after with before
+					/*
+					   If we find a column in the BEFORE image that's *not* present in the AFTER image,
+					   we're running in binlog_row_image = MINIMAL.  In this case, the BEFORE image acts
+					   as a sort of WHERE clause to update rows with the new values (present in the AFTER image).
+
+					   In order to reconstruct as much of the row as posssible, here we fill in
+					   missing data in the rowMap with values from the BEFORE image
+					 */
 					rowMap.putData(name, beforeValue);
 				} else {
 					if (!Objects.equals(rowMap.getData(name), beforeValue)) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellUpdateRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellUpdateRowsEvent.java
@@ -9,7 +9,7 @@ import com.google.code.or.binlog.impl.event.UpdateRowsEventV2;
 import com.google.code.or.common.glossary.Column;
 import com.google.code.or.common.glossary.Pair;
 import com.google.code.or.common.glossary.Row;
-import com.google.code.or.common.glossary.column.DatetimeColumn;
+import com.google.code.or.common.glossary.column.BitColumn;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
@@ -35,15 +35,16 @@ public class MaxwellUpdateRowsEvent extends MaxwellAbstractRowsEvent {
 		this.event = e;
 	}
 
+
 	@Override
-	public List<Row> getRows() {
+	public List<Row> getRows() { // only for filterRows() at the moment.  need to refactor that.
 		ArrayList<Row> result = new ArrayList<Row>();
 		for (Pair<Row> p : event.getRows()) {
 			result.add(p.getAfter());
 		}
-
 		return result;
 	}
+
 	@Override
 	public String sqlOperationString() {
 		return "REPLACE INTO ";
@@ -75,41 +76,37 @@ public class MaxwellUpdateRowsEvent extends MaxwellAbstractRowsEvent {
 	@Override
 	public List<RowMap> jsonMaps() {
 		ArrayList<RowMap> list = new ArrayList<>();
-		Object afterValue;
-		Object beforeValue;
 		for (Pair<Row> p : filteredRowsBeforeAndAfter() ) {
 			Row after = p.getAfter();
 			Row before = p.getBefore();
 
 			RowMap rowMap = buildRowMap();
 
-			Iterator<Column> aftIter = after.getColumns().iterator();
-			Iterator<Column> befIter = before.getColumns().iterator();
-			Iterator<ColumnDef> defIter = table.getColumnList().iterator();
-			while ( aftIter.hasNext() && defIter.hasNext() && befIter.hasNext() ) {
-				Column afterColumn = aftIter.next();
-				ColumnDef columnDef = defIter.next();
-				Column beforeColumn = befIter.next();
+			for ( ColumnWithDefinition cd : new ColumnWithDefinitionList(table, after, event.getUsedColumnsAfter())) {
+				rowMap.putData(cd.definition.getName(), cd.asJSON());
+			}
 
-				afterValue = valueForJson(afterColumn);
-				if ( afterValue != null ) {
-					afterValue = columnDef.asJSON(afterValue);
+			for ( ColumnWithDefinition cd : new ColumnWithDefinitionList(table, before, event.getUsedColumnsBefore())) {
+				String name = cd.definition.getName();
+				Object beforeValue = cd.asJSON();
+
+				if (!rowMap.hasData(name)) {
+					// running in MINIMAL binlog row image mode.  Fill in after with before
+					rowMap.putData(name, beforeValue);
+				} else {
+					if (!Objects.equals(rowMap.getData(name), beforeValue)) {
+						rowMap.putOldData(name, beforeValue);
+					}
 				}
-
-				beforeValue = valueForJson(beforeColumn);
-				if ( beforeValue != null) {
-					beforeValue = columnDef.asJSON(beforeValue);
-				}
-
-				if ( !Objects.equals(afterValue,beforeValue) ) {//afterValue is different from beforeValue so log beforeValue
-					rowMap.putOldData(columnDef.getName(), beforeValue);
-				}
-
-				rowMap.putData(columnDef.getName(), afterValue);
 			}
 			list.add(rowMap);
 		}
 
 		return list;
+	}
+
+	@Override
+	protected BitColumn getUsedColumns() {
+		return event.getUsedColumnsAfter(); // not actually used, since we override jsonMaps()
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/MaxwellWriteRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellWriteRowsEvent.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.google.code.or.binlog.impl.event.WriteRowsEvent;
 import com.google.code.or.binlog.impl.event.WriteRowsEventV2;
 import com.google.code.or.common.glossary.Row;
+import com.google.code.or.common.glossary.column.BitColumn;
 import com.zendesk.maxwell.schema.Table;
 
 
@@ -37,6 +38,11 @@ public class MaxwellWriteRowsEvent extends MaxwellAbstractRowsEvent {
 	@Override
 	public String sqlOperationString() {
 		return "REPLACE INTO ";
+	}
+
+	@Override
+	protected BitColumn getUsedColumns() {
+		return event.getUsedColumns();
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -202,4 +202,8 @@ public class RowMap implements Serializable {
 	public Long getTimestamp() {
 		return timestamp;
 	}
+
+	public boolean hasData(String name) {
+		return this.data.containsKey(name);
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -208,6 +208,22 @@ public class MaxwellIntegrationTest extends AbstractMaxwellTest {
 		}
 	}
 
+	@Test
+	public void testRunMinimalBinlog() throws Exception {
+		if ( server.getVersion().equals("5.5") )
+			return;
+
+		try {
+			server.getConnection().createStatement().execute("set global binlog_row_image='minimal'");
+			server.resetConnection(); // only new connections pick up the binlog setting
+
+			runJSONTestFile(getSQLDir() + "/json/test_minimal");
+		} finally {
+			server.getConnection().createStatement().execute("set global binlog_row_image='full'");
+			server.resetConnection();
+		}
+	}
+
 
 	private void runJSONTest(List<String> sql, List<Map<String, Object>> expectedJSON) throws Exception {
 		ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -67,12 +67,15 @@ public class MysqlIsolatedServer {
 		}
 
 
-		this.connection = DriverManager.getConnection("jdbc:mysql://127.0.0.1:" + port + "/mysql", "root", "");
+		resetConnection();
 		this.connection.createStatement().executeUpdate("GRANT REPLICATION SLAVE on *.* to 'maxwell'@'127.0.0.1' IDENTIFIED BY 'maxwell'");
 		this.connection.createStatement().executeUpdate("GRANT ALL on `maxwell`.* to 'maxwell'@'127.0.0.1'");
 		LOGGER.debug("booted at port " + this.port + ", outputting to file " + outputFile);
 	}
 
+	public void resetConnection() throws SQLException {
+		this.connection = DriverManager.getConnection("jdbc:mysql://127.0.0.1:" + port + "/mysql", "root", "");
+	}
 	public Connection getConnection() {
 		return connection;
 	}

--- a/src/test/resources/sql/json/test_minimal
+++ b/src/test/resources/sql/json/test_minimal
@@ -1,36 +1,17 @@
-set global binlog_row_image = 'minimal'
-CREATE DATABASE `test_db_1`
-CREATE DATABASE if not exists `test_db_1`
-CREATE TABLE `test_db_1`.`test_table` ( id bigint(20) not null auto_increment primary key, textcol mediumtext character set 'utf8' )
-CREATE INDEX `foo` on `test_db_1`.`test_table` (`id`);
-CREATE UNIQUE INDEX `foojj` on `test_db_1`.`test_table` (`id`);
-use test_db_1
-insert into test_table set textcol='test_col_1'
+use test
+DROP TABLE if exists `test_table`
+CREATE TABLE `test_table` ( id int auto_increment primary key, a text, b text )
+insert into test_table set a='avalue'
 
-->  {"database": "test_db_1", "table": "test_table", "type": "insert", "data": {"id": 1, "textcol": "test_col_1"} }
+->  {"database": "test", "table": "test_table", "type": "insert", "data": {"id": 1, "a": "avalue"} }
 
-insert into test_table set textcol='test_col_2'
+insert into test_table set a='avalue2', b='bvalue2'
 
-->  {"database": "test_db_1", "table": "test_table", "type": "insert", "data": { "id": 2, "textcol": "test_col_2"} }
+->  {"database": "test", "table": "test_table", "type": "insert", "data": {"id": 2, "a": "avalue2", "b": "bvalue2"} }
 
-alter table test_table add column `datecol` datetime NULL default null AFTER id
+update test_table set a='avalue3' where id = 2
 
-insert into test_table set textcol='test_col_2', datecol='1979-10-01 00:00:00'
-
--> {"database": "test_db_1", "table": "test_table", "type": "insert", "data": { "id": 3, "textcol": "test_col_2", "datecol": "1979-10-01 00:00:00"}  }
-
-update test_table set textcol='test_col_5' where id = 1
-
--> {"database": "test_db_1", "table": "test_table", "type": "update", "data": {"id": 1, "textcol": "test_col_5"}  }
-
-delete from test_table;
-
-/*!40000 ALTER TABLE `test_db_1`.`test_table` ENABLE KEYS */
-
--> {"database": "test_db_1", "table": "test_table", "type": "delete", "data": {"id": 1, "textcol": "test_col_5"} }
--> {"database": "test_db_1", "table": "test_table", "type": "delete", "data": {"id": 2, "textcol": "test_col_2"} }
--> {"database": "test_db_1", "table": "test_table", "type": "delete", "data": {"id": 3, "textcol": "test_col_2", "datecol": "1979-10-01 00:00:00"} }
+->  {"database": "test", "table": "test_table", "type": "update", "data": {"id": 2, "a": "avalue3"}, "old": { "a": "avalue2"}  }
 
 
-DROP DATABASE `test_db_1`;
 

--- a/src/test/resources/sql/json/test_minimal
+++ b/src/test/resources/sql/json/test_minimal
@@ -11,7 +11,14 @@ insert into test_table set a='avalue2', b='bvalue2'
 
 update test_table set a='avalue3' where id = 2
 
-->  {"database": "test", "table": "test_table", "type": "update", "data": {"id": 2, "a": "avalue3"}, "old": { "a": "avalue2"}  }
+->  { "database": "test", "table": "test_table", "type": "update", "data": {"id": 2, "a": "avalue3"} }
 
 
+# testing an open-replicator bug around >1 byte of NULLability columns
+CREATE TABLE `test_table_2` ( id int auto_increment primary key, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int, i10 int );
 
+insert into test_table_2 set i1=555, i2=777;
+->  { database: "test", table: "test_table_2", type: "insert", data: { id: 1, i1: 555, i2: 777 } }
+
+update test_table_2 set i3=444 where i1=555;
+->  { database: "test", table: "test_table_2", type: "update", data: { id: 1, i3: 444 } }


### PR DESCRIPTION
The bulk of the work in this changes was in creating a unified iterator that can 
traverse Columns, ColumnDefinitions, and the "which columns are actually present" bitmap in 
one go.

@zendesk/rules 