### PR TITLE
add --blacklist_tables command-line option

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -25,6 +25,7 @@ option                                        | description | default
 --exclude_dbs PATTERN                         | ignore updates from these databases |
 --include_tables PATTERN                      | only send updates from tables named like PATTERN |
 --exclude_tables PATTERN                      | ignore updates from tables named like PATTERN |
+--blacklist_tables PATTERN                    | ignore updates AND schema changes from tables named like PATTERN (see warnings below)|
 &nbsp;
 --bootstrapper                                | bootstrapper type: async|sync|none. | async
 --bootstrapper_fetch_size                     | number of rows fetched at a time during bootstrapping. | 64000
@@ -62,6 +63,12 @@ given as `option=/regex/`.  The options are evaluated as follows:
 
 So an example like `--include_dbs=/foo.*/ --exclude_tables=bar` will include `footy.zab` and exclude `footy.bar`
 
+The option `blacklist_tables` controls whether Maxwell will send updates for a table to its producer AND whether
+it captures schema changes for that table. Note that once Maxwell has been running with a table marked as blacklisted,
+you *must* continue to run Maxwell with that table blacklisted or else Maxwell will halt. If you want to stop
+blacklisting a table, you will have to drop the maxwell schema first. Also note that with table blacklisting enabled,
+Maxwell cannot distinguish between row updates for blacklisted tables and row updates for unknown tables; it will just
+assume that all row updates for unknown tables relate to blacklisted tables.
 
 <script>
   jQuery(document).ready(function () {

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -66,9 +66,7 @@ So an example like `--include_dbs=/foo.*/ --exclude_tables=bar` will include `fo
 The option `blacklist_tables` controls whether Maxwell will send updates for a table to its producer AND whether
 it captures schema changes for that table. Note that once Maxwell has been running with a table marked as blacklisted,
 you *must* continue to run Maxwell with that table blacklisted or else Maxwell will halt. If you want to stop
-blacklisting a table, you will have to drop the maxwell schema first. Also note that with table blacklisting enabled,
-Maxwell cannot distinguish between row updates for blacklisted tables and row updates for unknown tables; it will just
-assume that all row updates for unknown tables relate to blacklisted tables.
+blacklisting a table, you will have to drop the maxwell schema first.
 
 <script>
   jQuery(document).ready(function () {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -20,7 +20,7 @@ public class MaxwellConfig {
 
 	public MaxwellMysqlConfig maxwellMysql;
 
-	public String  includeDatabases, excludeDatabases, includeTables, excludeTables;
+	public String  includeDatabases, excludeDatabases, includeTables, excludeTables, blacklistTables;
 	public final Properties kafkaProperties;
 	public String kafkaTopic;
 	public String producerType;
@@ -86,6 +86,7 @@ public class MaxwellConfig {
 		parser.accepts( "exclude_dbs", "exclude these databases, formatted as exclude_dbs=db1,db2").withOptionalArg();
 		parser.accepts( "include_tables", "include these tables, formatted as include_tables=db1,db2").withOptionalArg();
 		parser.accepts( "exclude_tables", "exclude these tables, formatted as exclude_tables=tb1,tb2").withOptionalArg();
+		parser.accepts( "blacklist_tables", "ignore data AND schema changes to these tables, formatted as blacklist_tables=tb1,tb2. See the docs for details before setting this!").withOptionalArg();
 
 		parser.accepts( "__separator_7" );
 		parser.accepts( "help", "display help").forHelp();
@@ -181,6 +182,9 @@ public class MaxwellConfig {
 		
 		if ( options.has("exclude_tables"))
 			this.excludeTables = (String) options.valueOf("exclude_tables");
+
+		if ( options.has("blacklist_tables"))
+			this.blacklistTables = (String) options.valueOf("blacklist_tables");
 	}
 
 	private Properties readPropertiesFile(String filename, Boolean abortOnMissing) {
@@ -231,6 +235,7 @@ public class MaxwellConfig {
 		this.excludeDatabases = p.getProperty("exclude_dbs");
 		this.includeTables = p.getProperty("include_tables");
 		this.excludeTables = p.getProperty("exclude_tables");
+		this.blacklistTables = p.getProperty("blacklist_tables");
 
 		String maxSchemaString = p.getProperty("max_schemas");
 		if (maxSchemaString != null)

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -193,7 +193,8 @@ public class MaxwellContext {
 		return new MaxwellFilter(config.includeDatabases,
 			config.excludeDatabases,
 			config.includeTables,
-			config.excludeTables);
+			config.excludeTables,
+			config.blacklistTables);
 	}
 
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -157,16 +157,8 @@ public class MaxwellFilter {
 			|| ( matchesDatabase(database) && matchesTable(table) && matchesAnyRows(e) );
 	}
 
-	public boolean isBlacklisted(TableMapEvent e) {
-		return isTableBlacklisted(e.getTableName().toString());
-	}
-
 	public boolean isTableBlacklisted(String tableName) {
 		return ! matchesIncludeExcludeList(emptyList, blacklistTables, tableName);
-	}
-
-	public boolean hasTableBlacklist() {
-		return blacklistTables.size() > 0;
 	}
 
 	private void throwUnlessEmpty(HashSet<String> set, String objType) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import com.google.code.or.binlog.impl.event.TableMapEvent;
 import com.google.code.or.common.glossary.Column;
 import com.google.code.or.common.glossary.Row;
 
@@ -11,10 +12,12 @@ import com.google.code.or.common.glossary.Row;
 	(includeDatabases.nil? || includeDatabases.include?()
  */
 public class MaxwellFilter {
+	private static final List< Pattern > emptyList = Collections.unmodifiableList(new ArrayList<Pattern>());
 	private final ArrayList<Pattern> includeDatabases = new ArrayList<>();
 	private final ArrayList<Pattern> excludeDatabases = new ArrayList<>();
 	private final ArrayList<Pattern> includeTables = new ArrayList<>();
 	private final ArrayList<Pattern> excludeTables = new ArrayList<>();
+	private final ArrayList<Pattern> blacklistTables = new ArrayList<>();
 
 	private final HashMap<String, Integer> rowFilter = new HashMap<>();
 
@@ -22,7 +25,8 @@ public class MaxwellFilter {
 	public MaxwellFilter(String includeDatabases,
 						 String excludeDatabases,
 						 String includeTables,
-						 String excludeTables) throws MaxwellInvalidFilterException {
+						 String excludeTables,
+						 String blacklistTables) throws MaxwellInvalidFilterException {
 		if ( includeDatabases != null ) {
 			for (String s : includeDatabases.split(","))
 				includeDatabase(s);
@@ -42,6 +46,11 @@ public class MaxwellFilter {
 			for (String s : excludeTables.split(","))
 				excludeTable(s);
 		}
+
+		if ( blacklistTables != null ) {
+			for ( String s : blacklistTables.split(",") )
+				blacklistTable(s);
+		}
 	}
 
 
@@ -59,6 +68,10 @@ public class MaxwellFilter {
 
 	public void excludeTable(String name) throws MaxwellInvalidFilterException {
 		excludeTables.add(compile(name));
+	}
+
+	public void blacklistTable(String name) throws MaxwellInvalidFilterException {
+		blacklistTables.add(compile(name));
 	}
 
 	private Pattern compile(String name) throws MaxwellInvalidFilterException {
@@ -144,6 +157,17 @@ public class MaxwellFilter {
 			|| ( matchesDatabase(database) && matchesTable(table) && matchesAnyRows(e) );
 	}
 
+	public boolean isBlacklisted(TableMapEvent e) {
+		return isTableBlacklisted(e.getTableName().toString());
+	}
+
+	public boolean isTableBlacklisted(String tableName) {
+		return ! matchesIncludeExcludeList(emptyList, blacklistTables, tableName);
+	}
+
+	public boolean hasTableBlacklist() {
+		return blacklistTables.size() > 0;
+	}
 
 	private void throwUnlessEmpty(HashSet<String> set, String objType) {
 		if ( set.size() != 0 ) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -132,14 +132,17 @@ public class MaxwellReplicator extends RunLoopProcess {
 		MaxwellAbstractRowsEvent ew;
 		Table table;
 
-		table = tableCache.getTable(e.getTableId());
+		long tableId = e.getTableId();
 
-		if ( table == null && this.filter.hasTableBlacklist() ) {
-			LOGGER.warn(String.format("couldn't find table in cache for table id: %d, assuming blacklisted table", e.getTableId()));
+		if ( tableCache.isTableBlacklisted(tableId) ) {
+			LOGGER.debug(String.format("ignoring row event for blacklisted table %s", tableCache.getBlacklistedTableName(tableId)));
 			return null;
 		}
-		else if ( table == null ) {
-			throw new SchemaSyncError("couldn't find table in cache for table id: " + e.getTableId());
+
+		table = tableCache.getTable(tableId);
+
+		if ( table == null ) {
+			throw new SchemaSyncError("couldn't find table in cache for table id: " + tableId);
 		}
 
 		switch (e.getHeader().getEventType()) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellTableCache.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellTableCache.java
@@ -10,7 +10,7 @@ import com.zendesk.maxwell.schema.Table;
 public class MaxwellTableCache {
 	private final HashMap<Long, Table> tableMapCache = new HashMap<>();
 	// open-replicator keeps a very similar cache, but we can't get access to it.
-	public void processEvent(Schema schema, TableMapEvent event) {
+	public void processEvent(Schema schema, MaxwellFilter filter, TableMapEvent event) {
 		Long tableId = event.getTableId();
 		if ( !tableMapCache.containsKey(tableId) ) {
 			String dbName = new String(event.getDatabaseName().getValue());
@@ -20,7 +20,7 @@ public class MaxwellTableCache {
 				throw new RuntimeException("Couldn't find database " + dbName);
 
 			Table tbl = db.findTable(tblName);
-			if ( tbl == null )
+			if ( tbl == null && !filter.isTableBlacklisted(tblName) )
 				throw new RuntimeException("Couldn't find table " + tblName);
 
 			tableMapCache.put(tableId, tbl);

--- a/src/main/java/com/zendesk/maxwell/MaxwellTableCache.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellTableCache.java
@@ -9,6 +9,7 @@ import com.zendesk.maxwell.schema.Table;
 
 public class MaxwellTableCache {
 	private final HashMap<Long, Table> tableMapCache = new HashMap<>();
+	private final HashMap<Long, String> blacklistedTableCache = new HashMap<>();
 	// open-replicator keeps a very similar cache, but we can't get access to it.
 	public void processEvent(Schema schema, MaxwellFilter filter, TableMapEvent event) {
 		Long tableId = event.getTableId();
@@ -20,10 +21,13 @@ public class MaxwellTableCache {
 				throw new RuntimeException("Couldn't find database " + dbName);
 
 			Table tbl = db.findTable(tblName);
-			if ( tbl == null && !filter.isTableBlacklisted(tblName) )
-				throw new RuntimeException("Couldn't find table " + tblName);
 
-			tableMapCache.put(tableId, tbl);
+			if ( filter != null && filter.isTableBlacklisted(tblName) )
+				blacklistedTableCache.put(tableId, tblName);
+			else if ( tbl == null )
+				throw new RuntimeException("Couldn't find table " + tblName);
+			else
+				tableMapCache.put(tableId, tbl);
 		}
 	}
 
@@ -31,7 +35,16 @@ public class MaxwellTableCache {
 		return tableMapCache.get(tableId);
 	}
 
+	public boolean isTableBlacklisted(Long tableId) {
+		return blacklistedTableCache.containsKey(tableId);
+	}
+
+	public String getBlacklistedTableName(Long tableId) {
+		return blacklistedTableCache.get(tableId);
+	}
+
 	public void clear() {
 		tableMapCache.clear();
+		blacklistedTableCache.clear();
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseAlter.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.schema.ddl;
 
+import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 
@@ -27,5 +28,10 @@ public class DatabaseAlter extends SchemaChange {
 
 		d.setEncoding(characterSet);
 		return schema;
+	}
+
+	@Override
+	public boolean isBlacklisted(MaxwellFilter filter) {
+		return false;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseCreate.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.schema.ddl;
 
+import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 
@@ -36,6 +37,11 @@ public class DatabaseCreate extends SchemaChange {
 		database = new Database(dbName, createEncoding);
 		newSchema.addDatabase(database);
 		return newSchema;
+	}
+
+	@Override
+	public boolean isBlacklisted(MaxwellFilter filter) {
+		return false;
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseDrop.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.schema.ddl;
 
+import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 
@@ -28,6 +29,11 @@ public class DatabaseDrop extends SchemaChange {
 
 		newSchema.getDatabases().remove(database);
 		return newSchema;
+	}
+
+	@Override
+	public boolean isBlacklisted(MaxwellFilter filter) {
+		return false;
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.zendesk.maxwell.MaxwellFilter;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -96,4 +97,5 @@ public abstract class SchemaChange {
 		}
 	}
 
+	public abstract boolean isBlacklisted(MaxwellFilter filter);
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell.schema.ddl;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
@@ -66,5 +67,14 @@ public class TableAlter extends SchemaChange {
 		table.setDefaultColumnEncodings();
 
 		return newSchema;
+	}
+
+	@Override
+	public boolean isBlacklisted(MaxwellFilter filter) {
+		if ( filter == null ) {
+			return false;
+		} else {
+			return filter.isTableBlacklisted(this.tableName);
+		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell.schema.ddl;
 
 import java.util.ArrayList;
 
+import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
@@ -66,4 +67,14 @@ public class TableCreate extends SchemaChange {
 		t.rename(this.tableName);
 		d.addTable(t);
 	}
+
+	@Override
+	public boolean isBlacklisted(MaxwellFilter filter) {
+		if ( filter == null ) {
+			return false;
+		} else {
+			return filter.isTableBlacklisted(this.tableName);
+		}
+	}
+
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.schema.ddl;
 
+import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
@@ -36,6 +37,15 @@ public class TableDrop extends SchemaChange {
 
 		d.getTableList().remove(t);
 		return newSchema;
+	}
+
+	@Override
+	public boolean isBlacklisted(MaxwellFilter filter) {
+		if ( filter == null ) {
+			return false;
+		} else {
+			return filter.isTableBlacklisted(this.tableName);
+		}
 	}
 
 }


### PR DESCRIPTION
Add `--blacklist_tables PATTERN` command-line option.

The option `blacklist_tables` controls whether Maxwell will send updates for a table to its producer AND whether it captures schema changes for that table. Note that once Maxwell has been running with a table marked as blacklisted, you *must* continue to run Maxwell with that table blacklisted or else Maxwell will halt. If you want to stop blacklisting a table, you will have to drop the maxwell schema first. Also note that with table blacklisting enabled, Maxwell cannot distinguish between row updates for blacklisted tables and row updates for unknown tables; it will just assume that all row updates for unknown tables relate to blacklisted tables.
 