### PR TITLE
Use a streaming connection/statement for bootstrapping tables

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -32,7 +32,6 @@ option                                        | description | default
 --blacklist_tables PATTERN                    | ignore updates AND schema changes from tables named like PATTERN (see warnings below)|
 &nbsp;
 --bootstrapper                                | bootstrapper type: async|sync|none. | async
---bootstrapper_fetch_size                     | number of rows fetched at a time during bootstrapping. | 64000
 &nbsp;
 --init_position FILE:POSITION                 | ignore the information in maxwell.positions and start at the given binlog position. Not available in config.properties.
 --replay                                      | enable maxwell's read-only "replay" mode.  Not available in config.properties.

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -28,7 +28,6 @@ public class MaxwellConfig extends AbstractConfig {
 	public String kafkaPartitionHash;
 	public String kafkaPartitionKey;
 	public String bootstrapperType;
-	public Integer bootstrapperBatchFetchSize;
 
 	public String outputFile;
 	public String log_level;
@@ -82,7 +81,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "__separator_4" );
 
 		parser.accepts( "bootstrapper", "bootstrapper type: async|sync|none. default: async" ).withRequiredArg();
-		parser.accepts( "bootstrapper_fetch_size", "number of rows fetched at a time during bootstrapping. default: 64000" ).withRequiredArg();
+		parser.accepts( "bootstrapper_fetch_size", "(deprecated)" ).withRequiredArg();
 
 		parser.accepts( "__separator_5" );
 
