### PR TITLE
fix a race condition in the binlog position thread

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.min.js binary

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaPosition.java
@@ -112,13 +112,14 @@ public class SchemaPosition extends RunLoopProcess implements Runnable {
 		}
 	}
 
-	public void set(BinlogPosition p) {
-		position.set(p);
+	public synchronized void set(BinlogPosition p) {
+		if ( position.get() == null || p.newerThan(position.get()) )
+			position.set(p);
 	}
 
 	public void setSync(BinlogPosition p) throws SQLException {
 		LOGGER.debug("syncing binlog position: " + p);
-		position.set(p);
+		set(p);
 		while ( true ) {
 			thread.interrupt();
 			BinlogPosition s = storedPosition.get();


### PR DESCRIPTION
I latched onto a maxwell in production that was totally stuck.  I found that the main thread was waiting in setSync().  The variables were as follows:

```
main[2] dump p
p = {
    offset: 95823288
    file: "db7-bin-log.001331"
}

main[2] dump storedPosition.value
storedPosition.value = {
    offset: 95822855
    file: "db7-bin-log.001331"
}

main[2] dump position.value
position.value = {
    offset: 95822855
    file: "db7-bin-log.001331"
}
```

As you can see, the "requested" position for the thread(`position.value`) is *behind* the position "p" in setSync().  My best guess of what happened is that a kafka row came back after setSync() called position.set(), and clobbered the requested position.

Fix here is to never allow a position to rewind, which also means protecting the call with "synchronized".

@zendesk/rules 