### PR TITLE
backport of 2edecdf to the 1.0 branch

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -23,6 +23,10 @@ public class StringColumnDef extends ColumnDef {
 		  this.encoding = e;
 	}
 
+	public void setCharset(String encoding) {
+		this.encoding = encoding;
+	}
+
 	@Override
 	public boolean matchesMysqlType(int type) {
 		return type == MySQLConstants.TYPE_BLOB ||

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -7,6 +7,8 @@ import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
+import com.zendesk.maxwell.schema.columndef.ColumnDef;
+import com.zendesk.maxwell.schema.columndef.StringColumnDef;
 
 public class TableAlter extends SchemaChange {
 	public String dbName;
@@ -59,6 +61,16 @@ public class TableAlter extends SchemaChange {
 
 		for (ColumnMod mod : columnMods) {
 			mod.apply(table);
+		}
+
+		if ( convertCharset != null ) {
+			for ( ColumnDef c : table.getColumnList() ) {
+				if ( c instanceof StringColumnDef ) {
+					StringColumnDef sc = (StringColumnDef) c;
+					if ( !sc.getEncoding().toLowerCase().equals("binary") )
+						sc.setCharset(convertCharset);
+				}
+			}
 		}
 
 		if ( this.pks != null ) {

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -166,6 +166,15 @@ public class DDLIntegrationTest extends AbstractMaxwellTest {
 	}
 
 	@Test
+	public void testConvertCharset() throws Exception {
+		String sql[] = {
+			"CREATE TABLE t ( a varchar(255) character set latin1, b varchar(255) character set latin2, c blob, d varbinary(255), e varchar(255) binary)",
+			"ALTER TABLE t convert to character set 'utf8'"
+		};
+		testIntegration(sql);
+	}
+
+	@Test
 	public void testPKs() throws SQLException, SchemaSyncError, IOException {
 		String sql[] = {
 		   "create TABLE `test_pks` ( id int(11) unsigned primary KEY, str varchar(255) )",


### PR DESCRIPTION
I've started a 1.0 branch to pick up fixes like this one into the 1.0-RC series.  the refactor, renaming, all that stuff is too much to jam in while I'm trying to land a reasonably bug-free 1.0.  

so this is a backport of the fixes for `CONVERT CHARSET` into the v1_0 maintenance branch.

@zendesk/rules 