### PR TITLE
use ObjectOutputStream#reset to constrain memory

### DIFF
--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -37,9 +37,12 @@ public class ListWithDiskBuffer<T extends Serializable> {
 			if ( elementsInFile == 0 )
 				LOGGER.debug("Overflowed in-memory buffer, spilling over into " + file);
 
-			os.writeUnshared(this.list.removeFirst());
+			os.writeObject(this.list.removeFirst());
 
 			elementsInFile++;
+
+			if ( elementsInFile % maxInMemoryElements == 0 )
+				os.reset(); // flush ObjectOutputStream caches
 		}
 	}
 
@@ -58,7 +61,7 @@ public class ListWithDiskBuffer<T extends Serializable> {
 				is = new ObjectInputStream(new BufferedInputStream(new FileInputStream(file)));
 			}
 
-			T element = (T) is.readUnshared();
+			T element = (T) is.readObject();
 			elementsInFile--;
 			return element;
 		} else {


### PR DESCRIPTION
writeUnshared was (a) terribly slow, and (b) didn't actually prevent
ObjectOutputStream from holding onto references.  .reset() appears to
actually do what we want, which is to release references to the RowMap.

@zendesk/rules @dadah89 