### PR TITLE
Fix crash caused by multithreaded access of static dateFormatter and dateTimeFormatter

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -12,7 +12,7 @@ public class DateColumnDef extends ColumnDef {
 
 	private static SimpleDateFormat dateFormatter;
 
-	protected static SimpleDateFormat getDateFormatter() {
+	private static SimpleDateFormat getDateFormatter() {
 		if ( dateFormatter == null ) {
 			dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
 		}
@@ -26,7 +26,10 @@ public class DateColumnDef extends ColumnDef {
 	}
 
 	private String formatDate(Object value) {
-		return getDateFormatter().format((Date) value);
+		/* protect against multithreaded access of static dateFormatter */
+		synchronized ( DateColumnDef.class ) {
+			return getDateFormatter().format((Date) value);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -13,7 +13,7 @@ public class DateTimeColumnDef extends ColumnDef {
 
 	private static SimpleDateFormat dateTimeFormatter;
 
-	protected static SimpleDateFormat getDateTimeFormatter() {
+	private static SimpleDateFormat getDateTimeFormatter() {
 		if ( dateTimeFormatter == null ) {
 			dateTimeFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 		}
@@ -33,14 +33,17 @@ public class DateTimeColumnDef extends ColumnDef {
 	}
 
 	private String formatValue(Object value) {
-		if ( value instanceof Long && getType().equals("datetime") )
-			return formatLong((Long) value);
-		else if ( value instanceof Timestamp )
-			return getDateTimeFormatter().format((Timestamp) value);
-		else if ( value instanceof Date )
-			return getDateTimeFormatter().format((Date) value);
-		else
-			return "";
+		/* protect against multithreaded access of static dateTimeFormatter */
+		synchronized ( DateTimeColumnDef.class ) {
+			if ( value instanceof Long && getType().equals("datetime") )
+				return formatLong(( Long ) value);
+			else if ( value instanceof Timestamp )
+				return getDateTimeFormatter().format(( Timestamp ) value);
+			else if ( value instanceof Date )
+				return getDateTimeFormatter().format(( Date ) value);
+			else
+				return "";
+		}
 	}
 
 	private String formatLong(Long value) {


### PR DESCRIPTION
Fixes the following crash (only happens under high load):
```
java.lang.ArrayIndexOutOfBoundsException: 44
        at sun.util.calendar.BaseCalendar.getCalendarDateFromFixedDate(BaseCalendar.java:453)
        at java.util.GregorianCalendar.computeFields(GregorianCalendar.java:2397)
        at java.util.GregorianCalendar.computeFields(GregorianCalendar.java:2312)
        at java.util.Calendar.setTimeInMillis(Calendar.java:1804)
        at java.util.Calendar.setTime(Calendar.java:1770)
        at java.text.SimpleDateFormat.format(SimpleDateFormat.java:943)
        at java.text.SimpleDateFormat.format(SimpleDateFormat.java:936)
        at java.text.DateFormat.format(DateFormat.java:345)
        at com.zendesk.maxwell.schema.columndef.DateColumnDef.formatDate(DateColumnDef.java:29)
        at com.zendesk.maxwell.schema.columndef.DateColumnDef.asJSON(DateColumnDef.java:39)
        at com.zendesk.maxwell.bootstrap.SynchronousBootstrapper.setRowValues(SynchronousBootstrapper.java:217)
        at com.zendesk.maxwell.bootstrap.SynchronousBootstrapper.startBootstrap(SynchronousBootstrapper.java:60)
        at com.zendesk.maxwell.bootstrap.AsynchronousBootstrapper$1.run(AsynchronousBootstrapper.java:70)
        at java.lang.Thread.run(Thread.java:745)
```
The issue is that `SimpleDateFormat` isn't thread safe and both the bootstrapping and replicator threads were using the same static instances.