@@ -153,8 +152,6 @@ public class MaxwellConfig extends AbstractConfig {
 			this.producerType = (String) options.valueOf("producer");
 		if ( options.has("bootstrapper"))
 			this.bootstrapperType = (String) options.valueOf("bootstrapper");
-		if ( options.has("bootstrapper_fetch_size"))
-			this.bootstrapperBatchFetchSize = Integer.valueOf((String) options.valueOf("bootstrapper_fetch_size"));
 
 		if ( options.has("kafka.bootstrap.servers"))
 			this.kafkaProperties.setProperty("bootstrap.servers", (String) options.valueOf("kafka.bootstrap.servers"));
@@ -240,7 +237,6 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.producerType    = p.getProperty("producer", "stdout");
 		this.bootstrapperType = p.getProperty("bootstrapper", "async");
-		this.bootstrapperBatchFetchSize = Integer.valueOf(p.getProperty("bootstrapper_fetch_size", "64000"));
 
 		this.outputFile      = p.getProperty("output_file");
 		this.kafkaTopic      = p.getProperty("kafka_topic");

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -15,7 +15,6 @@ public class MaxwellMysqlConfig {
 	public String user;
 	public String password;
 	public ArrayList<String> jdbcOptions = new ArrayList<String>() {{
-		add("useCursorFetch=true");
 		add("zeroDateTimeBehavior=convertToNull");
 	}};
 
@@ -47,7 +46,7 @@ public class MaxwellMysqlConfig {
 			parseJDBCOptions(opts);
 		}
 	}
-	
+
 	public void parseJDBCOptions(String opts) {
 		if (opts == null) return;
 		for ( String opt : opts.split("&") ) {
@@ -56,7 +55,7 @@ public class MaxwellMysqlConfig {
 	}
 
 	public String getConnectionURI() {
-		return "jdbc:mysql://" + host + ":" + port + "?" +				
+		return "jdbc:mysql://" + host + ":" + port + "?" +
 				StringUtils.join(this.jdbcOptions.toArray(), "&");
 	}
 

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -49,7 +49,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		producer.push(bootstrapStartRowMap(table, position));
 		LOGGER.info(String.format("bootstrapping started for %s.%s, binlog position is %s", databaseName, tableName, position.toString()));
 		try ( Connection connection = getConnection();
-                Connection streamingConnection = getStreamingConnection()) {
+			  Connection streamingConnection = getStreamingConnection()) {
 			setBootstrapRowToStarted(startBootstrapRow, connection);
 			ResultSet resultSet = getAllRows(databaseName, tableName, schema, streamingConnection);
 			int insertedRows = 0;
@@ -91,11 +91,11 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		return conn;
 	}
 
-    protected Connection getStreamingConnection() throws SQLException {
-        Connection conn = DriverManager.getConnection(context.getConfig().replicationMysql.getConnectionURI(), context.getConfig().replicationMysql.user, context.getConfig().replicationMysql.password);
-        conn.setCatalog(context.getConfig().databaseName);
-        return conn;
-    }
+	protected Connection getStreamingConnection() throws SQLException {
+		Connection conn = DriverManager.getConnection(context.getConfig().replicationMysql.getConnectionURI(), context.getConfig().replicationMysql.user, context.getConfig().replicationMysql.password);
+		conn.setCatalog(context.getConfig().databaseName);
+		return conn;
+	}
 
 	private RowMap bootstrapStartRowMap(Table table, BinlogPosition position) {
 		return bootstrapEventRowMap("bootstrap-start", table, position);
@@ -188,11 +188,11 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		}
 	}
 
-    private Statement createBatchStatement(Connection connection) throws SQLException, InterruptedException {
-        Statement statement = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-        statement.setFetchSize(Integer.MIN_VALUE);
-        return statement;
-    }
+	private Statement createBatchStatement(Connection connection) throws SQLException, InterruptedException {
+		Statement statement = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+		statement.setFetchSize(Integer.MIN_VALUE);
+		return statement;
+	}
 
 	private void setBootstrapRowToStarted(RowMap startBootstrapRow, Connection connection) throws SQLException, NoSuchElementException {
 		String sql = "update `bootstrap` set started_at=NOW() where id=?";

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -388,9 +388,9 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		String[] opts = {"--jdbc_options= netTimeoutForStreamingResults=123& profileSQL=true  ", "--host=no-soup-spoons"};
 		MaxwellConfig config = new MaxwellConfig(opts);
 		assertEquals(config.maxwellMysql.getConnectionURI(),
-				"jdbc:mysql://no-soup-spoons:3306?useCursorFetch=true&zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
+				"jdbc:mysql://no-soup-spoons:3306?zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
 		assertEquals(config.replicationMysql.getConnectionURI(),
-				"jdbc:mysql://no-soup-spoons:3306?useCursorFetch=true&zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
+				"jdbc:mysql://no-soup-spoons:3306?zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
 
 	}
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -81,8 +81,6 @@ public class MaxwellTestSupport {
 
 		config.databaseName = "maxwell";
 
-		config.bootstrapperBatchFetchSize = 64;
-
 		config.initPosition = p;
 
 		return new MaxwellContext(config);

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -1,18 +1,24 @@
 package com.zendesk.maxwell;
 
-import java.io.*;
-import java.util.*;
-import java.sql.*;
-import java.nio.file.*;
-import java.nio.charset.Charset;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zendesk.maxwell.bootstrap.AsynchronousBootstrapper;
+import com.zendesk.maxwell.bootstrap.SynchronousBootstrapper;
+import com.zendesk.maxwell.producer.AbstractProducer;
+import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaCapturer;
+import com.zendesk.maxwell.schema.SchemaStore;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+import com.zendesk.maxwell.schema.ddl.SchemaChange;
 import org.apache.commons.lang.StringUtils;
 
-import com.zendesk.maxwell.bootstrap.*;
-import com.zendesk.maxwell.producer.AbstractProducer;
-import com.zendesk.maxwell.schema.*;
-import com.zendesk.maxwell.schema.ddl.*;
+import java.io.File;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -121,12 +127,12 @@ public class MaxwellTestSupport {
 						return conn;
 					}
 
-                    @Override
-                    protected Connection getStreamingConnection() throws SQLException {
-                        Connection conn = mysql.getNewConnection();
-                        conn.setCatalog(context.getConfig().databaseName);
-                        return conn;
-                    }
+					@Override
+					protected Connection getStreamingConnection() throws SQLException {
+						Connection conn = mysql.getNewConnection();
+						conn.setCatalog(context.getConfig().databaseName);
+						return conn;
+					}
 				};
 			}
 		};

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -120,6 +120,13 @@ public class MaxwellTestSupport {
 						conn.setCatalog(context.getConfig().databaseName);
 						return conn;
 					}
+
+                    @Override
+                    protected Connection getStreamingConnection() throws SQLException {
+                        Connection conn = mysql.getNewConnection();
+                        conn.setCatalog(context.getConfig().databaseName);
+                        return conn;
+                    }
 				};
 			}
 		};

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -95,7 +95,7 @@ public class MysqlIsolatedServer {
 	}
 
 	public Connection getNewConnection() throws SQLException {
-		return DriverManager.getConnection("jdbc:mysql://127.0.0.1:" + port + "/mysql?useCursorFetch=true&zeroDateTimeBehavior=convertToNull", "root", "");
+		return DriverManager.getConnection("jdbc:mysql://127.0.0.1:" + port + "/mysql?zeroDateTimeBehavior=convertToNull", "root", "");
 	}
 
 	public Connection getConnection() {


### PR DESCRIPTION
fetch sizes are ignored by the mysql connector, in order to achieve row by row streaming (useful for bootstrapping large tables) you need to configure the statement as follows
```
stmt = conn.createStatement(java.sql.ResultSet.TYPE_FORWARD_ONLY,
              java.sql.ResultSet.CONCUR_READ_ONLY);
stmt.setFetchSize(Integer.MIN_VALUE);
```
additional details in the connector documentation [here](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-implementation-notes.html)