### PR TITLE
Patch up unsigned schemas

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -356,12 +356,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 		if ( !this.context.getReplayMode() ) {
 			try (Connection c = this.context.getMaxwellConnection()) {
-				this.schemaStore = new SchemaStore(this.context.getServerID(),
-				                                   this.context.getCaseSensitivity(),
-				                                   updatedSchema,
-				                                   p,
-				                                   this.schemaStore.getSchemaID(),
-				                                   changes);
+				this.schemaStore = this.schemaStore.createDerivedSchema(updatedSchema, p, changes);
 				this.schemaStore.save(c);
 			}
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -307,6 +307,10 @@ public class SchemaStore {
 
 	private void restoreFrom(Connection conn, BinlogPosition targetPosition) throws SQLException, IOException, InvalidSchemaError {
 		Long schemaID = findSchema(conn, targetPosition, this.serverID);
+		if ( schemaID == null ) {
+			throw new InvalidSchemaError("Could not find schema for "
+					+ targetPosition.getFile() + ":" + targetPosition.getOffset());
+		}
 
 		restoreFromSchemaID(conn, schemaID);
 
@@ -507,8 +511,6 @@ public class SchemaStore {
 	}
 
 	private void handleVersionUpgrades(Connection conn, Long schemaID, int version) throws SQLException, InvalidSchemaError {
-		boolean shouldResave = false;
-
 		if ( version < 1 ) {
 			if ( this.schema != null && this.schema.findDatabase("mysql") == null ) {
 				LOGGER.info("Could not find mysql db, adding it to schema");

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -21,10 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class SchemaStore {
+	static int SchemaStoreVersion = 1;
+
 	private Schema schema;
 	private BinlogPosition position;
 	private Long schema_id;
-	private String charset;
+	private int schemaVersion;
 
 	private Long base_schema_id;
 	private List<ResolvedSchemaChange> deltas;
@@ -40,6 +42,7 @@ public class SchemaStore {
 	private final CaseSensitivity sensitivity;
 	private final Long serverID;
 
+	private boolean shouldSnapshotNextSchema = false;
 
 	public SchemaStore(Long serverID, CaseSensitivity sensitivity) throws SQLException {
 		this.serverID = serverID;
@@ -65,6 +68,13 @@ public class SchemaStore {
 		this.deltas = deltas;
 
 		this.position = position;
+	}
+
+	public SchemaStore createDerivedSchema(Schema newSchema, BinlogPosition position, List<ResolvedSchemaChange> deltas) throws SQLException {
+		if ( this.shouldSnapshotNextSchema )
+			return new SchemaStore(this.serverID, this.sensitivity, newSchema, position);
+		else
+			return new SchemaStore(this.serverID, this.sensitivity, newSchema, position, this.schema_id, deltas);
 	}
 
 	public Long getSchemaID() {
@@ -101,7 +111,7 @@ public class SchemaStore {
 
 	public Long saveDerivedSchema(Connection conn) throws SQLException {
 		PreparedStatement insert = conn.prepareStatement(
-				"INSERT into `schemas` SET base_schema_id = ?, deltas = ?, binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?",
+				"INSERT into `schemas` SET base_schema_id = ?, deltas = ?, binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?, version = ?",
 				Statement.RETURN_GENERATED_KEYS);
 
 		String deltaString;
@@ -118,7 +128,8 @@ public class SchemaStore {
 		                     position.getFile(),
 		                     position.getOffset(),
 		                     serverID,
-		                     schema.getCharset());
+		                     schema.getCharset(),
+		                     SchemaStoreVersion);
 
 	}
 
@@ -129,7 +140,7 @@ public class SchemaStore {
 		PreparedStatement schemaInsert, databaseInsert, tableInsert;
 
 		schemaInsert = conn.prepareStatement(
-				"INSERT INTO `schemas` SET binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?",
+				"INSERT INTO `schemas` SET binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?, version = ?",
 				Statement.RETURN_GENERATED_KEYS
 		);
 
@@ -144,7 +155,7 @@ public class SchemaStore {
 		);
 
 		Long schemaId = executeInsert(schemaInsert, position.getFile(),
-				position.getOffset(), serverID, schema.getCharset());
+				position.getOffset(), serverID, schema.getCharset(), SchemaStoreVersion);
 
 		ArrayList<Object> columnData = new ArrayList<Object>();
 
@@ -295,37 +306,11 @@ public class SchemaStore {
 	}
 
 	private void restoreFrom(Connection conn, BinlogPosition targetPosition) throws SQLException, IOException, InvalidSchemaError {
-		boolean shouldResave = false;
-
 		Long schemaID = findSchema(conn, targetPosition, this.serverID);
-
-		if (schemaID == null) {
-			// old versions of Maxwell had a bug where they set every server_id to 1.
-			// try to upgrade.
-
-			schemaID = findSchema(conn, targetPosition, 1L);
-
-			if ( schemaID == null )
-				throw new InvalidSchemaError("Could not find schema for "
-						+ targetPosition.getFile() + ":"
-						+ targetPosition.getOffset());
-
-			LOGGER.info("found schema with server_id == 1, re-saving...");
-			shouldResave = true;
-		}
 
 		restoreFromSchemaID(conn, schemaID);
 
-		if ( this.schema != null && this.schema.findDatabase("mysql") == null ) {
-			LOGGER.info("Could not find mysql db, adding it to schema");
-			SchemaCapturer sc = new SchemaCapturer(conn, sensitivity, "mysql");
-			Database db = sc.capture().findDatabase("mysql");
-			this.schema.addDatabase(db);
-			shouldResave = true;
-		}
-
-		if ( shouldResave )
-			this.schema_id = saveSchema(conn);
+		handleVersionUpgrades(conn, schemaID, this.schemaVersion);
 	}
 
 	private void restoreFromSchemaID(Connection conn, Long schemaID) throws SQLException, IOException, InvalidSchemaError {
@@ -354,13 +339,11 @@ public class SchemaStore {
 			this.base_schema_id = null;
 
 		this.deltas = parseDeltas(schemaRS.getString("deltas"));
-		this.charset = schemaRS.getString("charset");
+		this.schemaVersion = schemaRS.getInt("version");
+		this.schema = new Schema(new ArrayList<Database>(), schemaRS.getString("charset"), this.sensitivity);
 	}
 
 	private void restoreFullSchema(Connection conn, Long schemaID) throws SQLException, IOException, InvalidSchemaError {
-		ArrayList<Database> databases = new ArrayList<>();
-		this.schema = new Schema(databases, charset, sensitivity);
-
 		PreparedStatement p = conn.prepareStatement("SELECT * from `databases` where schema_id = ? ORDER by id");
 		p.setLong(1, this.schema_id);
 
@@ -476,5 +459,66 @@ public class SchemaStore {
 
 	public BinlogPosition getBinlogPosition() {
 		return this.position;
+	}
+
+	private void fixUnsignedColumns(Connection conn) throws SQLException, InvalidSchemaError {
+		int unsignedDiffs = 0;
+
+		Schema recaptured = new SchemaCapturer(conn, sensitivity).capture();
+
+		for ( Database dA : schema.getDatabases() ) {
+			Database dB = recaptured.findDatabaseOrThrow(dA.getName());
+			for ( Table tA : dA.getTableList() ) {
+				Table tB = dB.findTableOrThrow(tA.getName());
+				for ( ColumnDef cA : tA.getColumnList() ) {
+					ColumnDef cB = tB.findColumnOrThrow(cA.getName());
+
+					if ( cA instanceof IntColumnDef ) {
+						if ( !(cB instanceof IntColumnDef) )
+							throw new InvalidSchemaError("Expected " + cB.getName() + " to be an IntColumnDef");
+
+						if ( ((IntColumnDef)cA).isSigned() && !((IntColumnDef)cB).isSigned() ) {
+							((IntColumnDef)cA).setSigned(false);
+							unsignedDiffs++;
+						}
+					} else if ( cA instanceof BigIntColumnDef ) {
+						if ( !(cB instanceof BigIntColumnDef) )
+							throw new InvalidSchemaError("Expected " + cB.getName() + " to be an BigIntColumnDef");
+
+						if ( ((BigIntColumnDef)cA).isSigned() && !((BigIntColumnDef)cB).isSigned() )
+							((BigIntColumnDef)cA).setSigned(false);
+							unsignedDiffs++;
+
+					}
+				}
+			}
+		}
+
+		if ( unsignedDiffs > 0 ) {
+			/* A little explanation here: we've detected differences in signed-ness between the restored
+			 * and the recaptured schema.  99.9% of the time this will be the result of our capture bug.
+			 *
+			 * We can't however simply re-save the re-captured schema, as we might be behind some DDL updates
+			 * that we'd otherwise lose.  So we leave a marker so that the next time we save the schema, we'll
+			 * purposely break the delta chain and fix the unsigned columns in the database.
+			 * */
+			this.shouldSnapshotNextSchema = true;
+		}
+	}
+
+	private void handleVersionUpgrades(Connection conn, Long schemaID, int version) throws SQLException, InvalidSchemaError {
+		boolean shouldResave = false;
+
+		if ( version < 1 ) {
+			if ( this.schema != null && this.schema.findDatabase("mysql") == null ) {
+				LOGGER.info("Could not find mysql db, adding it to schema");
+				SchemaCapturer sc = new SchemaCapturer(conn, sensitivity, "mysql");
+				Database db = sc.capture().findDatabase("mysql");
+				this.schema.addDatabase(db);
+				this.shouldSnapshotNextSchema = true;
+			}
+
+			fixUnsignedColumns(conn);
+		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -2,6 +2,8 @@ package com.zendesk.maxwell.schema;
 
 import java.util.*;
 
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+
 import com.zendesk.maxwell.schema.columndef.EnumeratedColumnDef;
 import org.apache.commons.lang.StringUtils;
 
@@ -94,6 +96,14 @@ public class Table {
 		}
 
 		return null;
+	}
+
+	public ColumnDef findColumnOrThrow(String name) throws InvalidSchemaError {
+		ColumnDef c = findColumn(name);
+		if ( c == null )
+			throw new InvalidSchemaError("couldn't find column " + name + " in table " + this.name);
+
+		return c;
 	}
 
 

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -87,7 +87,7 @@ public class Table {
 		}
 	}
 
-	private ColumnDef findColumn(String name) {
+	public ColumnDef findColumn(String name) {
 		String lcName = name.toLowerCase();
 
 		for (ColumnDef c : columnList )  {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
@@ -42,4 +42,8 @@ public class BigIntColumnDef extends ColumnDef {
 	public boolean isSigned() {
 		return signed;
 	}
+
+	public void setSigned(boolean signed) {
+		this.signed = signed;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
@@ -86,4 +86,7 @@ public class IntColumnDef extends ColumnDef {
 		return signed;
 	}
 
+	public void setSigned(boolean signed) {
+		this.signed = signed;
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -82,7 +82,7 @@ public class MysqlIsolatedServer {
 
 		resetConnection();
 		this.connection.createStatement().executeUpdate("GRANT REPLICATION SLAVE on *.* to 'maxwell'@'127.0.0.1' IDENTIFIED BY 'maxwell'");
-		this.connection.createStatement().executeUpdate("GRANT ALL on `maxwell`.* to 'maxwell'@'127.0.0.1'");
+		this.connection.createStatement().executeUpdate("GRANT ALL on *.* to 'maxwell'@'127.0.0.1'");
 		LOGGER.debug("booted at port " + this.port + ", outputting to file " + outputFile);
 	}
 

--- a/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaStoreTest.java
@@ -62,22 +62,6 @@ public class SchemaStoreTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
-	public void testUpgradeToFixServerIDBug() throws Exception {
-		// create a couple of schemas
-		this.schemaStore.save(context.getMaxwellConnection());
-		Long badSchemaID = this.schemaStore.getSchemaID();
-
-		// throw into old state
-		String updateSQL[] = {"UPDATE `" + buildContext().getConfig().databaseName+ "`.`schemas` set server_id = 1"};
-		server.executeList(updateSQL);
-
-		SchemaStore restoredSchema = SchemaStore.restore(context.getMaxwellConnection(), context);
-
-		List<String> diffs = restoredSchema.getSchema().diff(this.schemaStore.getSchema(), "restored", "captured");
-		assert diffs.isEmpty() : "Expected empty schema diff, got" + diffs;
-	}
-
-	@Test
 	public void testMasterChange() throws Exception {
 		this.schema = new SchemaCapturer(server.getConnection(), context.getCaseSensitivity()).capture();
 		this.binlogPosition = BinlogPosition.capture(server.getConnection());
@@ -98,15 +82,5 @@ public class SchemaStoreTest extends MaxwellTestWithIsolatedServer {
 
 		rs = conn.createStatement().executeQuery("SELECT * from `positions`");
 		assertThat(rs.next(), is(false));
-	}
-
-	@Test
-	public void testRestoreMysqlDb() throws Exception {
-		Database db = this.schema.findDatabase("mysql");
-		String maxwellDBName = this.buildContext().getConfig().databaseName;
-		this.schema.getDatabases().remove(db);
-		this.schemaStore.save(context.getMaxwellConnection());
-		SchemaStore restoredSchema = SchemaStore.restore(server.getConnection(maxwellDBName), context);
-		assertThat(restoredSchema.getSchema().findDatabase("mysql"), is(not(nullValue())));
 	}
 }


### PR DESCRIPTION
Find and fix instances of the unsigned schema-capture bug

In order to repair the schemas, we patch up the in-memory representation of the schema and instruct the next snapshot to break its delta-history.

Note that after I get sign-off here I'm going to backport all of this back to the v1_0 branch.

@zendesk/rules 
