### PR TITLE
be more permissive about what's inside a quote character

### DIFF
--- a/src/main/antlr4/imports/mysql_idents.g4
+++ b/src/main/antlr4/imports/mysql_idents.g4
@@ -47,8 +47,7 @@ fragment TICK: '\'';
 fragment UNQUOTED_CHAR: [0-9a-zA-Z\u0080-\u00FF$_];
 IDENT: (UNQUOTED_CHAR)+;
 
-fragment QUOTED_CHAR: ~('/' | '\\' | '.' | '`');
-QUOTED_IDENT: '`' QUOTED_CHAR+? '`';
+QUOTED_IDENT: '`' (~'`')+? '`';
 
 fragment DIGIT: [0-9];
 WS  :   [ \t\n\r]+ -> skip ;

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
@@ -49,7 +49,7 @@ public class MysqlParserListener extends mysqlBaseListener {
 	}
 
 	private String unquote(String ident) {
-		return ident.replaceAll("^`", "").replaceAll("`$", "");
+		return ident.replaceFirst("^`", "").replaceFirst("`$", "");
 	}
 
 	private String unquote_literal(String ident) {

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -200,6 +200,7 @@ public class DDLParserTest {
 			"create table t2 (b varchar(10) not null unique) engine=MyISAM",
 			"create TABLE shard_1.20151214foo ( r1 REAL, b2 REAL (2,2) )",
 			"create TABLE shard_1.20151214 ( r1 REAL, b2 REAL (2,2) )",
+			"create table `shard1.foo` ( `id.foo` int )"
 		};
 
 		for ( String s : testSQL ) {


### PR DESCRIPTION
really, it's anything these days.  I must have followed "Before MySQL
5.1.6, database and table names cannot contain /, \, ., or characters
that are not permitted in file names."

dumb me for targeting an older mysql release.

@zendesk/rules 

addresses #204 