### PR TITLE
put data as ordered

### DIFF
--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -27,8 +28,8 @@ public class RowMap implements Serializable {
 	private Long xid;
 	private boolean txCommit;
 
-	private final HashMap<String, Object> data;
-	private final HashMap<String, Object> oldData;
+	private final LinkedHashMap<String, Object> data;
+	private final LinkedHashMap<String, Object> oldData;
 	private final List<String> pkColumns;
 	private List<Pattern> excludeColumns;
 
@@ -64,8 +65,8 @@ public class RowMap implements Serializable {
 		this.database = database;
 		this.table = table;
 		this.timestamp = timestamp;
-		this.data = new HashMap<>();
-		this.oldData = new HashMap<>();
+		this.data = new LinkedHashMap<>();
+		this.oldData = new LinkedHashMap<>();
 		this.nextPosition = nextPosition;
 		this.pkColumns = pkColumns;
 	}

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -119,7 +118,7 @@ public class RowMap implements Serializable {
 		return keys;
 	}
 
-	private void writeMapToJSON(String jsonMapName, HashMap<String, Object> data, boolean includeNullField) throws IOException {
+	private void writeMapToJSON(String jsonMapName, LinkedHashMap<String, Object> data, boolean includeNullField) throws IOException {
 		JsonGenerator generator = jsonGeneratorThreadLocal.get();
 		generator.writeObjectFieldStart(jsonMapName); // start of jsonMapName: {
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -357,4 +357,20 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		runJSON("/json/test_gis");
 	}
 
+	static String[] createDBSql = {
+			"CREATE database if not exists `foo`",
+			"CREATE TABLE if not exists `foo`.`ordered_output` ( id int, account_id int, user_id int )"
+	};
+	static String[] insertDBSql = {
+			"insert into `foo`.`ordered_output` set id = 1, account_id = 2, user_id = 3"
+	};
+
+	@Test
+	public void testOrderedOutput() throws Exception {
+		MaxwellFilter filter = new MaxwellFilter();
+		List<RowMap> rows = getRowsForSQL(filter, insertDBSql, createDBSql);
+		String ordered_data = "\"data\":\\{\"id\":1,\"account_id\":2,\"user_id\":3\\}";
+		assertTrue(Pattern.compile(ordered_data).matcher(rows.get(0).toJSON()).find());
+	}
+
 }


### PR DESCRIPTION
@osheroff 

turns out the solution is extremely simple, also `LinkedHashMap` has faster iteration.

I assume this is test-free..

### Reference
https://github.com/zendesk/maxwell/issues/306

FYI:

looks like maxwell does not allow empty password eh?

```
15:10:42,803 INFO  AuthenticatorImpl - start to login, user: root, host: 127.0.0.1, port: 3306
java.lang.NullPointerException
	at com.google.code.or.net.impl.AuthenticatorImpl.login(AuthenticatorImpl.java:73)
	at com.google.code.or.net.impl.TransportImpl.connect(TransportImpl.java:105)
	at com.google.code.or.OpenReplicator.start(OpenReplicator.java:103)
	at com.zendesk.maxwell.MaxwellReplicator.beforeStart(MaxwellReplicator.java:97)
	at com.zendesk.maxwell.RunLoopProcess.runLoop(RunLoopProcess.java:25)
	at com.zendesk.maxwell.Maxwell.run(Maxwell.java:103)
	at com.zendesk.maxwell.Maxwell.main(Maxwell.java:109)
15:10:42,804 INFO  SchemaPosition - Storing final position: null
```

in  AuthenticatorImpl.java

```
 s.writeBytes(MySQLUtils.password41OrLater(this.password.getBytes(this.encoding), ctx.getScramble().getBytes(this.encoding)));

```