### PR TITLE
refactor: move maxwell database schema management out of SchemaStore

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -13,6 +13,7 @@ import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaCapturer;
 import com.zendesk.maxwell.schema.SchemaStore;
+import com.zendesk.maxwell.schema.SchemaStoreSchema;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 public class Maxwell {
@@ -48,11 +49,11 @@ public class Maxwell {
 			MaxwellMysqlStatus.ensureReplicationMysqlState(connection);
 			MaxwellMysqlStatus.ensureMaxwellMysqlState(schemaConnection);
 
-			SchemaStore.ensureMaxwellSchema(schemaConnection, this.config.databaseName);
+			SchemaStoreSchema.ensureMaxwellSchema(schemaConnection, this.config.databaseName);
 			schemaConnection.setCatalog(this.config.databaseName);
-			SchemaStore.upgradeSchemaStoreSchema(schemaConnection, this.config.databaseName);
+			SchemaStoreSchema.upgradeSchemaStoreSchema(schemaConnection, this.config.databaseName);
 
-			SchemaStore.handleMasterChange(schemaConnection, context.getServerID(), this.config.databaseName);
+			SchemaStoreSchema.handleMasterChange(schemaConnection, context.getServerID(), this.config.databaseName);
 
 			if ( this.context.getInitialPosition() != null ) {
 				String producerClass = this.context.getProducer().getClass().getSimpleName();

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -356,12 +356,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 		if ( !this.context.getReplayMode() ) {
 			try (Connection c = this.context.getMaxwellConnection()) {
-				this.schemaStore = new SchemaStore(this.context.getServerID(),
-				                                   this.context.getCaseSensitivity(),
-				                                   updatedSchema,
-				                                   p,
-				                                   this.schemaStore.getSchemaID(),
-				                                   changes);
+				this.schemaStore = this.schemaStore.createDerivedSchema(updatedSchema, p, changes);
 				this.schemaStore.save(c);
 			}
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -21,10 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class SchemaStore {
+	static int SchemaStoreVersion = 1;
+
 	private Schema schema;
 	private BinlogPosition position;
 	private Long schema_id;
-	private String charset;
+	private int schemaVersion;
 
 	private Long base_schema_id;
 	private List<ResolvedSchemaChange> deltas;
@@ -40,6 +42,7 @@ public class SchemaStore {
 	private final CaseSensitivity sensitivity;
 	private final Long serverID;
 
+	private boolean shouldSnapshotNextSchema = false;
 
 	public SchemaStore(Long serverID, CaseSensitivity sensitivity) throws SQLException {
 		this.serverID = serverID;
@@ -65,6 +68,13 @@ public class SchemaStore {
 		this.deltas = deltas;
 
 		this.position = position;
+	}
+
+	public SchemaStore createDerivedSchema(Schema newSchema, BinlogPosition position, List<ResolvedSchemaChange> deltas) throws SQLException {
+		if ( this.shouldSnapshotNextSchema )
+			return new SchemaStore(this.serverID, this.sensitivity, newSchema, position);
+		else
+			return new SchemaStore(this.serverID, this.sensitivity, newSchema, position, this.schema_id, deltas);
 	}
 
 	public Long getSchemaID() {
@@ -101,7 +111,7 @@ public class SchemaStore {
 
 	public Long saveDerivedSchema(Connection conn) throws SQLException {
 		PreparedStatement insert = conn.prepareStatement(
-				"INSERT into `schemas` SET base_schema_id = ?, deltas = ?, binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?",
+				"INSERT into `schemas` SET base_schema_id = ?, deltas = ?, binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?, version = ?",
 				Statement.RETURN_GENERATED_KEYS);
 
 		String deltaString;
@@ -118,7 +128,8 @@ public class SchemaStore {
 		                     position.getFile(),
 		                     position.getOffset(),
 		                     serverID,
-		                     schema.getCharset());
+		                     schema.getCharset(),
+		                     SchemaStoreVersion);
 
 	}
 
@@ -129,7 +140,7 @@ public class SchemaStore {
 		PreparedStatement schemaInsert, databaseInsert, tableInsert;
 
 		schemaInsert = conn.prepareStatement(
-				"INSERT INTO `schemas` SET binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?",
+				"INSERT INTO `schemas` SET binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?, version = ?",
 				Statement.RETURN_GENERATED_KEYS
 		);
 
@@ -144,7 +155,7 @@ public class SchemaStore {
 		);
 
 		Long schemaId = executeInsert(schemaInsert, position.getFile(),
-				position.getOffset(), serverID, schema.getCharset());
+				position.getOffset(), serverID, schema.getCharset(), SchemaStoreVersion);
 
 		ArrayList<Object> columnData = new ArrayList<Object>();
 
@@ -295,37 +306,15 @@ public class SchemaStore {
 	}
 
 	private void restoreFrom(Connection conn, BinlogPosition targetPosition) throws SQLException, IOException, InvalidSchemaError {
-		boolean shouldResave = false;
-
 		Long schemaID = findSchema(conn, targetPosition, this.serverID);
-
-		if (schemaID == null) {
-			// old versions of Maxwell had a bug where they set every server_id to 1.
-			// try to upgrade.
-
-			schemaID = findSchema(conn, targetPosition, 1L);
-
-			if ( schemaID == null )
-				throw new InvalidSchemaError("Could not find schema for "
-						+ targetPosition.getFile() + ":"
-						+ targetPosition.getOffset());
-
-			LOGGER.info("found schema with server_id == 1, re-saving...");
-			shouldResave = true;
+		if ( schemaID == null ) {
+			throw new InvalidSchemaError("Could not find schema for "
+					+ targetPosition.getFile() + ":" + targetPosition.getOffset());
 		}
 
 		restoreFromSchemaID(conn, schemaID);
 
-		if ( this.schema != null && this.schema.findDatabase("mysql") == null ) {
-			LOGGER.info("Could not find mysql db, adding it to schema");
-			SchemaCapturer sc = new SchemaCapturer(conn, sensitivity, "mysql");
-			Database db = sc.capture().findDatabase("mysql");
-			this.schema.addDatabase(db);
-			shouldResave = true;
-		}
-
-		if ( shouldResave )
-			this.schema_id = saveSchema(conn);
+		handleVersionUpgrades(conn, schemaID, this.schemaVersion);
 	}
 
 	private void restoreFromSchemaID(Connection conn, Long schemaID) throws SQLException, IOException, InvalidSchemaError {
@@ -354,13 +343,11 @@ public class SchemaStore {
 			this.base_schema_id = null;
 
 		this.deltas = parseDeltas(schemaRS.getString("deltas"));
-		this.charset = schemaRS.getString("charset");
+		this.schemaVersion = schemaRS.getInt("version");
+		this.schema = new Schema(new ArrayList<Database>(), schemaRS.getString("charset"), this.sensitivity);
 	}
 
 	private void restoreFullSchema(Connection conn, Long schemaID) throws SQLException, IOException, InvalidSchemaError {
-		ArrayList<Database> databases = new ArrayList<>();
-		this.schema = new Schema(databases, charset, sensitivity);
-
 		PreparedStatement p = conn.prepareStatement("SELECT * from `databases` where schema_id = ? ORDER by id");
 		p.setLong(1, this.schema_id);
 
@@ -476,5 +463,64 @@ public class SchemaStore {
 
 	public BinlogPosition getBinlogPosition() {
 		return this.position;
+	}
+
+	private void fixUnsignedColumns(Connection conn) throws SQLException, InvalidSchemaError {
+		int unsignedDiffs = 0;
+
+		Schema recaptured = new SchemaCapturer(conn, sensitivity).capture();
+
+		for ( Database dA : schema.getDatabases() ) {
+			Database dB = recaptured.findDatabaseOrThrow(dA.getName());
+			for ( Table tA : dA.getTableList() ) {
+				Table tB = dB.findTableOrThrow(tA.getName());
+				for ( ColumnDef cA : tA.getColumnList() ) {
+					ColumnDef cB = tB.findColumnOrThrow(cA.getName());
+
+					if ( cA instanceof IntColumnDef ) {
+						if ( !(cB instanceof IntColumnDef) )
+							throw new InvalidSchemaError("Expected " + cB.getName() + " to be an IntColumnDef");
+
+						if ( ((IntColumnDef)cA).isSigned() && !((IntColumnDef)cB).isSigned() ) {
+							((IntColumnDef)cA).setSigned(false);
+							unsignedDiffs++;
+						}
+					} else if ( cA instanceof BigIntColumnDef ) {
+						if ( !(cB instanceof BigIntColumnDef) )
+							throw new InvalidSchemaError("Expected " + cB.getName() + " to be an BigIntColumnDef");
+
+						if ( ((BigIntColumnDef)cA).isSigned() && !((BigIntColumnDef)cB).isSigned() )
+							((BigIntColumnDef)cA).setSigned(false);
+							unsignedDiffs++;
+
+					}
+				}
+			}
+		}
+
+		if ( unsignedDiffs > 0 ) {
+			/* A little explanation here: we've detected differences in signed-ness between the restored
+			 * and the recaptured schema.  99.9% of the time this will be the result of our capture bug.
+			 *
+			 * We can't however simply re-save the re-captured schema, as we might be behind some DDL updates
+			 * that we'd otherwise lose.  So we leave a marker so that the next time we save the schema, we'll
+			 * purposely break the delta chain and fix the unsigned columns in the database.
+			 * */
+			this.shouldSnapshotNextSchema = true;
+		}
+	}
+
+	private void handleVersionUpgrades(Connection conn, Long schemaID, int version) throws SQLException, InvalidSchemaError {
+		if ( version < 1 ) {
+			if ( this.schema != null && this.schema.findDatabase("mysql") == null ) {
+				LOGGER.info("Could not find mysql db, adding it to schema");
+				SchemaCapturer sc = new SchemaCapturer(conn, sensitivity, "mysql");
+				Database db = sc.capture().findDatabase("mysql");
+				this.schema.addDatabase(db);
+				this.shouldSnapshotNextSchema = true;
+			}
+
+			fixUnsignedColumns(conn);
+		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -1,16 +1,9 @@
 package com.zendesk.maxwell.schema;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.*;
+
+import java.io.IOException;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.zendesk.maxwell.CaseSensitivity;
@@ -219,43 +212,6 @@ public class SchemaStore {
 
 		columnInsert.execute();
 		columnData.clear();
-	}
-
-	public static void ensureMaxwellSchema(Connection connection, String schemaDatabaseName) throws SQLException, IOException, InvalidSchemaError {
-		if ( !SchemaStore.storeDatabaseExists(connection, schemaDatabaseName) ) {
-			SchemaStore.createStoreDatabase(connection, schemaDatabaseName);
-		}
-	}
-
-	private static boolean storeDatabaseExists(Connection connection, String schemaDatabaseName) throws SQLException {
-		Statement s = connection.createStatement();
-		ResultSet rs = s.executeQuery("show databases like '" + schemaDatabaseName + "'");
-
-		return rs.next();
-	}
-
-	private static void executeSQLInputStream(Connection connection, InputStream schemaSQL, String schemaDatabaseName) throws SQLException, IOException {
-		BufferedReader r = new BufferedReader(new InputStreamReader(schemaSQL));
-		String sql = "", line;
-
-		LOGGER.info("Creating maxwell database");
-		connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS `" + schemaDatabaseName + "`");
-		if (!connection.getCatalog().equals(schemaDatabaseName))
-			connection.setCatalog(schemaDatabaseName);
-		while ((line = r.readLine()) != null) {
-			sql += line + "\n";
-		}
-		for (String statement : StringUtils.splitByWholeSeparator(sql, "\n\n")) {
-			if (statement.length() == 0)
-				continue;
-
-			connection.createStatement().execute(statement);
-		}
-	}
-
-	private static void createStoreDatabase(Connection connection, String schemaDatabaseName) throws SQLException, IOException {
-		executeSQLInputStream(connection, SchemaStore.class.getResourceAsStream("/sql/maxwell_schema.sql"), schemaDatabaseName);
-		executeSQLInputStream(connection, SchemaStore.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql"), schemaDatabaseName);
 	}
 
 	public static SchemaStore restore(Connection connection, MaxwellContext context) throws SQLException, IOException, InvalidSchemaError {
@@ -520,84 +476,5 @@ public class SchemaStore {
 
 	public BinlogPosition getBinlogPosition() {
 		return this.position;
-	}
-
-	/*
-		for the time being, when we detect other schemas we will simply wipe them down.
-		in the future, this is our moment to pick up where the master left off.
-	*/
-	public static void handleMasterChange(Connection c, Long serverID, String schemaDatabaseName) throws SQLException {
-		PreparedStatement s = c.prepareStatement(
-				"SELECT id from `schemas` WHERE server_id != ? and deleted = 0"
-		);
-
-		s.setLong(1, serverID);
-		ResultSet rs = s.executeQuery();
-
-		while ( rs.next() ) {
-			Long schemaID = rs.getLong("id");
-			LOGGER.info("maxwell detected schema " + schemaID + " from different server_id.  deleting...");
-			delete(c, schemaID);
-		}
-
-		c.createStatement().execute("delete from `positions` where server_id != " + serverID);
-	}
-
-	private static Map<String, String> getTableColumns(String table, Connection c) throws SQLException {
-		HashMap<String, String> map = new HashMap<>();
-		ResultSet rs = c.createStatement().executeQuery("show columns from `" + table + "`");
-		while (rs.next()) {
-			map.put(rs.getString("Field"), rs.getString("Type"));
-		}
-		return map;
-	}
-
-	private static List<String> getMaxwellTables(Connection c) throws SQLException {
-		ArrayList<String> l = new ArrayList<>();
-
-		ResultSet rs = c.createStatement().executeQuery("show tables");
-		while (rs.next()) {
-			l.add(rs.getString(1));
-		}
-		return l;
-	}
-
-	private static void performAlter(Connection c, String sql) throws SQLException {
-		LOGGER.info("Maxwell is upgrading its own schema: '" + sql + "'");
-		c.createStatement().execute(sql);
-	}
-
-	public static void upgradeSchemaStoreSchema(Connection c, String schemaDatabaseName) throws SQLException, IOException {
-		if ( !getTableColumns("schemas", c).containsKey("deleted") ) {
-			performAlter(c, "alter table `schemas` add column deleted tinyint(1) not null default 0");
-		}
-
-		if ( !getMaxwellTables(c).contains("bootstrap") )  {
-			LOGGER.info("adding `" + schemaDatabaseName + "`.`bootstrap` to the schema.");
-			InputStream is = SchemaStore.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql");
-			executeSQLInputStream(c, is, schemaDatabaseName);
-		}
-
-		if ( !getTableColumns("bootstrap", c).containsKey("total_rows") ) {
-			performAlter(c, "alter table `bootstrap` add column total_rows bigint unsigned not null default 0 after inserted_rows");
-			performAlter(c, "alter table `bootstrap` modify column inserted_rows bigint unsigned not null default 0");
-		}
-
-		if ( !getTableColumns("schemas", c).containsKey("charset")) {
-			String[] charsetTables = { "schemas", "databases", "tables", "columns" };
-			for ( String table : charsetTables ) {
-				performAlter(c, "alter table `" + table + "` change `encoding` `charset` varchar(255)");
-			}
-		}
-
-		if ( !getTableColumns("schemas", c).containsKey("base_schema_id"))
-			performAlter(c, "alter table `schemas` add column base_schema_id int unsigned NULL default NULL after binlog_position");
-
-		if ( !getTableColumns("schemas", c).containsKey("deltas"))
-			performAlter(c, "alter table `schemas` add column deltas mediumtext charset 'utf8' NULL default NULL after base_schema_id");
-
-		if ( !getTableColumns("schemas", c).containsKey("version")) {
-			performAlter(c, "alter table `schemas` add column `version` smallint unsigned not null default 0 after `charset`");
-		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -1,0 +1,139 @@
+package com.zendesk.maxwell.schema;
+
+/* represents the schema of the `maxwell` databases, and contains code around upgrading
+ * and managing that schema */
+
+import java.sql.*;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.io.IOException;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+
+public class SchemaStoreSchema {
+	static final Logger LOGGER = LoggerFactory.getLogger(SchemaStoreSchema.class);
+
+	public static void ensureMaxwellSchema(Connection connection, String schemaDatabaseName) throws SQLException, IOException, InvalidSchemaError {
+		if ( !storeDatabaseExists(connection, schemaDatabaseName) ) {
+			createStoreDatabase(connection, schemaDatabaseName);
+		}
+	}
+
+	private static boolean storeDatabaseExists(Connection connection, String schemaDatabaseName) throws SQLException {
+		Statement s = connection.createStatement();
+		ResultSet rs = s.executeQuery("show databases like '" + schemaDatabaseName + "'");
+
+		return rs.next();
+	}
+
+	private static void executeSQLInputStream(Connection connection, InputStream schemaSQL, String schemaDatabaseName) throws SQLException, IOException {
+		BufferedReader r = new BufferedReader(new InputStreamReader(schemaSQL));
+		String sql = "", line;
+
+		LOGGER.info("Creating maxwell database");
+		connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS `" + schemaDatabaseName + "`");
+		if (!connection.getCatalog().equals(schemaDatabaseName))
+			connection.setCatalog(schemaDatabaseName);
+		while ((line = r.readLine()) != null) {
+			sql += line + "\n";
+		}
+		for (String statement : StringUtils.splitByWholeSeparator(sql, "\n\n")) {
+			if (statement.length() == 0)
+				continue;
+
+			connection.createStatement().execute(statement);
+		}
+	}
+
+	private static void createStoreDatabase(Connection connection, String schemaDatabaseName) throws SQLException, IOException {
+		executeSQLInputStream(connection, SchemaStoreSchema.class.getResourceAsStream("/sql/maxwell_schema.sql"), schemaDatabaseName);
+		executeSQLInputStream(connection, SchemaStoreSchema.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql"), schemaDatabaseName);
+	}
+
+	/*
+		for the time being, when we detect other schemas we will simply wipe them down.
+		in the future, this is our moment to pick up where the master left off.
+	*/
+	public static void handleMasterChange(Connection c, Long serverID, String schemaDatabaseName) throws SQLException {
+		PreparedStatement s = c.prepareStatement(
+				"SELECT id from `schemas` WHERE server_id != ? and deleted = 0"
+		);
+
+		s.setLong(1, serverID);
+		ResultSet rs = s.executeQuery();
+
+		while ( rs.next() ) {
+			Long schemaID = rs.getLong("id");
+			LOGGER.info("maxwell detected schema " + schemaID + " from different server_id.  deleting...");
+			SchemaStore.delete(c, schemaID);
+		}
+
+		c.createStatement().execute("delete from `positions` where server_id != " + serverID);
+	}
+
+	private static HashMap<String, String> getTableColumns(String table, Connection c) throws SQLException {
+		HashMap<String, String> map = new HashMap<>();
+		ResultSet rs = c.createStatement().executeQuery("show columns from `" + table + "`");
+		while (rs.next()) {
+			map.put(rs.getString("Field"), rs.getString("Type"));
+		}
+		return map;
+	}
+
+	private static ArrayList<String> getMaxwellTables(Connection c) throws SQLException {
+		ArrayList<String> l = new ArrayList<>();
+
+		ResultSet rs = c.createStatement().executeQuery("show tables");
+		while (rs.next()) {
+			l.add(rs.getString(1));
+		}
+		return l;
+	}
+
+	private static void performAlter(Connection c, String sql) throws SQLException {
+		LOGGER.info("Maxwell is upgrading its own schema: '" + sql + "'");
+		c.createStatement().execute(sql);
+	}
+
+	public static void upgradeSchemaStoreSchema(Connection c, String schemaDatabaseName) throws SQLException, IOException {
+		if ( !getTableColumns("schemas", c).containsKey("deleted") ) {
+			performAlter(c, "alter table `schemas` add column deleted tinyint(1) not null default 0");
+		}
+
+		if ( !getMaxwellTables(c).contains("bootstrap") )  {
+			LOGGER.info("adding `" + schemaDatabaseName + "`.`bootstrap` to the schema.");
+			InputStream is = SchemaStore.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql");
+			executeSQLInputStream(c, is, schemaDatabaseName);
+		}
+
+		if ( !getTableColumns("bootstrap", c).containsKey("total_rows") ) {
+			performAlter(c, "alter table `bootstrap` add column total_rows bigint unsigned not null default 0 after inserted_rows");
+			performAlter(c, "alter table `bootstrap` modify column inserted_rows bigint unsigned not null default 0");
+		}
+
+		if ( !getTableColumns("schemas", c).containsKey("charset")) {
+			String[] charsetTables = { "schemas", "databases", "tables", "columns" };
+			for ( String table : charsetTables ) {
+				performAlter(c, "alter table `" + table + "` change `encoding` `charset` varchar(255)");
+			}
+		}
+
+		if ( !getTableColumns("schemas", c).containsKey("base_schema_id"))
+			performAlter(c, "alter table `schemas` add column base_schema_id int unsigned NULL default NULL after binlog_position");
+
+		if ( !getTableColumns("schemas", c).containsKey("deltas"))
+			performAlter(c, "alter table `schemas` add column deltas mediumtext charset 'utf8' NULL default NULL after base_schema_id");
+
+		if ( !getTableColumns("schemas", c).containsKey("version")) {
+			performAlter(c, "alter table `schemas` add column `version` smallint unsigned not null default 0 after `charset`");
+		}
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -2,6 +2,8 @@ package com.zendesk.maxwell.schema;
 
 import java.util.*;
 
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+
 import com.zendesk.maxwell.schema.columndef.EnumeratedColumnDef;
 import org.apache.commons.lang.StringUtils;
 
@@ -85,7 +87,7 @@ public class Table {
 		}
 	}
 
-	private ColumnDef findColumn(String name) {
+	public ColumnDef findColumn(String name) {
 		String lcName = name.toLowerCase();
 
 		for (ColumnDef c : columnList )  {
@@ -94,6 +96,14 @@ public class Table {
 		}
 
 		return null;
+	}
+
+	public ColumnDef findColumnOrThrow(String name) throws InvalidSchemaError {
+		ColumnDef c = findColumn(name);
+		if ( c == null )
+			throw new InvalidSchemaError("couldn't find column " + name + " in table " + this.name);
+
+		return c;
 	}
 
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
@@ -42,4 +42,8 @@ public class BigIntColumnDef extends ColumnDef {
 	public boolean isSigned() {
 		return signed;
 	}
+
+	public void setSigned(boolean signed) {
+		this.signed = signed;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
@@ -86,4 +86,7 @@ public class IntColumnDef extends ColumnDef {
 		return signed;
 	}
 
+	public void setSigned(boolean signed) {
+		this.signed = signed;
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.regex.*;
 
 import com.zendesk.maxwell.schema.SchemaStore;
+import com.zendesk.maxwell.schema.SchemaStoreSchema;
 import org.junit.Test;
 
 public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
@@ -324,7 +325,7 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 		lowerCaseServer.boot("--lower-case-table-names=1");
 		MaxwellContext context = MaxwellTestSupport.buildContext(lowerCaseServer.getPort(), null);
-		SchemaStore.ensureMaxwellSchema(lowerCaseServer.getConnection(), context.getConfig().databaseName);
+		SchemaStoreSchema.ensureMaxwellSchema(lowerCaseServer.getConnection(), context.getConfig().databaseName);
 
 		String[] sql = {
 			"CREATE TABLE `test`.`TOOTOOTWEE` ( id int )",

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -21,7 +21,7 @@ public class MaxwellTestSupport {
 		MysqlIsolatedServer server = new MysqlIsolatedServer();
 		server.boot(extraParams);
 
-		SchemaStore.ensureMaxwellSchema(server.getConnection(), "maxwell");
+		SchemaStoreSchema.ensureMaxwellSchema(server.getConnection(), "maxwell");
 		return server;
 	}
 

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -82,7 +82,7 @@ public class MysqlIsolatedServer {
 
 		resetConnection();
 		this.connection.createStatement().executeUpdate("GRANT REPLICATION SLAVE on *.* to 'maxwell'@'127.0.0.1' IDENTIFIED BY 'maxwell'");
-		this.connection.createStatement().executeUpdate("GRANT ALL on `maxwell`.* to 'maxwell'@'127.0.0.1'");
+		this.connection.createStatement().executeUpdate("GRANT ALL on *.* to 'maxwell'@'127.0.0.1'");
 		LOGGER.debug("booted at port " + this.port + ", outputting to file " + outputFile);
 	}
 

--- a/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
@@ -90,7 +90,7 @@ public class SchemaStoreTest extends MaxwellTestWithIsolatedServer {
 		Connection conn = context.getMaxwellConnection();
 		this.schemaStore.save(conn);
 
-		SchemaStore.handleMasterChange(conn, 123456L, dbName);
+		SchemaStoreSchema.handleMasterChange(conn, 123456L, dbName);
 
 		ResultSet rs = conn.createStatement().executeQuery("SELECT * from `schemas`");
 		assertThat(rs.next(), is(true));


### PR DESCRIPTION
SchemaStore was becoming overly long.  Move it out to a different class.

@zendesk/rules 

NOTE: merge by hand, this PR targets a branch