### PR TITLE
Bootstrap tweaks, part 2 of 3

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtility.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtility.java
@@ -13,6 +13,9 @@ import java.sql.SQLException;
 
 public class MaxwellBootstrapUtility {
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellBootstrapUtility.class);
+	protected class MissingBootstrapRowException extends Exception {
+		MissingBootstrapRowException(Long rowID) { super("Could not find bootstrap row with id: " + rowID); }
+	}
 
 	private static final long UPDATE_PERIOD_MILLIS = 250;
 	private static final long DISPLAY_PROGRESS_WARMUP_MILLIS = 5000;
@@ -22,40 +25,35 @@ public class MaxwellBootstrapUtility {
 
 	private void run(String[] argv) throws Exception {
 		MaxwellBootstrapUtilityConfig config = new MaxwellBootstrapUtilityConfig(argv);
+
 		if ( config.log_level != null ) {
 			MaxwellLogging.setLevel(config.log_level);
 		}
+
 		ConnectionPool connectionPool = getConnectionPool(config);
 		try ( final Connection connection = connectionPool.getConnection() ) {
-			int rowCount = getRowCount(connection, config);
-			final long rowId = insertBootstrapStartRow(connection, config);
-			Runtime.getRuntime().addShutdownHook(new Thread() {
-				public void run() {
-					try {
-						if ( !isComplete ) {
-							displayLine("");
-							LOGGER.warn("bootstrapping cancelled");
-							removeBootstrapRow(connection, rowId);
-						}
-					} catch ( Exception e ) {
-						System.exit(1);
-					}
-				}
-			});
-			int insertedRowsCount = 0;
-			Long startedTimeMillis = null;
-			while ( !isComplete ) {
-				if ( insertedRowsCount < rowCount ) {
-					if ( startedTimeMillis == null && insertedRowsCount > 0 ) {
-						startedTimeMillis = System.currentTimeMillis();
-					}
-					insertedRowsCount = getInsertedRowsCount(connection, rowId);
-				}
-				isComplete = getIsComplete(connection, rowId);
-				displayProgress(rowCount, insertedRowsCount, startedTimeMillis);
-				Thread.sleep(UPDATE_PERIOD_MILLIS);
+			if ( config.abortBootstrapID != null ) {
+				getInsertedRowsCount(connection, config.abortBootstrapID);
+				removeBootstrapRow(connection, config.abortBootstrapID);
+				return;
 			}
-			displayLine("");
+
+			long rowId;
+			if ( config.monitorBootstrapID != null ) {
+				getInsertedRowsCount(connection, config.monitorBootstrapID);
+				rowId = config.monitorBootstrapID;
+			} else {
+				Long totalRows = calculateRowCount(connection, config.databaseName, config.tableName);
+				rowId = insertBootstrapStartRow(connection, config.databaseName, config.tableName, totalRows);
+			}
+
+			try {
+				monitorProgress(connection, rowId);
+			} catch ( MissingBootstrapRowException e ) {
+				LOGGER.error("bootstrap aborted.");
+				Runtime.getRuntime().halt(1);
+			}
+
 		} catch ( SQLException e ) {
 			LOGGER.error("failed to connect to mysql server @ " + config.getConnectionURI());
 			LOGGER.error(e.getLocalizedMessage());
@@ -63,22 +61,69 @@ public class MaxwellBootstrapUtility {
 		}
 	}
 
-	private int getInsertedRowsCount(Connection connection, long rowId) throws SQLException {
+
+	private void monitorProgress(Connection connection, Long rowId) throws SQLException, MissingBootstrapRowException {
+		addMonitorShutdownHook(rowId);
+
+		long rowCount = getTotalRowCount(connection, rowId);
+		long initialRowCount, insertedRowsCount;
+		initialRowCount = getInsertedRowsCount(connection, rowId);
+		Long startedTimeMillis = null;
+
+		insertedRowsCount = initialRowCount;
+		while ( !isComplete ) {
+			if ( insertedRowsCount < rowCount ) {
+				if ( startedTimeMillis == null && insertedRowsCount > 0 ) {
+					startedTimeMillis = System.currentTimeMillis();
+				}
+				insertedRowsCount = getInsertedRowsCount(connection, rowId);
+			}
+			isComplete = getIsComplete(connection, rowId);
+			displayProgress(rowCount, insertedRowsCount, initialRowCount, startedTimeMillis);
+			try {
+				Thread.sleep(UPDATE_PERIOD_MILLIS);
+			} catch ( InterruptedException e) {}
+		}
+		displayLine("");
+	}
+
+	private void addMonitorShutdownHook(final Long rowId) {
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+			public void run() {
+				if ( !isComplete && console != null ) {
+					System.out.println("");
+					System.out.println("Exiting monitor.  Bootstrap will continue in the background.");
+					System.out.println("To abort, run maxwell-bootstrap --abort " + rowId);
+					System.out.println("To resume monitoring, run maxwell-bootstrap --monitor " + rowId);
+				}
+			}
+		});
+	}
+
+	private long getInsertedRowsCount(Connection connection, long rowId) throws SQLException, MissingBootstrapRowException {
 		String sql = "select inserted_rows from `bootstrap` where id = ?";
 		PreparedStatement preparedStatement = connection.prepareStatement(sql);
 		preparedStatement.setLong(1, rowId);
 		ResultSet resultSet = preparedStatement.executeQuery();
-		resultSet.next();
-		return resultSet.getInt(1);
+
+		if ( resultSet.next() ) {
+			return resultSet.getLong(1);
+		} else {
+			throw new MissingBootstrapRowException(rowId);
+		}
 	}
 
-	private boolean getIsComplete(Connection connection, long rowId) throws SQLException {
+	private boolean getIsComplete(Connection connection, long rowId) throws SQLException, MissingBootstrapRowException {
 		String sql = "select is_complete from `bootstrap` where id = ?";
 		PreparedStatement preparedStatement = connection.prepareStatement(sql);
 		preparedStatement.setLong(1, rowId);
 		ResultSet resultSet = preparedStatement.executeQuery();
-		resultSet.next();
-		return resultSet.getInt(1) == 1;
+
+		if ( resultSet.next() )  {
+			return resultSet.getInt(1) == 1;
+		} else {
+			throw new MissingBootstrapRowException(rowId);
+		}
 	}
 
 	private ConnectionPool getConnectionPool(MaxwellBootstrapUtilityConfig config) {
@@ -92,21 +137,32 @@ public class MaxwellBootstrapUtility {
 		return new ConnectionPool(name, maxPool, maxSize, idleTimeout, connectionURI, mysqlUser, mysqlPassword);
 	}
 
-	private int getRowCount(Connection connection, MaxwellBootstrapUtilityConfig config) throws SQLException {
+	private Long getTotalRowCount(Connection connection, Long bootstrapRowID) throws SQLException, MissingBootstrapRowException {
+		ResultSet resultSet =
+			connection.createStatement().executeQuery("select total_rows from `bootstrap` where id = " + bootstrapRowID);
+		if ( resultSet.next() ) {
+			return resultSet.getLong(1);
+		} else {
+			throw new MissingBootstrapRowException(bootstrapRowID);
+		}
+	}
+
+	private Long calculateRowCount(Connection connection, String db, String table) throws SQLException {
 		LOGGER.info("counting rows");
-		String sql = String.format("select count(*) from %s.%s", config.databaseName, config.tableName);
+		String sql = String.format("select count(*) from %s.%s", db, table);
 		PreparedStatement preparedStatement = connection.prepareStatement(sql);
 		ResultSet resultSet = preparedStatement.executeQuery();
 		resultSet.next();
-		return resultSet.getInt(1);
+		return resultSet.getLong(1);
 	}
 
-	private long insertBootstrapStartRow(Connection connection, MaxwellBootstrapUtilityConfig config) throws SQLException {
+	private long insertBootstrapStartRow(Connection connection, String db, String table, Long totalRows) throws SQLException {
 		LOGGER.info("inserting bootstrap start row");
-		String sql = "insert into `bootstrap` (database_name, table_name) values(?, ?)";
+		String sql = "insert into `bootstrap` (database_name, table_name, total_rows) values(?, ?, ?)";
 		PreparedStatement preparedStatement = connection.prepareStatement(sql);
-		preparedStatement.setString(1, config.databaseName);
-		preparedStatement.setString(2, config.tableName);
+		preparedStatement.setString(1, db);
+		preparedStatement.setString(2, table);
+		preparedStatement.setLong(3, totalRows);
 		preparedStatement.execute();
 		ResultSet generatedKeys = preparedStatement.getGeneratedKeys();
 		generatedKeys.next();
@@ -121,14 +177,14 @@ public class MaxwellBootstrapUtility {
 		preparedStatement.execute();
 	}
 
-	private void displayProgress(int total, int count, Long startedTimeMillis) {
+	private void displayProgress(long total, long count, long initialCount, Long startedTimeMillis) {
 		if ( startedTimeMillis == null ) {
 			displayLine("waiting for bootstrap to start... ");
 		}
 		else if ( count < total) {
 			long currentTimeMillis = System.currentTimeMillis();
 			long elapsedMillis = currentTimeMillis - startedTimeMillis;
-			long predictedTotalMillis = ( long ) ((elapsedMillis / ( float ) count) * total);
+			long predictedTotalMillis = ( long ) ((elapsedMillis / ( float ) (count - initialCount)) * (total - initialCount));
 			long remainingMillis = predictedTotalMillis - elapsedMillis;
 			String duration = prettyDuration(remainingMillis, elapsedMillis);
 			displayLine(String.format("%d / %d (%.2f%%) %s", count, total, ( count * 100.0 ) / total, duration));

--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
@@ -22,6 +22,9 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 	public String  tableName;
 	public String  log_level;
 
+	public Long    abortBootstrapID;
+	public Long    monitorBootstrapID;
+
 	public MaxwellBootstrapUtilityConfig(String argv[]) {
 		this.parse(argv);
 		this.setDefaults();
@@ -33,16 +36,31 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 
 	protected OptionParser buildOptionParser() {
 		OptionParser parser = new OptionParser();
+		parser.accepts( "config", "location of config file" ).withRequiredArg();
+		parser.accepts( "__separator_1", "" );
+		parser.accepts( "database", "database that contains the table to bootstrap").withRequiredArg();
+		parser.accepts( "table", "table to bootstrap").withRequiredArg();
+		parser.accepts( "__separator_2", "" );
+		parser.accepts( "abort", "bootstrap_id to abort" ).withRequiredArg();
+		parser.accepts( "monitor", "bootstrap_id to monitor" ).withRequiredArg();
+		parser.accepts( "__separator_3", "" );
 		parser.accepts( "log_level", "log level, one of DEBUG|INFO|WARN|ERROR. default: WARN" ).withRequiredArg();
 		parser.accepts( "host", "mysql host. default: localhost").withRequiredArg();
 		parser.accepts( "user", "mysql username. default: maxwell" ).withRequiredArg();
 		parser.accepts( "password", "mysql password" ).withRequiredArg();
 		parser.accepts( "port", "mysql port. default: 3306" ).withRequiredArg();
 		parser.accepts( "schema_database", "database that contains maxwell schema and state").withRequiredArg();
-		parser.accepts( "database", "database that contains the table to bootstrap").withRequiredArg();
-		parser.accepts( "table", "table to bootstrap").withRequiredArg();
 		parser.accepts( "help", "display help").forHelp();
-		parser.formatHelpWith(new BuiltinHelpFormatter(160, 4));
+
+		BuiltinHelpFormatter helpFormatter = new BuiltinHelpFormatter(200, 4) {
+			@Override
+			public String format(Map<String, ? extends OptionDescriptor> options) {
+				this.addRows(options.values());
+				String output = this.formattedHelpOutput();
+				return output.replaceAll("--__separator_.*", "");
+			}
+		};
+		parser.formatHelpWith(helpFormatter);
 		return parser;
 	}
 
@@ -63,7 +81,7 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 		}
 
 		if ( options.has("help") )
-			usage("Help for Maxwell Bootstrap Utility:");
+			usage("Help for Maxwell Bootstrap Utility:\n\nPlease provide one of:\n--database AND --table, --abort ID, or --monitor ID");
 
 		if ( options.has("log_level"))
 			this.log_level = parseLogLevel((String) options.valueOf("log_level"));
@@ -85,12 +103,31 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 
 		if ( options.has("database") )
 			this.databaseName = (String) options.valueOf("database");
-		else
+		else if ( !options.has("abort") && !options.has("monitor") )
 			usage("please specify a database");
+
+		if ( options.has("abort") ) {
+			this.abortBootstrapID = Long.valueOf((String) options.valueOf("abort"));
+		}
+
+		if ( options.has("monitor") )
+			this.monitorBootstrapID = Long.valueOf((String) options.valueOf("monitor"));
+
+		if ( this.abortBootstrapID != null ) {
+			if ( this.monitorBootstrapID != null )
+				usage("--abort is incompatible with --monitor");
+			if ( this.databaseName != null )
+				usage("--abort is incompatible with --database and --table");
+		}
+
+		if ( this.monitorBootstrapID != null ) {
+			if ( this.databaseName != null )
+				usage("--monitor is incompatible with --database and --table");
+		}
 
 		if ( options.has("table") )
 			this.tableName = (String) options.valueOf("table");
-		else
+		else if ( !options.has("abort") && !options.has("monitor") )
 			usage("please specify a table");
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -440,6 +440,11 @@ public class SchemaStore {
 			InputStream is = SchemaStore.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql");
 			executeSQLInputStream(c, is, schemaDatabaseName);
 		}
+
+		if ( !getTableColumns("bootstrap", c).containsKey("total_rows") ) {
+			performAlter(c, "alter table `bootstrap` add column total_rows bigint unsigned not null default 0 after inserted_rows");
+			performAlter(c, "alter table `bootstrap` modify column inserted_rows bigint unsigned not null default 0");
+		}
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -1,0 +1,46 @@
+package com.zendesk.maxwell.util;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import java.util.*;
+import joptsimple.*;
+
+public abstract class AbstractConfig {
+	static final protected String DEFAULT_CONFIG_FILE = "config.properties";
+	protected abstract OptionParser buildOptionParser();
+
+	protected void usage(String string) {
+		System.err.println(string);
+		System.err.println();
+		try {
+			buildOptionParser().printHelpOn(System.err);
+			System.exit(1);
+		} catch (IOException e) { }
+	}
+
+	protected Properties readPropertiesFile(String filename, Boolean abortOnMissing) {
+		Properties p = null;
+		File file = new File(filename);
+		if ( !file.exists() ) {
+			if ( abortOnMissing ) {
+				System.err.println("Couldn't find config file: " + filename);
+				System.exit(1);
+			} else {
+				return null;
+			}
+		}
+
+		try {
+			FileReader reader = new FileReader(file);
+			p = new Properties();
+			p.load(reader);
+		} catch ( IOException e ) {
+			System.err.println("Couldn't read config file: " + e);
+			System.exit(1);
+		}
+		return p;
+	}
+
+}


### PR DESCRIPTION
move common Config code into AbstractConfig.  mostly this is so the bootstrap utility can read share code to read config.properties (in the next PR).

@zendesk/rules @nmaquet 