### PR TITLE
Temporary table ALTER, CREATE and DROP now blacklisted

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
@@ -38,7 +38,7 @@ public abstract class SchemaChange {
 		SQL_BLACKLIST.add(Pattern.compile("^\\s*SET\\s+PASSWORD", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE));
 		SQL_BLACKLIST.add(Pattern.compile("^\\s*(ALTER|CREATE|DROP|RENAME)\\s+USER", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE));
 
-		SQL_BLACKLIST.add(Pattern.compile("^\\s*CREATE\\s+TEMPORARY\\s+TABLE", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE));
+		SQL_BLACKLIST.add(Pattern.compile("^\\s*(ALTER|CREATE|DROP)\\s+TEMPORARY\\s+TABLE", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE));
 		SQL_BLACKLIST.add(Pattern.compile("^\\s*TRUNCATE\\s+", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE));
 		SQL_BLACKLIST.add(Pattern.compile("^\\s*OPTIMIZE\\s+", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE));
 

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -224,6 +224,8 @@ public class DDLParserTest {
 			"ALTER ALGORITHM = UNDEFINED DEFINER='view'@'localhost' SQL SECURITY DEFINER VIEW `fooview` as (SELECT * FROM FOO)"
 				+ "VIEW view_name [(alskdj lk jdlfka j dlkjd lk",
 			"CREATE TEMPORARY TABLE 172898_16841_transmem SELECT t.* FROM map.transmem AS t",
+			"DROP TEMPORARY TABLE IF EXISTS 172898_16841_transmem",
+			"ALTER TEMPORARY TABLE 172898_16841_transmem ADD something VARCHAR(1)",
 			"/* hi bob */ CREATE EVENT FOO"
 		};
 


### PR DESCRIPTION
Was finding that Maxwell would throw in procedures where DROP was used before CREATE, added to the blacklist to ensure basic DDL statements for temporary tables are ignored.