### PR TITLE
refactor ColumnDef classes

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -121,7 +121,7 @@ public class SchemaCapturer {
 				enumValues = extractEnumValues(expandedType);
 			}
 
-			t.addColumn(ColumnDef.build(t.getName(), colName, colEnc, colType, colPos, colSigned, enumValues));
+			t.addColumn(ColumnDef.build(colName, colEnc, colType, colPos, colSigned, enumValues));
 			i++;
 		}
 		captureTablePK(t);

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -13,12 +13,12 @@ import java.util.*;
 
 import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.schema.columndef.*;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zendesk.maxwell.BinlogPosition;
-import com.zendesk.maxwell.schema.columndef.ColumnDef;
 import com.zendesk.maxwell.schema.ddl.SchemaSyncError;
 
 public class SchemaStore {
@@ -125,19 +125,33 @@ public class SchemaStore {
 
 
 				for (ColumnDef c : t.getColumnList()) {
-					String [] enumValues = c.getEnumValues();
 					String enumValuesSQL = null;
 
-					if ( enumValues != null ) {
-						enumValuesSQL = StringUtils.join(enumValues, ",");
+					if ( c instanceof EnumeratedColumnDef ) {
+						EnumeratedColumnDef enumColumn = (EnumeratedColumnDef) c;
+						enumValuesSQL = StringUtils.join(enumColumn.getEnumValues(), ",");
 					}
 
 					columnData.add(schemaId);
 					columnData.add(tableId);
 					columnData.add(c.getName());
-					columnData.add(c.getCharset());
+
+					if ( c instanceof StringColumnDef ) {
+						columnData.add(((StringColumnDef) c).getCharset());
+					} else {
+						columnData.add(null);
+					}
+
 					columnData.add(c.getType());
-					columnData.add(c.getSigned() ? 1 : 0);
+
+					if ( c instanceof IntColumnDef ) {
+						columnData.add(((IntColumnDef) c).isSigned() ? 1 : 0);
+					} else if ( c instanceof BigIntColumnDef ) {
+						columnData.add(((BigIntColumnDef) c).isSigned() ? 1 : 0);
+					} else {
+						columnData.add(0);
+					}
+
 					columnData.add(enumValuesSQL);
 				}
 
@@ -295,7 +309,7 @@ public class SchemaStore {
 			if ( cRS.getString("enum_values") != null )
 				enumValues = StringUtils.splitByWholeSeparatorPreserveAllTokens(cRS.getString("enum_values"), ",");
 
-			ColumnDef c = ColumnDef.build(t.getName(),
+			ColumnDef c = ColumnDef.build(
 					cRS.getString("name"), cRS.getString("charset"),
 					cRS.getString("coltype"), i++,
 					cRS.getInt("is_signed") == 1,

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell.schema;
 
 import java.util.*;
 
+import com.zendesk.maxwell.schema.columndef.EnumeratedColumnDef;
 import org.apache.commons.lang.StringUtils;
 
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
@@ -102,7 +103,7 @@ public class Table {
 			if ( other == null )
 				diffs.add(b.fullName() + " is missing column " + column.getName() + " in " + nameB);
 			else {
-                String colName = a.fullName() + ".`" + column.getName() + "` ";
+				String colName = a.fullName() + ".`" + column.getName() + "` ";
 				if ( !column.getType().equals(other.getType()) ) {
 					diffs.add(colName + "has a type mismatch, "
 									  + column.getType()
@@ -115,19 +116,33 @@ public class Table {
 									  + " vs "
 									  + other.getPos()
 									  + " in " + nameB);
-				} else if ( !Arrays.deepEquals(column.getEnumValues(), other.getEnumValues()) ) {
-					diffs.add(colName + "has an enum value mismatch, "
-									  + StringUtils.join(column.getEnumValues(), ",")
-									  + " vs "
-									  + StringUtils.join(other.getEnumValues(), ",")
-									  + " in " + nameB);
+				}
 
-				} else if ( !Objects.equals(column.getCharset(), other.getCharset()) ) {
-					diffs.add(colName + "has an charset mismatch, "
-						+ "'" + column.getCharset() + "'"
-						+ " vs "
-						+ "'" + other.getCharset() + "'"
-						+ " in " + nameB);
+				if ( column instanceof EnumeratedColumnDef ) {
+					EnumeratedColumnDef enumA, enumB;
+					enumA = (EnumeratedColumnDef) column;
+					enumB = (EnumeratedColumnDef) other;
+					if ( !Arrays.deepEquals(enumA.getEnumValues(), enumB.getEnumValues()) ) {
+						diffs.add(colName + "has an enum value mismatch, "
+								+ StringUtils.join(enumA.getEnumValues(), ",")
+								+ " vs "
+								+ StringUtils.join(enumB.getEnumValues(), ",")
+								+ " in " + nameB);
+					}
+				}
+
+				if ( column instanceof StringColumnDef ) {
+					StringColumnDef stringA, stringB;
+					stringA = (StringColumnDef) column;
+					stringB = (StringColumnDef) other;
+
+					if ( !Objects.equals(stringA.getCharset(), stringB.getCharset()) ) {
+						diffs.add(colName + "has an charset mismatch, "
+								+ "'" + stringA.getCharset() + "'"
+								+ " vs "
+								+ "'" + stringB.getCharset() + "'"
+								+ " in " + nameB);
+					}
 
 				}
 			}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
@@ -7,8 +7,9 @@ import com.google.code.or.common.util.MySQLConstants;
 public class BigIntColumnDef extends ColumnDef {
 	private final BigInteger longlong_max = BigInteger.ONE.shiftLeft(64);
 
-	public BigIntColumnDef(String tableName, String name, String type, int pos, boolean signed) {
-		super(tableName, name, type, pos);
+	protected boolean signed;
+	public BigIntColumnDef(String name, String type, int pos, boolean signed) {
+		super(name, type, pos);
 		this.signed = signed;
 	}
 
@@ -37,4 +38,12 @@ public class BigIntColumnDef extends ColumnDef {
 		return toNumeric(value);
 	}
 
+	@Override
+	public ColumnDef copy() {
+		return new BigIntColumnDef(name, type, pos, signed);
+	}
+
+	public boolean isSigned() {
+		return signed;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
@@ -5,8 +5,8 @@ import com.google.code.or.common.util.MySQLConstants;
 import java.math.BigInteger;
 
 public class BitColumnDef extends ColumnDef {
-	public BitColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public BitColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
 
 	@Override
@@ -22,6 +22,11 @@ public class BitColumnDef extends ColumnDef {
 		} else {
 			return bytesToLong(bytes);
 		}
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new BitColumnDef(name, type, pos);
 	}
 
 	private BigInteger bytesToBigInteger(byte[] bytes) {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -1,20 +1,14 @@
 package com.zendesk.maxwell.schema.columndef;
 
 public abstract class ColumnDef {
-	protected final String tableName;
-	protected final String name;
-	protected final String type;
-	protected String[] enumValues;
-	private int pos;
-	public boolean signed;
-	public String charset;
+	protected String name;
+	protected String type;
+	protected int pos;
 
-	public ColumnDef(String tableName, String name, String type, int pos) {
-		this.tableName = tableName;
+	public ColumnDef(String name, String type, int pos) {
 		this.name = name.toLowerCase();
 		this.type = type;
 		this.pos = pos;
-		this.signed = false;
 	}
 
 	public abstract boolean matchesMysqlType(int type);
@@ -24,33 +18,31 @@ public abstract class ColumnDef {
 		return value;
 	}
 
-	public ColumnDef copy() {
-		return build(this.tableName, this.name, this.charset, this.type, this.pos, this.signed, this.enumValues);
-	}
+	abstract public ColumnDef copy();
 
-	public static ColumnDef build(String tableName, String name, String charset, String type, int pos, boolean signed, String enumValues[]) {
+	public static ColumnDef build(String name, String charset, String type, int pos, boolean signed, String enumValues[]) {
 		switch(type) {
 		case "tinyint":
 		case "smallint":
 		case "mediumint":
 		case "int":
-			return new IntColumnDef(tableName, name, type, pos, signed);
+			return new IntColumnDef(name, type, pos, signed);
 		case "bigint":
-			return new BigIntColumnDef(tableName, name, type, pos, signed);
+			return new BigIntColumnDef(name, type, pos, signed);
 		case "tinytext":
 		case "text":
 		case "mediumtext":
 		case "longtext":
 		case "varchar":
 		case "char":
-			return new StringColumnDef(tableName, name, type, pos, charset);
+			return new StringColumnDef(name, type, pos, charset);
 		case "tinyblob":
 		case "blob":
 		case "mediumblob":
 		case "longblob":
 		case "binary":
 		case "varbinary":
-			return new StringColumnDef(tableName, name, type, pos, "binary");
+			return new StringColumnDef(name, type, pos, "binary");
 		case "geometry":
 		case "geometrycollection":
 		case "linestring":
@@ -59,27 +51,27 @@ public abstract class ColumnDef {
 		case "multipolygon":
 		case "polygon":
 		case "point":
-			return new GeometryColumnDef(tableName, name, type, pos);
+			return new GeometryColumnDef(name, type, pos);
 		case "float":
 		case "double":
-			return new FloatColumnDef(tableName, name, type, pos);
+			return new FloatColumnDef(name, type, pos);
 		case "decimal":
-			return new DecimalColumnDef(tableName, name, type, pos);
+			return new DecimalColumnDef(name, type, pos);
 		case "date":
-			return new DateColumnDef(tableName, name, type, pos);
+			return new DateColumnDef(name, type, pos);
 		case "datetime":
 		case "timestamp":
-			return new DateTimeColumnDef(tableName, name, type, pos);
+			return new DateTimeColumnDef(name, type, pos);
 		case "year":
-			return new YearColumnDef(tableName, name, type, pos);
+			return new YearColumnDef(name, type, pos);
 		case "time":
-			return new TimeColumnDef(tableName, name, type, pos);
+			return new TimeColumnDef(name, type, pos);
 		case "enum":
-			return new EnumColumnDef(tableName, name, type, pos, enumValues);
+			return new EnumColumnDef(name, type, pos, enumValues);
 		case "set":
-			return new SetColumnDef(tableName, name, type, pos, enumValues);
+			return new SetColumnDef(name, type, pos, enumValues);
 		case "bit":
-			return new BitColumnDef(tableName, name, type, pos);
+			return new BitColumnDef(name, type, pos);
 		default:
 			throw new IllegalArgumentException("unsupported column type " + type);
 		}
@@ -170,10 +162,6 @@ public abstract class ColumnDef {
 		return name;
 	}
 
-	public String getTableName() {
-		return tableName;
-	}
-
 	public String getType() {
 		return type;
 	}
@@ -185,17 +173,5 @@ public abstract class ColumnDef {
 	public void setPos(int i) {
 		this.pos = i;
 	}
-
-	public String getCharset() {
-		return this.charset;
-	}
-
-	public boolean getSigned() {
-		return this.signed;
-	}
-
-	public String[] getEnumValues() {
-		return enumValues;
-	}
-
 }
+

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -6,8 +6,8 @@ import java.util.Date;
 import com.google.code.or.common.util.MySQLConstants;
 
 public class DateColumnDef extends ColumnDef {
-	public DateColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public DateColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
 
 	private static SimpleDateFormat dateFormatter;
@@ -40,6 +40,11 @@ public class DateColumnDef extends ColumnDef {
 	@Override
 	public Object asJSON(Object value) {
 		return formatDate(value);
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new DateColumnDef(name, type, pos);
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -7,8 +7,8 @@ import java.util.Date;
 import com.google.code.or.common.util.MySQLConstants;
 
 public class DateTimeColumnDef extends ColumnDef {
-	public DateTimeColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public DateTimeColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
 
 	private static SimpleDateFormat dateTimeFormatter;
@@ -67,6 +67,11 @@ public class DateTimeColumnDef extends ColumnDef {
 	@Override
 	public Object asJSON(Object value) {
 		return formatValue(value);
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new DateTimeColumnDef(name, type, pos);
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DecimalColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DecimalColumnDef.java
@@ -5,8 +5,8 @@ import java.math.BigDecimal;
 import com.google.code.or.common.util.MySQLConstants;
 
 public class DecimalColumnDef extends ColumnDef {
-	public DecimalColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public DecimalColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
 
 	@Override
@@ -19,6 +19,11 @@ public class DecimalColumnDef extends ColumnDef {
 		BigDecimal d = (BigDecimal) value;
 
 		return d.toEngineeringString();
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new DecimalColumnDef(name, type, pos);
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/EnumColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/EnumColumnDef.java
@@ -2,10 +2,9 @@ package com.zendesk.maxwell.schema.columndef;
 
 import com.google.code.or.common.util.MySQLConstants;
 
-public class EnumColumnDef extends ColumnDef {
-	public EnumColumnDef(String tableName, String name, String type, int pos, String[] enumValues) {
-		super(tableName, name, type, pos);
-		this.enumValues = enumValues;
+public class EnumColumnDef extends EnumeratedColumnDef {
+	public EnumColumnDef(String name, String type, int pos, String[] enumValues) {
+		super(name, type, pos, enumValues);
 	}
 
 	@Override
@@ -21,6 +20,11 @@ public class EnumColumnDef extends ColumnDef {
 	@Override
 	public String asJSON(Object value) {
 		return asString(value);
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new EnumColumnDef(name, type, pos, enumValues);
 	}
 
 	private String asString(Object value) {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/EnumeratedColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/EnumeratedColumnDef.java
@@ -1,0 +1,14 @@
+package com.zendesk.maxwell.schema.columndef;
+
+abstract public class EnumeratedColumnDef extends ColumnDef  {
+	protected String[] enumValues;
+
+	public EnumeratedColumnDef(String name, String type, int pos, String [] enumValues) {
+		super(name, type, pos);
+		this.enumValues = enumValues;
+	}
+
+	public String[] getEnumValues() {
+		return enumValues;
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/FloatColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/FloatColumnDef.java
@@ -3,9 +3,11 @@ package com.zendesk.maxwell.schema.columndef;
 import com.google.code.or.common.util.MySQLConstants;
 
 public class FloatColumnDef extends ColumnDef {
-	public FloatColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public FloatColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
+
+	public boolean signed;
 
 	@Override
 	public boolean matchesMysqlType(int type) {
@@ -18,6 +20,11 @@ public class FloatColumnDef extends ColumnDef {
 	@Override
 	public String toSQL(Object value) {
 		return value.toString();
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new FloatColumnDef(name, type, pos);
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/GeometryColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/GeometryColumnDef.java
@@ -7,8 +7,8 @@ import com.vividsolutions.jts.geom.Geometry;
  * Created by ben on 12/30/15.
  */
 public class GeometryColumnDef extends ColumnDef {
-	public GeometryColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public GeometryColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
 
 	@Override
@@ -20,6 +20,11 @@ public class GeometryColumnDef extends ColumnDef {
 	public Object asJSON(Object value) {
 		Geometry g = (Geometry) value;
 		return g.toText();
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new GeometryColumnDef(name, type, pos);
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
@@ -6,8 +6,10 @@ import com.google.code.or.common.util.MySQLConstants;
 public class IntColumnDef extends ColumnDef {
 	private final int bits;
 
-	public IntColumnDef(String tableName, String name, String type, int pos, boolean signed) {
-		super(tableName, name, type, pos);
+	protected boolean signed;
+
+	public IntColumnDef(String name, String type, int pos, boolean signed) {
+		super(name, type, pos);
 		this.signed = signed;
 		this.bits = bitsFromType(type);
 	}
@@ -50,6 +52,11 @@ public class IntColumnDef extends ColumnDef {
 	}
 
 	@Override
+	public ColumnDef copy() {
+		return new IntColumnDef(name, type, pos, signed);
+	}
+
+	@Override
 	public boolean matchesMysqlType(int type) {
 		switch(this.bits) {
 		case 8:
@@ -80,9 +87,7 @@ public class IntColumnDef extends ColumnDef {
 		}
 	}
 
-
-	@Override
-	public boolean getSigned() {
+	public boolean isSigned() {
 		return signed;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
@@ -7,10 +7,9 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.code.or.common.util.MySQLConstants;
 
-public class SetColumnDef extends ColumnDef {
-	public SetColumnDef(String tableName, String name, String type, int pos, String[] enumValues) {
-		super(tableName, name, type, pos);
-		this.enumValues = enumValues;
+public class SetColumnDef extends EnumeratedColumnDef {
+	public SetColumnDef(String name, String type, int pos, String[] enumValues) {
+		super(name, type, pos, enumValues);
 	}
 
 	@Override
@@ -26,6 +25,11 @@ public class SetColumnDef extends ColumnDef {
 	@Override
 	public Object asJSON(Object value) {
 		return asList(value);
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new SetColumnDef(name, type, pos, enumValues);
 	}
 
 	private ArrayList<String> asList(Object value) {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -24,6 +24,10 @@ public class StringColumnDef extends ColumnDef {
 		return charset;
 	}
 
+	public void setCharset(String charset) {
+		this.charset = charset;
+	}
+
 	public void setDefaultCharset(String e) {
 		if ( this.charset == null )
 		  this.charset = e;

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -12,10 +12,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class StringColumnDef extends ColumnDef {
+	protected String charset;
+
 	static final Logger LOGGER = LoggerFactory.getLogger(StringColumnDef.class);
-	public StringColumnDef(String tableName, String name, String type, int pos, String charset) {
-		super(tableName, name, type, pos);
+	public StringColumnDef(String name, String type, int pos, String charset) {
+		super(name, type, pos);
 		this.charset = charset;
+	}
+
+	public String getCharset() {
+		return charset;
 	}
 
 	public void setDefaultCharset(String e) {
@@ -34,7 +40,7 @@ public class StringColumnDef extends ColumnDef {
 	public String toSQL(Object value) {
 		byte[] b = (byte[]) value;
 
-		if ( getCharset().equals("utf8") || getCharset().equals("utf8mb4")) {
+		if ( charset.equals("utf8") || charset.equals("utf8mb4")) {
 			return quoteString(new String(b));
 		} else {
 			return "x'" +  Hex.encodeHexString( b ) + "'";
@@ -70,10 +76,16 @@ public class StringColumnDef extends ColumnDef {
 		}
 	}
 
+	@Override
+	public ColumnDef copy() {
+		return new StringColumnDef(name, type, pos, charset);
+	}
+
 	private String quoteString(String s) {
 		String escaped = StringEscapeUtils.escapeSql(s);
 		escaped = escaped.replaceAll("\n", "\\\\n");
 		escaped = escaped.replaceAll("\r", "\\\\r");
 		return "'" + escaped + "'";
 	}
+
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
@@ -5,8 +5,8 @@ import java.sql.Time;
 import com.google.code.or.common.util.MySQLConstants;
 
 public class TimeColumnDef extends ColumnDef {
-	public TimeColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public TimeColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
 
 	@Override
@@ -23,6 +23,11 @@ public class TimeColumnDef extends ColumnDef {
 	@Override
 	public Object asJSON(Object value) {
 		return String.valueOf((Time) value);
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new TimeColumnDef(name, type, pos);
 	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/YearColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/YearColumnDef.java
@@ -6,8 +6,8 @@ import java.sql.Date;
 import java.util.Calendar;
 
 public class YearColumnDef extends ColumnDef {
-	public YearColumnDef(String tableName, String name, String type, int pos) {
-		super(tableName, name, type, pos);
+	public YearColumnDef(String name, String type, int pos) {
+		super(name, type, pos);
 	}
 
 	@Override
@@ -23,6 +23,11 @@ public class YearColumnDef extends ColumnDef {
 			return calendar.get(Calendar.YEAR);
 		}
 		return value;
+	}
+
+	@Override
+	public ColumnDef copy() {
+		return new YearColumnDef(name, type, pos);
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
@@ -359,8 +359,7 @@ public class MysqlParserListener extends mysqlBaseListener {
 		}
 
 		colType = ColumnDef.unalias_type(colType.toLowerCase(), longStringFlag, columnLength, byteFlagToStringColumn);
-		ColumnDef c = ColumnDef.build(this.tableName,
-					                   name,
+		ColumnDef c = ColumnDef.build(name,
 					                   colCharset,
 					                   colType.toLowerCase(),
 					                   -1,

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -7,6 +7,8 @@ import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
+import com.zendesk.maxwell.schema.columndef.ColumnDef;
+import com.zendesk.maxwell.schema.columndef.StringColumnDef;
 
 public class TableAlter extends SchemaChange {
 	public String database;
@@ -59,6 +61,16 @@ public class TableAlter extends SchemaChange {
 
 		for (ColumnMod mod : columnMods) {
 			mod.apply(table);
+		}
+
+		if ( convertCharset != null ) {
+			for ( ColumnDef c : table.getColumnList() ) {
+				if ( c instanceof StringColumnDef ) {
+					StringColumnDef sc = (StringColumnDef) c;
+					if ( !sc.getCharset().toLowerCase().equals("binary") )
+						sc.setCharset(convertCharset);
+				}
+			}
 		}
 
 		if ( this.pks != null ) {

--- a/src/test/java/com/zendesk/maxwell/ColumnDefTest.java
+++ b/src/test/java/com/zendesk/maxwell/ColumnDefTest.java
@@ -28,7 +28,7 @@ import com.zendesk.maxwell.schema.columndef.StringColumnDef;
 
 public class ColumnDefTest {
 	private ColumnDef build(String type, boolean signed) {
-		return ColumnDef.build("foo", "bar", "", type, 1, signed, null);
+		return ColumnDef.build("bar", "", type, 1, signed, null);
 	}
 
 	@Before
@@ -103,7 +103,7 @@ public class ColumnDefTest {
 
 	@Test
 	public void testUTF8String() {
-		ColumnDef d = ColumnDef.build("foo", "bar", "utf8", "varchar", 1, false, null);
+		ColumnDef d = ColumnDef.build("bar", "utf8", "varchar", 1, false, null);
 
 		assertThat(d, instanceOf(StringColumnDef.class));
 		byte input[] = "He∆˚ß∆".getBytes();
@@ -114,7 +114,7 @@ public class ColumnDefTest {
 	public void TestUTF8MB4String() {
 		String utf8_4 = "😁";
 
-		ColumnDef d = ColumnDef.build("foo", "bar", "utf8mb4", "varchar", 1, false, null);
+		ColumnDef d = ColumnDef.build("bar", "utf8mb4", "varchar", 1, false, null);
 		byte input[] = utf8_4.getBytes();
 		assertThat(d.toSQL(input), is("'😁'"));
 	}
@@ -127,7 +127,7 @@ public class ColumnDefTest {
 		input[2] = Byte.valueOf((byte) 126);
 		input[3] = Byte.valueOf((byte) 126);
 
-		ColumnDef d = ColumnDef.build("foo", "bar", "ascii", "varchar", 1, false, null);
+		ColumnDef d = ColumnDef.build("bar", "ascii", "varchar", 1, false, null);
 		assertThat((String) d.asJSON(input), is("~~~~"));
 	}
 
@@ -139,7 +139,7 @@ public class ColumnDefTest {
 		input[2] = Byte.valueOf((byte) 169);
 		input[3] = Byte.valueOf((byte) 169);
 
-		ColumnDef d = ColumnDef.build("foo", "bar", "latin1", "varchar", 1, false, null);
+		ColumnDef d = ColumnDef.build("bar", "latin1", "varchar", 1, false, null);
 
 		assertThat((String) d.asJSON(input), is("©©©©"));
 	}

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -166,6 +166,15 @@ public class DDLIntegrationTest extends AbstractMaxwellTest {
 	}
 
 	@Test
+	public void testConvertCharset() throws Exception {
+		String sql[] = {
+			"CREATE TABLE t ( a varchar(255) character set latin1, b varchar(255) character set latin2, c blob, d varbinary(255), e varchar(255) binary)",
+			"ALTER TABLE t convert to character set 'utf8'"
+		};
+		testIntegration(sql);
+	}
+
+	@Test
 	public void testPKs() throws SQLException, SchemaSyncError, IOException {
 		String sql[] = {
 		   "create TABLE `test_pks` ( id int(11) unsigned primary KEY, str varchar(255) )",


### PR DESCRIPTION
In preparation for serializing ColumnDef classes, we move them to a more "proper" hierarchy in which only string columns have a character set, only enum columns have enum values, and only integer columns have a signed flag.

There's still some type-checking hacks that it'd be good to remove by delegating the methods to the objects, but this is good for now.

@zendesk/rules 

NOTE: this is a PR off field_renames_2.  merge appropriately.