### PR TITLE
Fix encoding stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:openjdk-7-jre
 ENV MAXWELL_VERSION 1.1.0-PRE1
 
-RUN apt-get update && apt-get upgrade
+RUN apt-get update && apt-get -y upgrade
 
 RUN mkdir /app
 WORKDIR /app

--- a/bin/maxwell
+++ b/bin/maxwell
@@ -15,7 +15,5 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
-export LANG="en_US.UTF-8"
-
-exec $JAVA $JAVA_OPTS -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
+exec $JAVA $JAVA_OPTS -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
 


### PR DESCRIPTION
change method for setting up default file encoding.  In rare cases, the locale `en_US.UTF-8` appears to not be available.  This then defaults all output buffers to a standard "C" locale, which then happily corrupts utf-8 data.

At least, I think that's what's happening.  adding `-Dfile.encoding=UTF-8` appears to fix the case that I could reproduce locally. 

@zendesk/rules 