### PR TITLE
change method for setting up default file encoding

### DIFF
--- a/bin/maxwell
+++ b/bin/maxwell
@@ -15,7 +15,4 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
-export LANG="en_US.UTF-8"
-
-exec $JAVA -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
-
+exec $JAVA $JAVA_OPTS -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"


### PR DESCRIPTION
In rare cases, the locale `en_US.UTF-8` appears to not be available.
this then defaults all output buffers to a standard "C" locale, which
then happily corrupts utf-8 data.

At least, I think that's the gist of it.  adding `-Dfile.encoding=UTF-8`
appears to fix the case that I could reproduce.

@zendesk/rules 