### PR TITLE
stop copying schemas

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -334,7 +334,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 			if ( !change.isBlacklisted(this.filter) ) {
 				ResolvedSchemaChange resolved = change.resolve(updatedSchema);
 				if ( resolved != null ) {
-					updatedSchema = resolved.apply(updatedSchema);
+					resolved.apply(updatedSchema);
 
 					resolvedSchemaChanges.add(resolved);
 				}
@@ -343,7 +343,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 			}
 		}
 
-		if ( updatedSchema != getSchema() ) {
+		if ( resolvedSchemaChanges.size() > 0 ) {
 			BinlogPosition p = eventBinlogPosition(event);
 			LOGGER.info("storing schema @" + p + " after applying \"" + sql.replace('\n', ' ') + "\"");
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -328,7 +328,7 @@ public class SchemaStore {
 		for ( Long id : schemaChain ) {
 			List<ResolvedSchemaChange> deltas = parseDeltas((String) schemas.get(id).get("deltas"));
 			for ( ResolvedSchemaChange delta : deltas ) {
-				schema = delta.apply(schema);
+				delta.apply(schema);
 			}
 			count++;
 		}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseAlter.java
@@ -14,18 +14,13 @@ public class ResolvedDatabaseAlter extends ResolvedSchemaChange {
 	}
 
 	@Override
-	public Schema apply(Schema originalSchema) throws InvalidSchemaError {
+	public void apply(Schema schema) throws InvalidSchemaError {
 		if ( charset == null )
-			return originalSchema;
+			return;
 
-		Schema schema = originalSchema.copy();
 		Database d = schema.findDatabaseOrThrow(database);
 
-		if ( d.getCharset().equals(charset) )
-			return originalSchema;
-
-		d.setCharset(charset);
-		return schema;
+		if ( !d.getCharset().equals(charset) )
+			d.setCharset(charset);
 	}
-
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseCreate.java
@@ -13,13 +13,10 @@ public class ResolvedDatabaseCreate extends ResolvedSchemaChange {
 	}
 
 	@Override
-	public Schema apply(Schema originalSchema) throws InvalidSchemaError {
-		Schema newSchema = originalSchema.copy();
-
-		if ( newSchema.hasDatabase(database) )
+	public void apply(Schema schema) throws InvalidSchemaError {
+		if ( schema.hasDatabase(database) )
 			throw new InvalidSchemaError("Unexpectedly asked to create existing database " + database);
 
-		newSchema.addDatabase(new Database(database, charset));
-		return newSchema;
+		schema.addDatabase(new Database(database, charset));
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseDrop.java
@@ -11,11 +11,8 @@ public class ResolvedDatabaseDrop extends ResolvedSchemaChange {
 	}
 
 	@Override
-	public Schema apply(Schema originalSchema) throws InvalidSchemaError {
-		Schema newSchema = originalSchema.copy();
-
-		Database d = newSchema.findDatabaseOrThrow(database);
-		newSchema.getDatabases().remove(d);
-		return newSchema;
+	public void apply(Schema schema) throws InvalidSchemaError {
+		Database d = schema.findDatabaseOrThrow(database);
+		schema.getDatabases().remove(d);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedSchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedSchemaChange.java
@@ -14,5 +14,5 @@ import com.zendesk.maxwell.schema.Schema;
 })
 
 public abstract class ResolvedSchemaChange {
-	public abstract Schema apply(Schema originalSchema) throws InvalidSchemaError;
+	public abstract void apply(Schema originalSchema) throws InvalidSchemaError;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedTableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedTableAlter.java
@@ -29,21 +29,18 @@ public class ResolvedTableAlter extends ResolvedSchemaChange {
 	}
 
 	@Override
-	public Schema apply(Schema originalSchema) throws InvalidSchemaError {
-		Schema newSchema = originalSchema.copy();
-
-		Database oldDatabase = newSchema.findDatabaseOrThrow(this.database);
+	public void apply(Schema schema) throws InvalidSchemaError {
+		Database oldDatabase = schema.findDatabaseOrThrow(this.database);
 		Table table = oldDatabase.findTableOrThrow(this.table);
 
 		Database newDatabase;
 		if ( this.database.equals(newTable.database) )
 			newDatabase = oldDatabase;
 		else
-			newDatabase = newSchema.findDatabaseOrThrow(newTable.database);
+			newDatabase = schema.findDatabaseOrThrow(newTable.database);
 
 		oldDatabase.removeTable(this.table);
 		newDatabase.addTable(newTable);
-		return newSchema;
 	}
 }
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedTableCreate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedTableCreate.java
@@ -19,15 +19,12 @@ public class ResolvedTableCreate extends ResolvedSchemaChange {
 	}
 
 	@Override
-	public Schema apply(Schema originalSchema) throws InvalidSchemaError {
-		Schema newSchema = originalSchema.copy();
-
-		Database d = newSchema.findDatabaseOrThrow(this.database);
+	public void apply(Schema schema) throws InvalidSchemaError {
+		Database d = schema.findDatabaseOrThrow(this.database);
 
 		if ( d.hasTable(this.table) )
 			throw new InvalidSchemaError("Unexpectedly asked to create existing table " + this.table);
 
 		d.addTable(this.def);
-		return newSchema;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedTableDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedTableDrop.java
@@ -13,13 +13,10 @@ public class ResolvedTableDrop extends ResolvedSchemaChange {
 	}
 
 	@Override
-	public Schema apply(Schema originalSchema) throws InvalidSchemaError {
-		Schema newSchema = originalSchema.copy();
-
-		Database d = newSchema.findDatabaseOrThrow(this.database);
+	public void apply(Schema schema) throws InvalidSchemaError {
+		Database d = schema.findDatabaseOrThrow(this.database);
 		d.findTableOrThrow(this.table);
 
 		d.removeTable(this.table);
-		return newSchema;
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -146,6 +146,7 @@ public class MaxwellTestSupport {
 		server.executeList(Arrays.asList(alters));
 
 		ObjectMapper m = new ObjectMapper();
+
 		for ( String alterSQL : alters) {
 			List<SchemaChange> changes = SchemaChange.parse("shard_1", alterSQL);
 			if ( changes != null ) {
@@ -159,7 +160,7 @@ public class MaxwellTestSupport {
 					String json = m.writeValueAsString(resolvedChange);
 					ResolvedSchemaChange fromJson = m.readValue(json, ResolvedSchemaChange.class);
 
-					topSchema = fromJson.apply(topSchema);
+					fromJson.apply(topSchema);
 				}
 			}
 		}

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLSerializationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLSerializationTest.java
@@ -43,7 +43,7 @@ public class DDLSerializationTest extends MaxwellTestWithIsolatedServer {
 				ResolvedSchemaChange resolved = change.resolve(schema);
 				if ( resolved != null ) {
 					schemaChanges.add(resolved);
-					schema = resolved.apply(schema);
+					resolved.apply(schema);
 				}
 			}
 		}


### PR DESCRIPTION
this is worth about 100x speed-up when processing large amounts of deltas, and should be safe; the copying was important in the world before ResovledSchemaChange, but not now.

@zendesk/rules 