### PR TITLE
Bootstrap tweaks, part 3 of 3

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
@@ -22,6 +22,9 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 	public String  tableName;
 	public String  log_level;
 
+	public Long    abortBootstrapID;
+	public Long    monitorBootstrapID;
+
 	public MaxwellBootstrapUtilityConfig(String argv[]) {
 		this.parse(argv);
 		this.setDefaults();
@@ -33,16 +36,31 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 
 	protected OptionParser buildOptionParser() {
 		OptionParser parser = new OptionParser();
+		parser.accepts( "config", "location of config file" ).withRequiredArg();
+		parser.accepts( "__separator_1", "" );
+		parser.accepts( "database", "database that contains the table to bootstrap").withRequiredArg();
+		parser.accepts( "table", "table to bootstrap").withRequiredArg();
+		parser.accepts( "__separator_2", "" );
+		parser.accepts( "abort", "bootstrap_id to abort" ).withRequiredArg();
+		parser.accepts( "monitor", "bootstrap_id to abort" ).withRequiredArg();
+		parser.accepts( "__separator_3", "" );
 		parser.accepts( "log_level", "log level, one of DEBUG|INFO|WARN|ERROR. default: WARN" ).withRequiredArg();
 		parser.accepts( "host", "mysql host. default: localhost").withRequiredArg();
 		parser.accepts( "user", "mysql username. default: maxwell" ).withRequiredArg();
 		parser.accepts( "password", "mysql password" ).withRequiredArg();
 		parser.accepts( "port", "mysql port. default: 3306" ).withRequiredArg();
 		parser.accepts( "schema_database", "database that contains maxwell schema and state").withRequiredArg();
-		parser.accepts( "database", "database that contains the table to bootstrap").withRequiredArg();
-		parser.accepts( "table", "table to bootstrap").withRequiredArg();
 		parser.accepts( "help", "display help").forHelp();
-		parser.formatHelpWith(new BuiltinHelpFormatter(160, 4));
+
+		BuiltinHelpFormatter helpFormatter = new BuiltinHelpFormatter(200, 4) {
+			@Override
+			public String format(Map<String, ? extends OptionDescriptor> options) {
+				this.addRows(options.values());
+				String output = this.formattedHelpOutput();
+				return output.replaceAll("--__separator_.*", "");
+			}
+		};
+		parser.formatHelpWith(helpFormatter);
 		return parser;
 	}
 
@@ -63,7 +81,7 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 		}
 
 		if ( options.has("help") )
-			usage("Help for Maxwell Bootstrap Utility:");
+			usage("Help for Maxwell Bootstrap Utility:\n\nPlease provide one of:\n--database AND --table, --abort ID, or --monitor ID");
 
 		if ( options.has("log_level"))
 			this.log_level = parseLogLevel((String) options.valueOf("log_level"));
@@ -85,14 +103,36 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 
 		if ( options.has("database") )
 			this.databaseName = (String) options.valueOf("database");
-		else
+		else if ( !options.has("abort") && !options.has("monitor") )
 			usage("please specify a database");
+
+		if ( options.has("abort") ) {
+			this.abortBootstrapID = Long.valueOf((String) options.valueOf("abort"));
+		}
+
+		if ( options.has("monitor") )
+			this.monitorBootstrapID = Long.valueOf((String) options.valueOf("monitor"));
+
+		if ( this.abortBootstrapID != null ) {
+			if ( this.monitorBootstrapID != null )
+				usage("--abort is incompatible with --monitor");
+			if ( this.databaseName != null )
+				usage("--abort is incompatible with --database and --table");
+		}
+
+		if ( this.monitorBootstrapID != null ) {
+			if ( this.databaseName != null )
+				usage("--monitor is incompatible with --database and --table");
+		}
 
 		if ( options.has("table") )
 			this.tableName = (String) options.valueOf("table");
-		else
+		else if ( !options.has("abort") && !options.has("monitor") )
 			usage("please specify a table");
 	}
+
+	private void parseFile(String filename, boolean abortOnMissing) {
+		Properties p = this.readPropertiesFile(filename, abortOnMissing);
 
 	private void parseFile(String filename, boolean abortOnMissing) {
 		Properties p = this.readPropertiesFile(filename, abortOnMissing);

--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
@@ -42,7 +42,7 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 		parser.accepts( "table", "table to bootstrap").withRequiredArg();
 		parser.accepts( "__separator_2", "" );
 		parser.accepts( "abort", "bootstrap_id to abort" ).withRequiredArg();
-		parser.accepts( "monitor", "bootstrap_id to abort" ).withRequiredArg();
+		parser.accepts( "monitor", "bootstrap_id to monitor" ).withRequiredArg();
 		parser.accepts( "__separator_3", "" );
 		parser.accepts( "log_level", "log level, one of DEBUG|INFO|WARN|ERROR. default: WARN" ).withRequiredArg();
 		parser.accepts( "host", "mysql host. default: localhost").withRequiredArg();

--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
@@ -134,9 +134,6 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 	private void parseFile(String filename, boolean abortOnMissing) {
 		Properties p = this.readPropertiesFile(filename, abortOnMissing);
 
-	private void parseFile(String filename, boolean abortOnMissing) {
-		Properties p = this.readPropertiesFile(filename, abortOnMissing);
-
 		if ( p == null )
 			return;
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -440,6 +440,11 @@ public class SchemaStore {
 			InputStream is = SchemaStore.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql");
 			executeSQLInputStream(c, is, schemaDatabaseName);
 		}
+
+		if ( !getTableColumns("bootstrap", c).containsKey("total_rows") ) {
+			performAlter(c, "alter table `bootstrap` add column total_rows bigint unsigned not null default 0 after inserted_rows");
+			performAlter(c, "alter table `bootstrap` modify column inserted_rows bigint unsigned not null default 0");
+		}
 	}
 
 }


### PR DESCRIPTION
ah, the sauce. 

Rework how bootstrap command line works

The main thrust here is that we no longer cancel a bootstrap on CTRL-C
-- in my tests it was too easy for the bootstrap utility to get a SIGHUP
because you didn't launch it under screen, and having that kill off the
bootstrap seems to violate principle-of-least-surprise.

Other changes that came along to support this:
- add --abort ID and --monitor ID to cancel/resume bootstrap operations
- count rows to be bootstrapped once, and store that number in the table
- the bootstrap utility now picks up config.properties

@zendesk/rules @nmaquet 