### PR TITLE
Field renames, part 2

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseAlter.java
@@ -5,11 +5,11 @@ import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 
 public class DatabaseAlter extends SchemaChange {
-	private final String dbName;
+	public String database;
 	public String charset;
 
-	public DatabaseAlter(String dbName) {
-		this.dbName = dbName;
+	public DatabaseAlter(String database) {
+		this.database = database;
 	}
 
 	@Override
@@ -18,10 +18,10 @@ public class DatabaseAlter extends SchemaChange {
 			return originalSchema;
 
 		Schema schema = originalSchema.copy();
-		Database d = schema.findDatabase(dbName);
+		Database d = schema.findDatabase(database);
 
 		if ( d == null )
-			throw new SchemaSyncError("Couldn't find database: " + dbName + " while applying database alter");
+			throw new SchemaSyncError("Couldn't find database: " + database + " while applying database alter");
 
 		if ( d.getCharset().equals(charset) )
 			return originalSchema;

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseCreate.java
@@ -5,25 +5,25 @@ import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 
 public class DatabaseCreate extends SchemaChange {
-	public final String dbName;
+	public final String database;
 	private final boolean ifNotExists;
 	public final String charset;
 
-	public DatabaseCreate(String dbName, boolean ifNotExists, String charset) {
-		this.dbName = dbName;
+	public DatabaseCreate(String database, boolean ifNotExists, String charset) {
+		this.database = database;
 		this.ifNotExists = ifNotExists;
 		this.charset = charset;
 	}
 
 	@Override
 	public Schema apply(Schema originalSchema) throws SchemaSyncError {
-		Database database = originalSchema.findDatabase(dbName);
+		Database d = originalSchema.findDatabase(database);
 
-		if ( database != null ) {
+		if ( d != null ) {
 			if ( ifNotExists )
 				return originalSchema;
 			else
-				throw new SchemaSyncError("Unexpectedly asked to create existing database " + dbName);
+				throw new SchemaSyncError("Unexpectedly asked to create existing database " + database);
 		}
 
 		Schema newSchema = originalSchema.copy();
@@ -34,8 +34,7 @@ public class DatabaseCreate extends SchemaChange {
 		else
 			createCharset = newSchema.getCharset();
 
-		database = new Database(dbName, createCharset);
-		newSchema.addDatabase(database);
+		newSchema.addDatabase(new Database(database, createCharset));
 		return newSchema;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DatabaseDrop.java
@@ -5,11 +5,11 @@ import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 
 public class DatabaseDrop extends SchemaChange {
-	public String dbName;
+	public String database;
 	public boolean ifExists;
 
-	public DatabaseDrop(String dbName, boolean ifExists) {
-		this.dbName = dbName;
+	public DatabaseDrop(String database, boolean ifExists) {
+		this.database = database;
 		this.ifExists = ifExists;
 	}
 
@@ -17,17 +17,17 @@ public class DatabaseDrop extends SchemaChange {
 	public Schema apply(Schema originalSchema) throws SchemaSyncError {
 		Schema newSchema = originalSchema.copy();
 
-		Database database = newSchema.findDatabase(dbName);
+		Database d = newSchema.findDatabase(database);
 
-		if ( database == null ) {
+		if ( d == null ) {
 			if ( ifExists ) { // ignore missing databases
 				return originalSchema;
 			} else {
-				throw new SchemaSyncError("Can't drop missing database: " + dbName);
+				throw new SchemaSyncError("Can't drop missing database: " + database);
 			}
 		}
 
-		newSchema.getDatabases().remove(database);
+		newSchema.getDatabases().remove(d);
 		return newSchema;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
@@ -126,7 +126,7 @@ public class MysqlParserListener extends mysqlBaseListener {
 		String tableName = getTable(ctx.table_name());
 
 		TableAlter alterStatement = new TableAlter(dbName, tableName);
-		this.tableName = alterStatement.tableName;
+		this.tableName = alterStatement.table;
 
 		this.schemaChanges.add(alterStatement);
 	}
@@ -213,7 +213,7 @@ public class MysqlParserListener extends mysqlBaseListener {
 		boolean ifNotExists = ctx.if_not_exists() != null;
 
 		TableCreate createStatement = new TableCreate(dbName, tblName, ifNotExists);
-		this.tableName = createStatement.tableName;
+		this.tableName = createStatement.table;
 
 		this.schemaChanges.add(createStatement);
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -10,7 +10,7 @@ import com.zendesk.maxwell.schema.Table;
 
 public class TableAlter extends SchemaChange {
 	public String database;
-	public String tableName;
+	public String table;
 	public ArrayList<ColumnMod> columnMods;
 	public String newTableName;
 	public String newDatabase;
@@ -20,15 +20,15 @@ public class TableAlter extends SchemaChange {
 	public List<String> pks;
 
 
-	public TableAlter(String database, String tableName) {
+	public TableAlter(String database, String table) {
 		this.database = database;
-		this.tableName = tableName;
+		this.table = table;
 		this.columnMods = new ArrayList<>();
 	}
 
 	@Override
 	public String toString() {
-		return "TableAlter<database: " + database + ", table:" + tableName + ">";
+		return "TableAlter<database: " + database + ", table:" + table + ">";
 	}
 
 	@Override
@@ -40,9 +40,9 @@ public class TableAlter extends SchemaChange {
 			throw new SchemaSyncError("Couldn't find database: " + this.database);
 		}
 
-		Table table = database.findTable(this.tableName);
+		Table table = database.findTable(this.table);
 		if ( table == null ) {
-			throw new SchemaSyncError("Couldn't find table: " + this.database + "." + this.tableName);
+			throw new SchemaSyncError("Couldn't find table: " + this.database + "." + this.table);
 		}
 
 
@@ -74,7 +74,7 @@ public class TableAlter extends SchemaChange {
 		if ( filter == null ) {
 			return false;
 		} else {
-			return filter.isTableBlacklisted(this.tableName);
+			return filter.isTableBlacklisted(this.table);
 		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -9,7 +9,7 @@ import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
 
 public class TableAlter extends SchemaChange {
-	public String dbName;
+	public String database;
 	public String tableName;
 	public ArrayList<ColumnMod> columnMods;
 	public String newTableName;
@@ -21,35 +21,35 @@ public class TableAlter extends SchemaChange {
 
 
 	public TableAlter(String database, String tableName) {
-		this.dbName = database;
+		this.database = database;
 		this.tableName = tableName;
 		this.columnMods = new ArrayList<>();
 	}
 
 	@Override
 	public String toString() {
-		return "TableAlter<database: " + dbName + ", table:" + tableName + ">";
+		return "TableAlter<database: " + database + ", table:" + tableName + ">";
 	}
 
 	@Override
 	public Schema apply(Schema originalSchema) throws SchemaSyncError {
 		Schema newSchema = originalSchema.copy();
 
-		Database database = newSchema.findDatabase(this.dbName);
+		Database database = newSchema.findDatabase(this.database);
 		if ( database == null ) {
-			throw new SchemaSyncError("Couldn't find database: " + this.dbName);
+			throw new SchemaSyncError("Couldn't find database: " + this.database);
 		}
 
 		Table table = database.findTable(this.tableName);
 		if ( table == null ) {
-			throw new SchemaSyncError("Couldn't find table: " + this.dbName + "." + this.tableName);
+			throw new SchemaSyncError("Couldn't find table: " + this.database + "." + this.tableName);
 		}
 
 
 		if ( newTableName != null && newDatabase != null ) {
 			Database destDB = newSchema.findDatabase(this.newDatabase);
 			if ( destDB == null )
-				throw new SchemaSyncError("Couldn't find database " + this.dbName);
+				throw new SchemaSyncError("Couldn't find database " + this.database);
 
 			table.rename(newTableName);
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
@@ -9,7 +9,7 @@ import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
 public class TableCreate extends SchemaChange {
-	public String dbName;
+	public String database;
 	public String tableName;
 	public ArrayList<ColumnDef> columns;
 	public ArrayList<String> pks;
@@ -19,8 +19,8 @@ public class TableCreate extends SchemaChange {
 	public String likeTable;
 	public final boolean ifNotExists;
 
-	public TableCreate (String dbName, String tableName, boolean ifNotExists) {
-		this.dbName = dbName;
+	public TableCreate (String database, String tableName, boolean ifNotExists) {
+		this.database = database;
 		this.tableName = tableName;
 		this.ifNotExists = ifNotExists;
 		this.columns = new ArrayList<>();
@@ -31,9 +31,9 @@ public class TableCreate extends SchemaChange {
 	public Schema apply(Schema originalSchema) throws SchemaSyncError {
 		Schema newSchema = originalSchema.copy();
 
-		Database d = newSchema.findDatabase(this.dbName);
+		Database d = newSchema.findDatabase(this.database);
 		if ( d == null )
-			throw new SchemaSyncError("Couldn't find database " + this.dbName);
+			throw new SchemaSyncError("Couldn't find database " + this.database);
 
 		if ( likeDB != null && likeTable != null ) {
 			applyCreateLike(newSchema, d);

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableCreate.java
@@ -10,7 +10,7 @@ import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
 public class TableCreate extends SchemaChange {
 	public String database;
-	public String tableName;
+	public String table;
 	public ArrayList<ColumnDef> columns;
 	public ArrayList<String> pks;
 	public String charset;
@@ -19,9 +19,9 @@ public class TableCreate extends SchemaChange {
 	public String likeTable;
 	public final boolean ifNotExists;
 
-	public TableCreate (String database, String tableName, boolean ifNotExists) {
+	public TableCreate (String database, String table, boolean ifNotExists) {
 		this.database = database;
-		this.tableName = tableName;
+		this.table = table;
 		this.ifNotExists = ifNotExists;
 		this.columns = new ArrayList<>();
 		this.pks = new ArrayList<>();
@@ -38,15 +38,15 @@ public class TableCreate extends SchemaChange {
 		if ( likeDB != null && likeTable != null ) {
 			applyCreateLike(newSchema, d);
 		} else {
-			Table existingTable = d.findTable(this.tableName);
+			Table existingTable = d.findTable(this.table);
 			if (existingTable != null) {
 				if (ifNotExists) {
 					return originalSchema;
 				} else {
-					throw new SchemaSyncError("Unexpectedly asked to create existing table " + this.tableName);
+					throw new SchemaSyncError("Unexpectedly asked to create existing table " + this.table);
 				}
 			}
-			Table t = d.buildTable(this.tableName, this.charset, this.columns, this.pks);
+			Table t = d.buildTable(this.table, this.charset, this.columns, this.pks);
 			t.setDefaultColumnCharsets();
 		}
 
@@ -64,7 +64,7 @@ public class TableCreate extends SchemaChange {
 			throw new SchemaSyncError("Couldn't find table " + likeDB + "." + likeTable);
 
 		Table t = sourceTable.copy();
-		t.rename(this.tableName);
+		t.rename(this.table);
 		d.addTable(t);
 	}
 
@@ -73,7 +73,7 @@ public class TableCreate extends SchemaChange {
 		if ( filter == null ) {
 			return false;
 		} else {
-			return filter.isTableBlacklisted(this.tableName);
+			return filter.isTableBlacklisted(this.table);
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
@@ -6,12 +6,12 @@ import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
 
 public class TableDrop extends SchemaChange {
-	final String dbName;
+	public String database;
 	final String tableName;
 	final boolean ifExists;
 
-	public TableDrop(String dbName, String tableName, boolean ifExists) {
-		this.dbName = dbName;
+	public TableDrop(String database, String tableName, boolean ifExists) {
+		this.database = database;
 		this.tableName = tableName;
 		this.ifExists = ifExists;
 	}
@@ -19,7 +19,7 @@ public class TableDrop extends SchemaChange {
 	public Schema apply(Schema originalSchema) throws SchemaSyncError {
 		Schema newSchema = originalSchema.copy();
 
-		Database d = newSchema.findDatabase(this.dbName);
+		Database d = newSchema.findDatabase(this.database);
 
 		// it's perfectly legal to say drop table if exists `random_garbage_db`.`random_garbage_table`
 		Table t = null;
@@ -31,7 +31,7 @@ public class TableDrop extends SchemaChange {
 			if ( ifExists ) { // DROP TABLE IF NOT EXISTS ; ignore missing tables
 				return originalSchema;
 			} else {
-				throw new SchemaSyncError("Can't drop non-existant table: " + this.dbName + "." + this.tableName);
+				throw new SchemaSyncError("Can't drop non-existant table: " + this.database + "." + this.tableName);
 			}
 		}
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableDrop.java
@@ -7,12 +7,12 @@ import com.zendesk.maxwell.schema.Table;
 
 public class TableDrop extends SchemaChange {
 	public String database;
-	final String tableName;
+	final String table;
 	final boolean ifExists;
 
-	public TableDrop(String database, String tableName, boolean ifExists) {
+	public TableDrop(String database, String table, boolean ifExists) {
 		this.database = database;
-		this.tableName = tableName;
+		this.table = table;
 		this.ifExists = ifExists;
 	}
 	@Override
@@ -24,14 +24,14 @@ public class TableDrop extends SchemaChange {
 		// it's perfectly legal to say drop table if exists `random_garbage_db`.`random_garbage_table`
 		Table t = null;
 		if (d != null) {
-			t = d.findTable(this.tableName);
+			t = d.findTable(this.table);
 		}
 
 		if ( t == null ) {
 			if ( ifExists ) { // DROP TABLE IF NOT EXISTS ; ignore missing tables
 				return originalSchema;
 			} else {
-				throw new SchemaSyncError("Can't drop non-existant table: " + this.database + "." + this.tableName);
+				throw new SchemaSyncError("Can't drop non-existant table: " + this.database + "." + this.table);
 			}
 		}
 
@@ -44,7 +44,7 @@ public class TableDrop extends SchemaChange {
 		if ( filter == null ) {
 			return false;
 		} else {
-			return filter.isTableBlacklisted(this.tableName);
+			return filter.isTableBlacklisted(this.table);
 		}
 	}
 

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -303,7 +303,7 @@ public class DDLParserTest {
 	public void testCreateTable() {
 		TableCreate c = parseCreate("CREATE TABLE `foo` ( id int(11) auto_increment not null, `textcol` mediumtext character set 'utf8' not null )");
 
-		assertThat(c.dbName,  is("default_db"));
+		assertThat(c.database,  is("default_db"));
 		assertThat(c.tableName, is("foo"));
 
 		assertThat(c.columns.size(), is(2));
@@ -373,7 +373,7 @@ public class DDLParserTest {
 
 		TableDrop d = (TableDrop) changes.get(0);
 		assertThat(d.tableName, is("bar"));
-		assertThat(d.dbName, is("foo"));
+		assertThat(d.database, is("foo"));
 
 	}
 
@@ -381,7 +381,7 @@ public class DDLParserTest {
 	public void testCreateDatabase() {
 		List<SchemaChange> changes = parse("CREATE DATABASE if not exists `foo` default character set='latin1'");
 		DatabaseCreate create = (DatabaseCreate) changes.get(0);
-		assertThat(create.dbName, is("foo"));
+		assertThat(create.database, is("foo"));
 		assertThat(create.charset, is("latin1"));
 	}
 
@@ -389,7 +389,7 @@ public class DDLParserTest {
 	public void testCreateSchema() {
 		List<SchemaChange> changes = parse("CREATE SCHEMA if not exists `foo`");
 		DatabaseCreate create = (DatabaseCreate) changes.get(0);
-		assertThat(create.dbName, is("foo"));
+		assertThat(create.database, is("foo"));
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -304,7 +304,7 @@ public class DDLParserTest {
 		TableCreate c = parseCreate("CREATE TABLE `foo` ( id int(11) auto_increment not null, `textcol` mediumtext character set 'utf8' not null )");
 
 		assertThat(c.database,  is("default_db"));
-		assertThat(c.tableName, is("foo"));
+		assertThat(c.table, is("foo"));
 
 		assertThat(c.columns.size(), is(2));
 		assertThat(c.columns.get(0).getName(), is("id"));
@@ -360,7 +360,7 @@ public class DDLParserTest {
 		TableCreate c = parseCreate("CREATE TABLE `foo` LIKE `bar`.`baz`");
 
 		assertThat(c, not(nullValue()));
-		assertThat(c.tableName, is("foo"));
+		assertThat(c.table, is("foo"));
 
 		assertThat(c.likeDB,    is("bar"));
 		assertThat(c.likeTable, is("baz"));
@@ -372,7 +372,7 @@ public class DDLParserTest {
 		assertThat(changes.size(), is(2));
 
 		TableDrop d = (TableDrop) changes.get(0);
-		assertThat(d.tableName, is("bar"));
+		assertThat(d.table, is("bar"));
 		assertThat(d.database, is("foo"));
 
 	}


### PR DESCRIPTION
talk about `database` and `table` exclusively in DDL classes to prep for serializating them to JSON.

@zendesk/rules 

NOTE: this is a PR off field_renames.  merge by hand or first.