### PR TITLE
mysql-test, part 15

### DIFF
--- a/src/main/antlr4/imports/mysql_alter_table.g4
+++ b/src/main/antlr4/imports/mysql_alter_table.g4
@@ -40,7 +40,7 @@ ignored_alter_specifications:
     | DROP INDEX index_name
     | DISABLE KEYS
     | ENABLE KEYS
-    | ORDER BY index_columns
+    | ORDER BY alter_ordering (',' alter_ordering)*
     | FORCE
     /*
      I'm also leaving out the following from the alter table definition because who cares:
@@ -65,3 +65,9 @@ ignored_alter_specifications:
     ;
   algorithm_type: DEFAULT | INPLACE | COPY;
   lock_type: DEFAULT | NONE | SHARED | EXCLUSIVE;
+
+alter_ordering: alter_ordering_column (ASC|DESC)?;
+alter_ordering_column:
+    name '.' name '.' name
+  | name '.' name
+  | name;

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -439,6 +439,11 @@ public class DDLParserTest {
 	}
 
 	@Test
+	public void testAlterOrderBy() {
+		assertThat(parseAlter("ALTER TABLE t1 ORDER BY t1.id, t1.status, t1.type_id, t1.user_id, t1.body"), is(notNullValue()));
+	}
+
+	@Test
 	public void testMysqlTestFixedSQL() throws Exception {
 		int i = 1;
 		List<String> lines = Files.readAllLines(Paths.get(getSQLDir() + "/ddl/mysql-test-fixed.sql"), Charset.defaultCharset());

--- a/src/test/resources/sql/ddl/mysql-test-errors.sql
+++ b/src/test/resources/sql/ddl/mysql-test-errors.sql
@@ -1,6 +1,5 @@
 ALTER TABLE t1 ADD b GEOMETRY NOT NULL, ADD SPATIAL INDEX(b)
 ALTER TABLE t1 ADD c POINT
-ALTER TABLE t1 ORDER BY t1.id, t1.status, t1.type_id, t1.user_id, t1.body
 ALTER TABLE ti1 CHECKSUM 1
 ALTER TABLE tm1 CHECKSUM 1
 ALTER USER 'bernt' PASSWORD EXPIRE
@@ -43,7 +42,6 @@ alter table bug19145a alter column s set default null
 alter table bug19145b alter column e set default null
 alter table bug19145b alter column s set default null
 alter table t1 add f2 enum(0xFFFF)
-alter table table_24562 order by table_24562.subsection ASC, table_24562.section DESC
 create table t1 ( min_num   dec(6,6)     default .000001)
 create table t1 ( min_num   dec(6,6)     default 0.000001)
 create table t1 ("t1 column" int)

--- a/src/test/resources/sql/ddl/mysql-test-fixed.sql
+++ b/src/test/resources/sql/ddl/mysql-test-fixed.sql
@@ -28,6 +28,7 @@ ALTER TABLE t1 DROP KEY idx
 ALTER TABLE t1 DROP KEY s1, ADD KEY(s1(1))
 ALTER TABLE t1 FORCE
 ALTER TABLE t1 MODIFY a DATETIME(6), MODIFY b TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), MODIFY c DATE
+ALTER TABLE t1 ORDER BY t1.id, t1.status, t1.type_id, t1.user_id, t1.body
 ALTER TABLE t1 RENAME t2
 ALTER TABLE t1 STORAGE DISK
 ALTER TABLE t1 STORAGE DISK TABLESPACE ts2
@@ -249,6 +250,7 @@ alter table t3 rename t4
 alter table t8 rename t7
 alter table t9 rename mysqltest.t9
 alter table t9 rename t8, add column d int not null
+alter table table_24562 order by table_24562.subsection ASC, table_24562.section DESC
 alter table test.t1 rename test.t1
 create database имя_базы_в_кодировке_утф8_длиной_больше_чем_45
 create database това_е_дълго_име_за_база_данни_нали


### PR DESCRIPTION
MERGE MANUALLY

- handle table names and ASC/DESC in `ALTER TABLE ORDER BY` ddl

@zendesk/rules 