### PR TITLE
Aurora capture performance fixes

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -128,8 +128,8 @@ public class SchemaCapturer {
 	}
 
 	private static final String pkSQL =
-			"SELECT column_name from information_schema.key_column_usage  "
-	      + "WHERE constraint_name = 'PRIMARY' and table_schema = ? and table_name = ? order by ordinal_position";
+			"SELECT column_name, ordinal_position from information_schema.key_column_usage  "
+	      + "WHERE constraint_name = 'PRIMARY' and table_schema = ? and table_name = ?";
 
 	private void captureTablePK(Table t) throws SQLException, InvalidSchemaError {
 		PreparedStatement p = connection.prepareStatement(pkSQL);
@@ -140,7 +140,7 @@ public class SchemaCapturer {
 
 		ArrayList<String> l = new ArrayList<>();
 		while ( rs.next() ) {
-			l.add(rs.getString("column_name"));
+			l.add(rs.getInt("ordinal_position") - 1, rs.getString("column_name"));
 		}
 		t.setPKList(l);
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -218,6 +218,7 @@ public class SchemaStore {
 			columnInsert.setObject(i++,  o);
 
 		columnInsert.execute();
+		columnInsert.close();
 		columnData.clear();
 	}
 


### PR DESCRIPTION
stop asking mysql to order primary keys by ordinal_position.  For some odd reason this is a performance nightmare on AWS Aurora, leading to schema capture times of like 15 minutes (vs 10 seconds after
the fix).

@zendesk/rules 