### PR TITLE
deal with backtick quoted identifiers in table creation

### DIFF
--- a/src/main/antlr4/imports/mysql_create_table.g4
+++ b/src/main/antlr4/imports/mysql_create_table.g4
@@ -50,7 +50,7 @@ creation_auto_increment: AUTO_INCREMENT '='? integer;
 creation_avg_row_length: AVG_ROW_LENGTH '='? integer;
 creation_character_set: DEFAULT? ((CHARACTER SET) | CHARSET) '='? charset_name;
 creation_checksum:  CHECKSUM '=' integer;
-creation_collation: DEFAULT? COLLATE '='? string;
+creation_collation: default_collation;
 creation_comment: COMMENT '='? string_literal;
 creation_connection: CONNECTION '='? string_literal;
 creation_data_directory: DATA DIRECTORY '='? string_literal;

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -198,7 +198,8 @@ public class DDLParserTest {
 			"create table t2 (b varchar(10) not null unique) engine=MyISAM",
 			"create TABLE shard_1.20151214foo ( r1 REAL, b2 REAL (2,2) )",
 			"create TABLE shard_1.20151214 ( r1 REAL, b2 REAL (2,2) )",
-			"create table `shard1.foo` ( `id.foo` int )"
+			"create table `shard1.foo` ( `id.foo` int )",
+			"create table `shard1.foo` ( `id.foo` int ) collate = `utf8_bin`"
 		};
 
 		for ( String s : testSQL ) {


### PR DESCRIPTION
I had fixed this in ALTER TABLE landia, but needed to in regular landia too.

addresses https://github.com/zendesk/maxwell/issues/255

@zendesk/rules 
