### PR TITLE
consume OpenReplicator heartbeats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
     	<groupId>com.zendesk</groupId>
     	<artifactId>open-replicator</artifactId>
-    	<version>1.4.0</version>
+    	<version>1.4.2</version>
     </dependency>
     <dependency>
     	<groupId>net.sf.jopt-simple</groupId>

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -58,6 +58,8 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 		this.replicator.setLevel2BufferSize(50 * 1024 * 1024);
 
+		this.replicator.setHeartbeatPeriod(0.5f);
+
 		this.producer = producer;
 		this.bootstrapper = bootstrapper;
 
@@ -77,6 +79,13 @@ public class MaxwellReplicator extends RunLoopProcess {
 	private void ensureReplicatorThread() throws Exception {
 		if ( !replicator.isRunning() ) {
 			LOGGER.warn("open-replicator stopped at position " + replicator.getBinlogFileName() + ":" + replicator.getBinlogPosition() + " -- restarting");
+			replicator.start();
+		}
+
+		Long ms = replicator.millisSinceLastEvent();
+		if ( ms != null && ms > 2000 ) {
+			LOGGER.warn("no heartbeat heard from server in " + ms + "ms.  restarting replication.");
+			replicator.stop(5, TimeUnit.SECONDS);
 			replicator.start();
 		}
 	}


### PR DESCRIPTION
long-lived connections can, at some points, good dead.  It's better to be vigilant than assume the network is reliable.

Note that I've tested this locally with `kill -STOP [mysqld_pid]`, but I don't know of a reliable way to get the connection to die underneath me in a test suite. 

@zendesk/rules 