### PR TITLE
fix parser's ability to handle DATABASE.12345_TBL

### DIFF
--- a/src/main/antlr4/imports/mysql_idents.g4
+++ b/src/main/antlr4/imports/mysql_idents.g4
@@ -10,9 +10,14 @@ table_name: (db_name '.' name)
 user: user_token ('@' user_token)?;
 user_token: (IDENT | QUOTED_IDENT | STRING_LITERAL);
 
-name: ( id | tokens_available_for_names );
+name: ( id | tokens_available_for_names | INTEGER_LITERAL);
 id: ( IDENT | QUOTED_IDENT );
-literal: (INTEGER_LITERAL | STRING_LITERAL | FLOAT_LITERAL);
+literal: (float_literal | integer_literal | string_literal);
+
+float_literal: INTEGER_LITERAL? '.' INTEGER_LITERAL;
+integer_literal: INTEGER_LITERAL;
+string_literal: STRING_LITERAL;
+
 string: (IDENT | STRING_LITERAL);
 integer: INTEGER_LITERAL;
 charset_name: (IDENT | STRING_LITERAL | QUOTED_IDENT);
@@ -34,8 +39,6 @@ SQL_COMMENT: '/*' ~'!' (.)*? '*/' -> skip;
 SQL_LINE_COMMENT: ('#' | '--') (~'\n')* ('\n' | EOF) -> skip;
 
 STRING_LITERAL: TICK ('\\\'' | '\'\'' | ~('\''))* TICK;
-
-FLOAT_LITERAL: DIGIT* '.' DIGIT+;
 
 INTEGER_LITERAL: DIGIT+;
 

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -194,4 +194,14 @@ public class DDLIntegrationTest extends AbstractMaxwellTest {
 
 		testIntegration(sql);
 	}
+
+	@Test
+	public void testNumericNames() throws Exception {
+		String sql[] = {
+			"create TABLE shard_1.20151214_foo ( r1 REAL, b2 REAL (2,2) )",
+			"create TABLE shard_1.20151214 ( r1 REAL, b2 REAL (2,2) )"
+		};
+
+		testIntegration(sql);
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -197,7 +197,9 @@ public class DDLParserTest {
 			"alter table t add column `foo` int, algorithm copy, lock=exclusive",
 			"create table t (id int) engine=memory",
 			"CREATE TABLE `t1` (id int, UNIQUE `int` (`int`))",
-			"create table t2 (b varchar(10) not null unique) engine=MyISAM"
+			"create table t2 (b varchar(10) not null unique) engine=MyISAM",
+			"create TABLE shard_1.20151214foo ( r1 REAL, b2 REAL (2,2) )",
+			"create TABLE shard_1.20151214 ( r1 REAL, b2 REAL (2,2) )",
 		};
 
 		for ( String s : testSQL ) {


### PR DESCRIPTION
the problem was that the string '.12345restoftablename' would match
FLOAT_LITERAL + IDENT.  The fix is to shorten the tokens, so that the
'.' character is no longer part of a longer token, and must always match
independently.  We then reconstruct the floating point parsing rules out
of INTEGER_LITERAL tokens.

addresses lucky issue #200.  
@zendesk/rules 