### PR TITLE
move towards changing the kafka key format

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -26,6 +26,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public final Properties kafkaProperties;
 	public String kafkaTopic;
+	public String kafkaKeyFormat;
 	public String producerType;
 	public String kafkaPartitionHash;
 	public String kafkaPartitionKey;
@@ -79,6 +80,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "kafka_partition_by", "database|table|primary_key, kafka producer assigns partition by hashing the specified parameter").withRequiredArg();
 		parser.accepts( "kafka_partition_hash", "default|murmur3, hash function for partitioning").withRequiredArg();
 		parser.accepts( "kafka_topic", "optionally provide a topic name to push to. default: maxwell").withOptionalArg();
+		parser.accepts( "kafka_key_format", "how to format the kafka key; array|hash").withOptionalArg();
 
 		parser.accepts( "__separator_4" );
 
@@ -162,6 +164,9 @@ public class MaxwellConfig extends AbstractConfig {
 		if ( options.has("kafka_topic"))
 			this.kafkaTopic = (String) options.valueOf("kafka_topic");
 
+		if ( options.has("kafka_key_format"))
+			this.kafkaKeyFormat = (String) options.valueOf("kafka_key_format");
+
 		if ( options.has("kafka_partition_by"))
 			this.kafkaPartitionKey = (String) options.valueOf("kafka_partition_by");
 
@@ -240,6 +245,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.kafkaTopic      = p.getProperty("kafka_topic");
 		this.kafkaPartitionHash = p.getProperty("kafka_partition_hash", "default");
 		this.kafkaPartitionKey = p.getProperty("kafka_partition_by", "database");
+		this.kafkaKeyFormat = p.getProperty("kafka_key_format", "hash");
 		this.includeDatabases = p.getProperty("include_dbs");
 		this.excludeDatabases = p.getProperty("exclude_dbs");
 		this.includeTables = p.getProperty("include_tables");
@@ -283,6 +289,11 @@ public class MaxwellConfig extends AbstractConfig {
 					&& !this.kafkaPartitionKey.equals("primary_key") ) {
 				usage("please specify --kafka_partition_by=database|table|primary_key");
 			}
+
+
+			if ( !this.kafkaKeyFormat.equals("hash") && !this.kafkaKeyFormat.equals("array") )
+				usage("invalid kafka_key_format: " + this.kafkaKeyFormat);
+
 		} else if ( this.producerType.equals("file")
 				&& this.outputFile == null) {
 			usage("please specify --output_file=FILE to use the file producer");

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -14,6 +14,8 @@ import java.util.Set;
 import java.util.UUID;
 
 public class RowMap implements Serializable {
+	public enum KeyFormat { HASH, ARRAY }
+
 	static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 
 	private final String rowType;
@@ -66,7 +68,14 @@ public class RowMap implements Serializable {
 		this.pkColumns = pkColumns;
 	}
 
-	public String pkToJson() throws IOException {
+	public String pkToJson(KeyFormat keyFormat) throws IOException {
+		if ( keyFormat == KeyFormat.HASH )
+			return pkToJsonHash();
+		else
+			return pkToJsonArray();
+	}
+
+	private String pkToJsonHash() throws IOException {
 		JsonGenerator g = jsonGeneratorThreadLocal.get();
 
 		g.writeStartObject(); // start of row {
@@ -87,6 +96,29 @@ public class RowMap implements Serializable {
 		}
 
 		g.writeEndObject(); // end of 'data: { }'
+		g.flush();
+		return jsonFromStream();
+	}
+
+	private String pkToJsonArray() throws IOException {
+		JsonGenerator g = jsonGeneratorThreadLocal.get();
+
+		g.writeStartArray();
+		g.writeString(database);
+		g.writeString(table);
+
+		g.writeStartArray();
+		for (String pk : pkColumns) {
+			Object pkValue = null;
+			if ( data.containsKey(pk) )
+				pkValue = data.get(pk);
+
+			g.writeStartObject();
+			g.writeObjectField(pk, pkValue);
+			g.writeEndObject();
+		}
+		g.writeEndArray();
+		g.writeEndArray();
 		g.flush();
 		return jsonFromStream();
 	}

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -24,7 +24,17 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		String expectedJSON = "{\"database\":\"shard_1\",\"table\":\"minimal\",\"pk.id\":1,\"pk.text_field\":\"hello\"}";
 		list = getRowsForSQL(input);
 		assertThat(list.size(), is(1));
-		assertThat(list.get(0).pkToJson(), is(expectedJSON));
+		assertThat(list.get(0).pkToJson(RowMap.KeyFormat.HASH), is(expectedJSON));
+	}
+
+	@Test
+	public void testAlternativePKString() throws Exception {
+		List<RowMap> list;
+		String input[] = {"insert into minimal set account_id =1, text_field='hello'"};
+		String expectedJSON = "[\"shard_1\",\"minimal\",[{\"id\":1},{\"text_field\":\"hello\"}]]";
+		list = getRowsForSQL(input);
+		assertThat(list.size(), is(1));
+		assertThat(list.get(0).pkToJson(RowMap.KeyFormat.ARRAY), is(expectedJSON));
 	}
 
 	@Test


### PR DESCRIPTION
The old keyformat was nicely descriptive, but unfortunately it was quite hard to reproduce in any library that didn't do direct JSON serialization like maxwell does; so re-processing the stream in KStreams sucked, so I thought I'd convert it to something easier to make consistent. 

@zendesk/rules 

NOTE: merge into master by hand.  this is a chained pull request.