### PR TITLE
allow for empty parens with CURRENT_TIMESTAMP

### DIFF
--- a/src/main/antlr4/imports/column_definitions.g4
+++ b/src/main/antlr4/imports/column_definitions.g4
@@ -72,7 +72,7 @@ column_options:
 	  nullability
 	| default_value
 	| primary_key
-	| ON UPDATE ( CURRENT_TIMESTAMP length? | now_function )
+	| ON UPDATE ( CURRENT_TIMESTAMP current_timestamp_length? | now_function )
 	| UNIQUE KEY?
 	| KEY
 	| AUTO_INCREMENT
@@ -91,9 +91,10 @@ charset_def: character_set | ASCII;
 character_set: ((CHARACTER SET) | CHARSET) charset_name;
 
 nullability: (NOT NULL | NULL);
-default_value: DEFAULT (literal | CURRENT_TIMESTAMP length? | now_function);
+default_value: DEFAULT (literal | CURRENT_TIMESTAMP current_timestamp_length? | now_function);
 length: '(' INTEGER_LITERAL ')';
 int_flags: ( SIGNED | UNSIGNED | ZEROFILL );
 decimal_length: '(' INTEGER_LITERAL ( ',' INTEGER_LITERAL )? ')';
 
 now_function: NOW '(' ')';
+current_timestamp_length: length | '(' ')';

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -201,7 +201,8 @@ public class DDLParserTest {
 			"create table `shard1.foo` ( `id.foo` int )",
 			"create table `shard1.foo` ( `id.foo` int ) collate = `utf8_bin`",
 			"ALTER TABLE .`users` CHANGE COLUMN `password` `password` VARCHAR(60) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL COMMENT 'Length 60 for Bcrypt'",
-			"create table `shard1.foo` ( `id.foo` int ) collate = `utf8_bin`"
+			"create table `shard1.foo` ( `id.foo` int ) collate = `utf8_bin`",
+			"create table if not exists audit_payer_bank_details (event_time TIMESTAMP default CURRENT_TIMESTAMP())"
 		};
 
 		for ( String s : testSQL ) {


### PR DESCRIPTION
addresses https://github.com/zendesk/maxwell/issues/309

@zendesk/rules 