### PR TITLE
Stop keeping a Connection object with the schema

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -16,7 +16,7 @@ import com.zendesk.maxwell.schema.SchemaStore;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 public class Maxwell {
-	private Schema schema;
+	private SchemaStore schemaStore;
 	private MaxwellConfig config;
 	private MaxwellContext context;
 	static final Logger LOGGER = LoggerFactory.getLogger(Maxwell.class);
@@ -24,13 +24,12 @@ public class Maxwell {
 	private void initFirstRun(Connection connection, Connection schemaConnection) throws SQLException, IOException, InvalidSchemaError {
 		LOGGER.info("Maxwell is capturing initial schema");
 		SchemaCapturer capturer = new SchemaCapturer(connection, this.context.getCaseSensitivity());
-		this.schema = capturer.capture();
+		Schema schema = capturer.capture();
 
 		BinlogPosition pos = BinlogPosition.capture(connection);
 
-		SchemaStore store = new SchemaStore(schemaConnection, this.context.getServerID(), this.schema, pos, this.config.databaseName);
-
-		store.save();
+		this.schemaStore = new SchemaStore(this.context.getServerID(), this.context.getCaseSensitivity(), schema, pos);
+		this.schemaStore.save(schemaConnection);
 
 		this.context.setPosition(pos);
 	}
@@ -60,9 +59,7 @@ public class Maxwell {
 
 				LOGGER.info("Maxwell is booting (" + producerClass + "), starting at " + this.context.getInitialPosition());
 
-				SchemaStore store = SchemaStore.restore(schemaConnection, this.context);
-
-				this.schema = store.getSchema();
+				this.schemaStore = SchemaStore.restore(schemaConnection, this.context);
 			} else {
 				initFirstRun(connection, schemaConnection);
 			}
@@ -75,7 +72,7 @@ public class Maxwell {
 		AbstractProducer producer = this.context.getProducer();
 		AbstractBootstrapper bootstrapper = this.context.getBootstrapper();
 
-		final MaxwellReplicator p = new MaxwellReplicator(this.schema, producer, bootstrapper, this.context, this.context.getInitialPosition());
+		final MaxwellReplicator p = new MaxwellReplicator(this.schemaStore, producer, bootstrapper, this.context, this.context.getInitialPosition());
 
 		bootstrapper.resume(producer, p);
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -29,7 +29,8 @@ public class MaxwellReplicator extends RunLoopProcess {
 	private final long MAX_TX_ELEMENTS = 10000;
 	String filePath, fileName;
 	private long rowEventsProcessed;
-	protected Schema schema;
+	protected SchemaStore schemaStore;
+
 	private MaxwellFilter filter;
 
 	private final LinkedBlockingDeque<BinlogEventV4> queue = new LinkedBlockingDeque<>(20);
@@ -44,8 +45,8 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellReplicator.class);
 
-	public MaxwellReplicator(Schema currentSchema, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
-		this.schema = currentSchema;
+	public MaxwellReplicator(SchemaStore schemaStore, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
+		this.schemaStore = schemaStore;
 
 		this.binlogEventListener = new MaxwellBinlogEventListener(queue);
 
@@ -222,7 +223,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 					break;
 				case MySQLConstants.TABLE_MAP_EVENT:
-					tableCache.processEvent(this.schema, this.filter, (TableMapEvent) v4Event);
+					tableCache.processEvent(getSchema(), this.filter, (TableMapEvent) v4Event);
 					break;
 				case MySQLConstants.QUERY_EVENT:
 					QueryEvent qe = (QueryEvent) v4Event;
@@ -290,7 +291,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 					rowBuffer = getTransactionRows();
 					break;
 				case MySQLConstants.TABLE_MAP_EVENT:
-					tableCache.processEvent(this.schema, this.filter, (TableMapEvent) v4Event);
+					tableCache.processEvent(getSchema(), this.filter, (TableMapEvent) v4Event);
 					break;
 				case MySQLConstants.QUERY_EVENT:
 					QueryEvent qe = (QueryEvent) v4Event;
@@ -322,7 +323,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 		if ( changes == null )
 			return;
 
-		Schema updatedSchema = this.schema;
+		Schema updatedSchema = getSchema();
 
 		for ( SchemaChange change : changes ) {
 			if ( !change.isBlacklisted(this.filter) ) {
@@ -334,7 +335,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 			}
 		}
 
-		if ( updatedSchema != this.schema) {
+		if ( updatedSchema != getSchema() ) {
 			BinlogPosition p = eventBinlogPosition(event);
 			LOGGER.info("storing schema @" + p + " after applying \"" + sql.replace('\n', ' ') + "\"");
 
@@ -343,12 +344,12 @@ public class MaxwellReplicator extends RunLoopProcess {
 	}
 
 	private void saveSchema(Schema updatedSchema, BinlogPosition p) throws SQLException {
-		this.schema = updatedSchema;
 		tableCache.clear();
 
 		if ( !this.context.getReplayMode() ) {
 			try (Connection c = this.context.getMaxwellConnection()) {
-				new SchemaStore(c, this.context.getServerID(), this.schema, p, this.context.getConfig().databaseName).save();
+				this.schemaStore = new SchemaStore(this.context.getServerID(), this.context.getCaseSensitivity(), updatedSchema, p);
+				this.schemaStore.save(c);
 			}
 
 			this.context.setPositionSync(p);
@@ -356,11 +357,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 	}
 
 	public Schema getSchema() {
-		return schema;
-	}
-
-	public void setSchema(Schema schema) {
-		this.schema = schema;
+		return this.schemaStore.getSchema();
 	}
 
 	public void setFilter(MaxwellFilter filter) {

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -23,52 +23,37 @@ import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 public class SchemaStore {
 	private static int maxSchemas = 5;
-
-	private final Connection connection;
-	private final String schemaDatabaseName;
 	private Schema schema;
 	private BinlogPosition position;
 	private Long schema_id;
+	private String charset;
 
 	public Long getSchemaID() {
 		return schema_id;
 	}
 
 	static final Logger LOGGER = LoggerFactory.getLogger(SchemaStore.class);
-	private final PreparedStatement schemaInsert, databaseInsert, tableInsert;
-	private final String columnInsertSQL;
 
+	private final static String columnInsertSQL =
+		"INSERT INTO `columns` (schema_id, table_id, name, charset, coltype, is_signed, enum_values) VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+	private final CaseSensitivity sensitivity;
 	private final Long serverID;
 
-	public SchemaStore(Connection connection, Long serverID, String dbName) throws SQLException {
+
+	public SchemaStore(Long serverID, CaseSensitivity sensitivity) throws SQLException {
 		this.serverID = serverID;
-		this.connection = connection;
-		this.schemaDatabaseName = dbName;
-		this.schemaInsert = connection
-				.prepareStatement(
-						"INSERT INTO `schemas` SET binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?",
-						Statement.RETURN_GENERATED_KEYS);
-		this.databaseInsert = connection
-				.prepareStatement(
-						"INSERT INTO `databases` SET schema_id = ?, name = ?, charset=?",
-						Statement.RETURN_GENERATED_KEYS);
-		this.tableInsert = connection
-				.prepareStatement(
-						"INSERT INTO `tables` SET schema_id = ?, database_id = ?, name = ?, charset=?, pk=?",
-						Statement.RETURN_GENERATED_KEYS);
-		this.columnInsertSQL = "INSERT INTO `columns` (schema_id, table_id, name, charset, coltype, is_signed, enum_values) "
-				+ " VALUES (?, ?, ?, ?, ?, ?, ?)";
+		this.sensitivity = sensitivity;
 	}
 
-	public SchemaStore(Connection connection, Long serverID, Schema schema, BinlogPosition position, String dbName) throws SQLException {
-		this(connection, serverID, dbName);
+	public SchemaStore(Long serverID, CaseSensitivity sensitivity, Schema schema, BinlogPosition position) throws SQLException {
+		this(serverID, sensitivity);
 		this.schema = schema;
 		this.position = position;
 	}
 
-	public SchemaStore(Connection connection, Long serverID, Long schema_id, String dbName) throws SQLException {
-		this(connection, serverID, dbName);
-		this.schema_id = schema_id;
+	public SchemaStore(MaxwellContext context, Schema schema, BinlogPosition position) throws SQLException {
+		this(context.getServerID(), context.getCaseSensitivity(), schema, position);
 	}
 
 	public static int getMaxSchemas() {
@@ -94,24 +79,40 @@ public class SchemaStore {
 			return null;
 	}
 
-	public void save() throws SQLException {
+	public void save(Connection connection) throws SQLException {
 		if (this.schema == null)
 			throw new RuntimeException("Uninitialized schema!");
 
 		try {
 			connection.setAutoCommit(false);
-			this.schema_id = saveSchema();
+			this.schema_id = saveSchema(connection);
 			connection.commit();
 		} finally {
 			connection.setAutoCommit(true);
 		}
 		if ( this.schema_id != null ) {
-			deleteOldSchemas(schema_id);
+			deleteOldSchemas(connection, schema_id);
 		}
 	}
 
+	public Long saveSchema(Connection conn) throws SQLException {
+		PreparedStatement schemaInsert, databaseInsert, tableInsert;
 
-	public Long saveSchema() throws SQLException {
+		schemaInsert = conn.prepareStatement(
+				"INSERT INTO `schemas` SET binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?",
+				Statement.RETURN_GENERATED_KEYS
+		);
+
+		databaseInsert = conn.prepareStatement(
+				"INSERT INTO `databases` SET schema_id = ?, name = ?, charset=?",
+				Statement.RETURN_GENERATED_KEYS
+		);
+
+		tableInsert = conn.prepareStatement(
+				"INSERT INTO `tables` SET schema_id = ?, database_id = ?, name = ?, charset=?, pk=?",
+				Statement.RETURN_GENERATED_KEYS
+		);
+
 		Long schemaId = executeInsert(schemaInsert, position.getFile(),
 				position.getOffset(), serverID, schema.getCharset());
 
@@ -156,24 +157,24 @@ public class SchemaStore {
 				}
 
 				if ( columnData.size() > 1000 )
-					executeColumnInsert(columnData);
+					executeColumnInsert(conn, columnData);
 
 			}
 		}
 		if ( columnData.size() > 0 )
-			executeColumnInsert(columnData);
+			executeColumnInsert(conn, columnData);
 
 		return schemaId;
 	}
 
-	private void executeColumnInsert(ArrayList<Object> columnData) throws SQLException {
+	private void executeColumnInsert(Connection conn, ArrayList<Object> columnData) throws SQLException {
 		String insertColumnSQL = this.columnInsertSQL;
 
 		for (int i=1; i < columnData.size() / 7; i++) {
 			insertColumnSQL = insertColumnSQL + ", (?, ?, ?, ?, ?, ?, ?)";
 		}
 
-		PreparedStatement columnInsert = connection.prepareStatement(insertColumnSQL);
+		PreparedStatement columnInsert = conn.prepareStatement(insertColumnSQL);
 		int i = 1;
 
 		for (Object o : columnData)
@@ -220,27 +221,27 @@ public class SchemaStore {
 		executeSQLInputStream(connection, SchemaStore.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql"), schemaDatabaseName);
 	}
 
-	public static SchemaStore restore(Connection connection, MaxwellContext context) throws SQLException, InvalidSchemaError {
-		SchemaStore s = new SchemaStore(connection, context.getServerID(), context.getConfig().databaseName);
+	public static SchemaStore restore(Connection connection, MaxwellContext context) throws SQLException, IOException, InvalidSchemaError {
+		SchemaStore s = new SchemaStore(context.getServerID(), context.getCaseSensitivity());
 
-		s.restoreFrom(context.getInitialPosition(), context.getCaseSensitivity());
+		s.restoreFrom(connection, context.getInitialPosition());
 
 		return s;
 	}
 
-	private void restoreFrom(BinlogPosition targetPosition, CaseSensitivity sensitivity)
-			throws SQLException, InvalidSchemaError {
+	private void restoreFrom(Connection conn, BinlogPosition targetPosition) throws SQLException, InvalidSchemaError {
 		PreparedStatement p;
 		boolean shouldResave = false;
-		ResultSet schemaRS = findSchema(targetPosition, this.serverID);
 
-		if (schemaRS == null) {
+		Long schemaID = findSchema(conn, targetPosition, this.serverID);
+
+		if (schemaID == null) {
 			// old versions of Maxwell had a bug where they set every server_id to 1.
 			// try to upgrade.
 
-			schemaRS = findSchema(targetPosition, 1L);
+			schemaID = findSchema(conn, targetPosition, 1L);
 
-			if ( schemaRS == null )
+			if ( schemaID == null )
 				throw new InvalidSchemaError("Could not find schema for "
 						+ targetPosition.getFile() + ":"
 						+ targetPosition.getOffset());
@@ -249,37 +250,53 @@ public class SchemaStore {
 			shouldResave = true;
 		}
 
-		ArrayList<Database> databases = new ArrayList<>();
-		this.schema = new Schema(databases, schemaRS.getString("charset"), sensitivity);
-		this.position = new BinlogPosition(schemaRS.getInt("binlog_position"),
-				schemaRS.getString("binlog_file"));
-
-		LOGGER.info("Restoring schema id " + schemaRS.getInt("id") + " (last modified at " + this.position + ")");
-
-		this.schema_id = schemaRS.getLong("id");
-		p = connection.prepareStatement("SELECT * from `databases` where schema_id = ? ORDER by id");
-		p.setLong(1, this.schema_id);
-
-		ResultSet dbRS = p.executeQuery();
-
-		while (dbRS.next()) {
-			this.schema.addDatabase(restoreDatabase(dbRS.getInt("id"), dbRS.getString("name"), dbRS.getString("charset")));
-		}
+		restoreSchemaMetadata(conn, schemaID);
+		restoreFullSchema(conn, schemaID);
 
 		if ( this.schema.findDatabase("mysql") == null ) {
 			LOGGER.info("Could not find mysql db, adding it to schema");
-			SchemaCapturer sc = new SchemaCapturer(connection, sensitivity, "mysql");
+			SchemaCapturer sc = new SchemaCapturer(conn, sensitivity, "mysql");
 			Database db = sc.capture().findDatabase("mysql");
 			this.schema.addDatabase(db);
 			shouldResave = true;
 		}
 
 		if ( shouldResave )
-			this.schema_id = saveSchema();
+			this.schema_id = saveSchema(conn);
 	}
 
-	private Database restoreDatabase(int id, String name, String charset) throws SQLException {
-		Statement s = connection.createStatement();
+	private void restoreSchemaMetadata(Connection conn, Long schemaID) throws SQLException {
+		PreparedStatement p = conn.prepareStatement("select * from `schemas` where id = " + schemaID);
+		ResultSet schemaRS = p.executeQuery();
+
+		schemaRS.next();
+
+		this.position = new BinlogPosition(schemaRS.getInt("binlog_position"), schemaRS.getString("binlog_file"));
+
+		LOGGER.info("Restoring schema id " + schemaRS.getInt("id") + " (last modified at " + this.position + ")");
+
+		this.schema_id = schemaRS.getLong("id");
+		this.charset = schemaRS.getString("charset");
+	}
+
+
+	private void restoreFullSchema(Connection conn, Long schemaID) throws SQLException, InvalidSchemaError {
+		ArrayList<Database> databases = new ArrayList<>();
+		this.schema = new Schema(databases, charset, sensitivity);
+
+		PreparedStatement p = conn.prepareStatement("SELECT * from `databases` where schema_id = ? ORDER by id");
+		p.setLong(1, this.schema_id);
+
+		ResultSet dbRS = p.executeQuery();
+
+		while (dbRS.next()) {
+			this.schema.addDatabase(restoreDatabase(conn, dbRS.getInt("id"), dbRS.getString("name"), dbRS.getString("charset")));
+		}
+
+	}
+
+	private Database restoreDatabase(Connection conn, int id, String name, String charset) throws SQLException {
+		Statement s = conn.createStatement();
 		Database d = new Database(name, charset);
 
 		ResultSet tRS = s.executeQuery("SELECT * from `tables` where database_id = " + id + " ORDER by id");
@@ -291,12 +308,12 @@ public class SchemaStore {
 
 			int tID = tRS.getInt("id");
 
-			restoreTable(d, tName, tID, tCharset, tPKs);
+			restoreTable(conn, d, tName, tID, tCharset, tPKs);
 		}
 		return d;
 	}
 
-	private void restoreTable(Database d, String name, int id, String charset, String pks) throws SQLException {
+	private void restoreTable(Connection connection, Database d, String name, int id, String charset, String pks) throws SQLException {
 		Statement s = connection.createStatement();
 
 		Table t = d.buildTable(name, charset);
@@ -324,11 +341,11 @@ public class SchemaStore {
 
 	}
 
-	private ResultSet findSchema(BinlogPosition targetPosition, Long serverID)
+	private Long findSchema(Connection connection, BinlogPosition targetPosition, Long serverID)
 			throws SQLException {
 		LOGGER.debug("looking to restore schema at target position " + targetPosition);
 		PreparedStatement s = connection.prepareStatement(
-			"SELECT * from `schemas` "
+			"SELECT id from `schemas` "
 			+ "WHERE deleted = 0 "
 			+ "AND ((binlog_file < ?) OR (binlog_file = ? and binlog_position <= ?)) AND server_id = ? "
 			+ "ORDER BY id desc limit 1");
@@ -340,7 +357,7 @@ public class SchemaStore {
 
 		ResultSet rs = s.executeQuery();
 		if (rs.next()) {
-			return rs;
+			return rs.getLong("id");
 		} else
 			return null;
 	}
@@ -359,24 +376,21 @@ public class SchemaStore {
 		}
 	}
 
-	public void delete() throws SQLException {
-		ensureSchemaID();
+	public static void delete(Connection connection, long schema_id) throws SQLException {
 		connection.createStatement().execute("update `schemas` set deleted = 1 where id = " + schema_id);
 	}
 
-	public void destroy() throws SQLException {
+	public void destroy(Connection connection) throws SQLException {
 		ensureSchemaID();
 
 		String[] tables = { "databases", "tables", "columns" };
 		connection.createStatement().execute("delete from `schemas` where id = " + schema_id);
 		for ( String tName : tables ) {
-            connection.createStatement().execute(
-            		"delete from `" + tName + "` where schema_id = " + schema_id
-            );
+			connection.createStatement().execute("delete from `" + tName + "` where schema_id = " + schema_id);
 		}
 	}
 
-	public boolean schemaExists(long schema_id) throws SQLException {
+	public boolean schemaExists(Connection connection, long schema_id) throws SQLException {
 		if ( this.schema_id == null )
 			return false;
 		ResultSet rs = connection.createStatement().executeQuery("select id from `schemas` where id = " + schema_id);
@@ -387,13 +401,13 @@ public class SchemaStore {
 		return this.position;
 	}
 
-	private void deleteOldSchemas(Long currentSchemaId) throws SQLException {
+	private void deleteOldSchemas(Connection connection, Long currentSchemaId) throws SQLException {
 		if ( maxSchemas <= 0  )
 			return;
 
 		Long toDelete = currentSchemaId - maxSchemas; // start with the highest numbered ID to delete, work downwards until we run out
-		while ( toDelete > 0 && schemaExists(toDelete) ) {
-			new SchemaStore(connection, serverID, toDelete, this.schemaDatabaseName).delete();
+		while ( toDelete > 0 && schemaExists(connection, toDelete) ) {
+			delete(connection, toDelete);
 			toDelete--;
 		}
 	}
@@ -413,7 +427,7 @@ public class SchemaStore {
 		while ( rs.next() ) {
 			Long schemaID = rs.getLong("id");
 			LOGGER.info("maxwell detected schema " + schemaID + " from different server_id.  deleting...");
-			new SchemaStore(c, null, schemaID, schemaDatabaseName).delete();
+			delete(c, schemaID);
 		}
 
 		c.createStatement().execute("delete from `positions` where server_id != " + serverID);
@@ -439,8 +453,7 @@ public class SchemaStore {
 	}
 
 	private static void performAlter(Connection c, String sql) throws SQLException {
-		LOGGER.info("Maxwell is upgrading its own schema...");
-		LOGGER.info(sql);
+		LOGGER.info("Maxwell is upgrading its own schema: '" + sql + "'");
 		c.createStatement().execute(sql);
 	}
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -150,7 +150,7 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	public void testExcludeColumns() throws Exception {
 		List<RowMap> list;
 		MaxwellFilter filter = new MaxwellFilter();
-	
+
 		list = getRowsForSQL(filter, insertSQL, createDBs);
 		String json = list.get(1).toJSON();
 		assertTrue(Pattern.compile("\"id\":1").matcher(json).find());
@@ -382,13 +382,13 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		String ordered_data = "\"data\":\\{\"id\":1,\"account_id\":2,\"user_id\":3\\}";
 		assertTrue(Pattern.compile(ordered_data).matcher(rows.get(0).toJSON()).find());
 	}
-	
+
 	@Test
 	public void testJdbcConnectionOptions() throws Exception {
-		String[] opts = {"--jdbc_options= netTimeoutForStreamingResults=123& profileSQL=true  "};
+		String[] opts = {"--jdbc_options= netTimeoutForStreamingResults=123& profileSQL=true  ", "--host=no-soup-spoons"};
 		MaxwellConfig config = new MaxwellConfig(opts);
-		assertEquals(config.maxwellMysql.getConnectionURI(), 
-				"jdbc:mysql://localhost:3306?useCursorFetch=true&zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
+		assertEquals(config.maxwellMysql.getConnectionURI(),
+				"jdbc:mysql://no-soup-spoons:3306?useCursorFetch=true&zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
 	}
 
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -94,6 +94,8 @@ public class MaxwellTestSupport {
 
 
 		Schema initialSchema = capturer.capture();
+		SchemaStore initialSchemaStore = new SchemaStore(context, initialSchema, BinlogPosition.capture(mysql.getConnection()));
+		initialSchemaStore.save(context.getMaxwellConnection());
 
 		mysql.executeList(Arrays.asList(queries));
 
@@ -122,13 +124,11 @@ public class MaxwellTestSupport {
 			}
 		};
 
-		TestMaxwellReplicator p = new TestMaxwellReplicator(initialSchema, producer, bootstrapper, context, start, endPosition);
+		TestMaxwellReplicator p = new TestMaxwellReplicator(initialSchemaStore, producer, bootstrapper, context, start, endPosition);
 
 		p.setFilter(filter);
 
 		p.getEvents(producer);
-
-		Schema schema = p.schema;
 
 		bootstrapper.join();
 

--- a/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
@@ -38,9 +38,8 @@ public class SchemaScavengerTest extends MaxwellTestWithIsolatedServer {
 		this.scavenger = new SchemaScavenger(buildContext().getMaxwellConnectionPool(), context.getConfig().databaseName);
 		Connection conn = server.getConnection();
 		conn.setCatalog(context.getConfig().databaseName);
-		this.schemaStore = new SchemaStore(conn, MysqlIsolatedServer.SERVER_ID, this.schema, binlogPosition, context.getConfig().databaseName);
-
-		this.schemaStore.save();
+		this.schemaStore = new SchemaStore(context, this.schema, binlogPosition);
+		this.schemaStore.save(conn);
 	}
 
 	private Long getCount(String sql) throws SQLException {
@@ -61,7 +60,7 @@ public class SchemaScavengerTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testDelete() throws Exception {
 		Long initialCount = countSchemaRows();
-		this.schemaStore.delete();
+		SchemaStore.delete(server.getConnection(), this.schemaStore.getSchemaID());
 		scavenger.deleteSchemas(20000L);
 
 		assertThat(countSchemaRows(), is(0L));

--- a/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Connection;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
@@ -34,23 +35,23 @@ public class SchemaStoreTest extends MaxwellTestWithIsolatedServer {
 		this.binlogPosition = BinlogPosition.capture(server.getConnection());
 		this.context = buildContext(binlogPosition);
 		this.schema = new SchemaCapturer(server.getConnection(), context.getCaseSensitivity()).capture();
-		this.schemaStore = new SchemaStore(server.getConnection(this.buildContext().getConfig().databaseName), MysqlIsolatedServer.SERVER_ID, this.schema, binlogPosition, context.getConfig().databaseName);
+		this.schemaStore = new SchemaStore(this.context, this.schema, binlogPosition);
 	}
 
 	@Test
 	public void testSave() throws SQLException, IOException, InvalidSchemaError {
-		this.schemaStore.save();
+		this.schemaStore.save(context.getMaxwellConnection());
 
-		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(this.buildContext().getConfig().databaseName), context);
+		SchemaStore restoredSchema = SchemaStore.restore(context.getMaxwellConnection(), context);
 		List<String> diff = this.schema.diff(restoredSchema.getSchema(), "captured schema", "restored schema");
 		assertThat(StringUtils.join(diff, "\n"), diff.size(), is(0));
 	}
 
 	@Test
 	public void testRestorePK() throws Exception {
-		this.schemaStore.save();
+		this.schemaStore.save(context.getMaxwellConnection());
 
-		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(this.buildContext().getConfig().databaseName), context);
+		SchemaStore restoredSchema = SchemaStore.restore(context.getMaxwellConnection(), context);
 		Table t = restoredSchema.getSchema().findDatabase("shard_1").findTable("pks");
 
 		assertThat(t.getPKList(), is(not(nullValue())));
@@ -63,14 +64,14 @@ public class SchemaStoreTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testUpgradeToFixServerIDBug() throws Exception {
 		// create a couple of schemas
-		this.schemaStore.save();
+		this.schemaStore.save(context.getMaxwellConnection());
 		Long badSchemaID = this.schemaStore.getSchemaID();
 
 		// throw into old state
 		String updateSQL[] = {"UPDATE `" + buildContext().getConfig().databaseName+ "`.`schemas` set server_id = 1"};
 		server.executeList(updateSQL);
 
-		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(this.buildContext().getConfig().databaseName), context);
+		SchemaStore restoredSchema = SchemaStore.restore(context.getMaxwellConnection(), context);
 
 		List<String> diffs = restoredSchema.getSchema().diff(this.schemaStore.getSchema(), "restored", "captured");
 		assert diffs.isEmpty() : "Expected empty schema diff, got" + diffs;
@@ -80,18 +81,22 @@ public class SchemaStoreTest extends MaxwellTestWithIsolatedServer {
 	public void testMasterChange() throws Exception {
 		this.schema = new SchemaCapturer(server.getConnection(), context.getCaseSensitivity()).capture();
 		this.binlogPosition = BinlogPosition.capture(server.getConnection());
-		String dbName = this.buildContext().getConfig().databaseName;
-		this.schemaStore = new SchemaStore(server.getConnection(dbName), 5551234L, this.schema, binlogPosition, dbName);
 
-		this.schemaStore.save();
+		MaxwellContext context = this.buildContext();
+		String dbName = context.getConfig().databaseName;
 
-		SchemaStore.handleMasterChange(server.getConnection(dbName), 123456L, dbName);
+		this.schemaStore = new SchemaStore(5551234L, context.getCaseSensitivity(), this.schema, binlogPosition);
 
-		ResultSet rs = server.getConnection(dbName).createStatement().executeQuery("SELECT * from `schemas`");
+		Connection conn = context.getMaxwellConnection();
+		this.schemaStore.save(conn);
+
+		SchemaStore.handleMasterChange(conn, 123456L, dbName);
+
+		ResultSet rs = conn.createStatement().executeQuery("SELECT * from `schemas`");
 		assertThat(rs.next(), is(true));
 		assertThat(rs.getBoolean("deleted"), is(true));
 
-		rs = server.getConnection(dbName).createStatement().executeQuery("SELECT * from `positions`");
+		rs = conn.createStatement().executeQuery("SELECT * from `positions`");
 		assertThat(rs.next(), is(false));
 	}
 
@@ -100,7 +105,7 @@ public class SchemaStoreTest extends MaxwellTestWithIsolatedServer {
 		Database db = this.schema.findDatabase("mysql");
 		String maxwellDBName = this.buildContext().getConfig().databaseName;
 		this.schema.getDatabases().remove(db);
-		this.schemaStore.save();
+		this.schemaStore.save(context.getMaxwellConnection());
 		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(maxwellDBName), context);
 		assertThat(restoredSchema.getSchema().findDatabase("mysql"), is(not(nullValue())));
 	}

--- a/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
+++ b/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
@@ -5,6 +5,7 @@ import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.bootstrap.AsynchronousBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaStore;
 
 import java.util.concurrent.TimeUnit;
 
@@ -15,13 +16,13 @@ public class TestMaxwellReplicator extends MaxwellReplicator {
 	private final BinlogPosition stopAt;
 	private boolean shouldStop;
 
-	public TestMaxwellReplicator(Schema currentSchema,
+	public TestMaxwellReplicator(SchemaStore schemaStore,
 								 AbstractProducer producer,
 								 AbstractBootstrapper bootstrapper,
 								 MaxwellContext ctx,
 								 BinlogPosition start,
 								 BinlogPosition stop) throws Exception {
-		super(currentSchema, producer, bootstrapper, ctx, start);
+		super(schemaStore, producer, bootstrapper, ctx, start);
 		LOGGER.debug("TestMaxwellReplicator initialized from " + start + " to " + stop);
 		this.stopAt = stop;
 	}


### PR DESCRIPTION
it was dangerous and silly to do that -- the connection is pulled from the connection pool, and so shouldn't be kept for longer than it takes to do work.


@zendesk/rules 