### PR TITLE
Fix unsigned int schema capture bug

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -110,7 +110,7 @@ public class SchemaCapturer {
 			String colType    = r.getString("DATA_TYPE");
 			String colEnc     = r.getString("CHARACTER_SET_NAME");
 			int colPos        = r.getInt("ORDINAL_POSITION") - 1;
-			boolean colSigned = !r.getString("COLUMN_TYPE").matches(" unsigned$");
+			boolean colSigned = !r.getString("COLUMN_TYPE").matches(".* unsigned$");
 
 			if ( r.getString("COLUMN_KEY").equals("PRI") )
 				t.pkIndex = i;

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -595,6 +595,9 @@ public class SchemaStore {
 
 		if ( !getTableColumns("schemas", c).containsKey("deltas"))
 			performAlter(c, "alter table `schemas` add column deltas mediumtext charset 'utf8' NULL default NULL after base_schema_id");
-	}
 
+		if ( !getTableColumns("schemas", c).containsKey("version")) {
+			performAlter(c, "alter table `schemas` add column `version` smallint unsigned not null default 0 after `charset`");
+		}
+	}
 }

--- a/src/main/resources/sql/maxwell_schema.sql
+++ b/src/main/resources/sql/maxwell_schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS `schemas` (
   deltas mediumtext charset 'utf8' NULL default NULL,
   server_id int unsigned,
   charset varchar(255),
+  version smallint unsigned not null default 0,
   deleted tinyint(1) not null default 0
 );
 

--- a/src/test/java/com/zendesk/maxwell/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaCaptureTest.java
@@ -79,6 +79,8 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 
 		assertThat(columns[1], allOf(notNullValue(), instanceOf(IntColumnDef.class)));
 		assertThat(columns[1].getName(), is("account_id"));
+		assertThat(columns[1], instanceOf(IntColumnDef.class));
+		assertThat(((IntColumnDef) columns[1]).isSigned(), is(false));
 	}
 
 	@Test

--- a/src/test/resources/sql/schema/sharded.sql
+++ b/src/test/resources/sql/schema/sharded.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `sharded` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `account_id` int(11) NOT NULL,
+  `account_id` int(11) UNSIGNED NOT NULL,
   `nice_id` int(11) NOT NULL,
   `status_id` tinyint NOT NULL default 2,
   `date_field` datetime,


### PR DESCRIPTION
a bug in the regex prevented us from properly capturing whether a column was unsigned or not.  buh.

@zendesk/rules 