### PR TITLE
better at-least-once semantics regarding commiting position

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM java:openjdk-7-jre
-ENV MAXWELL_VERSION 1.1.1-PRE1
+ENV MAXWELL_VERSION 1.1.1
 
 RUN apt-get update && apt-get -y upgrade
 

--- a/src/main/java/com/zendesk/maxwell/BinlogPosition.java
+++ b/src/main/java/com/zendesk/maxwell/BinlogPosition.java
@@ -21,6 +21,10 @@ public class BinlogPosition implements Serializable {
 		return new BinlogPosition(rs.getInt("Position"), rs.getString("File"));
 	}
 
+	public static BinlogPosition at(long offset, String file) {
+		return new BinlogPosition(offset, file);
+	}
+
 	public long getOffset() {
 		return offset;
 	}
@@ -46,5 +50,14 @@ public class BinlogPosition implements Serializable {
 		} else {
 			return false;
 		}
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if ( !(other instanceof BinlogPosition) )
+			return false;
+		BinlogPosition otherPosition = (BinlogPosition) other;
+
+		return this.file.equals(otherPosition.file) && this.offset == otherPosition.offset;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -359,7 +359,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 				this.savedSchema.save(c);
 			}
 
-			this.context.setPositionSync(p);
+			this.producer.writePosition(p);
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
@@ -1,5 +1,8 @@
 package com.zendesk.maxwell.producer;
 
+import java.sql.SQLException;
+
+import com.zendesk.maxwell.BinlogPosition;
 import com.zendesk.maxwell.MaxwellAbstractRowsEvent;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.RowMap;
@@ -12,4 +15,8 @@ public abstract class AbstractProducer {
 	}
 
 	abstract public void push(RowMap r) throws Exception;
+
+	public void writePosition(BinlogPosition p) throws SQLException {
+		this.context.setPosition(p);
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -1,0 +1,64 @@
+package com.zendesk.maxwell.producer;
+/* respresents a list of inflight messages -- stuff being sent over the
+   network, that may complete in any order.  Allows for only bumping
+   the binlog position upon completion of the oldest outstanding item.
+
+   Assumes .addInflight(position) will be call monotonically.
+   */
+
+import com.zendesk.maxwell.BinlogPosition;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.ListIterator;
+
+public class InflightMessageList {
+	class InflightMessage {
+		public final BinlogPosition position;
+		public boolean isComplete;
+		InflightMessage(BinlogPosition position) {
+			this.position = position;
+			this.isComplete = false;
+		}
+	}
+
+	private LinkedList<InflightMessage> list;
+	private HashMap<String, InflightMessage> hash;
+
+	public InflightMessageList() {
+		this.list = new LinkedList<>();
+		this.hash = new HashMap<>();
+	}
+
+	public void addMessage(BinlogPosition p) {
+		InflightMessage m = new InflightMessage(p);
+		this.list.add(m);
+		this.hash.put(p.toString(), m);
+	}
+
+	/* returns the position that stuff is complete up to, or null if there were no changes */
+	public BinlogPosition completeMessage(BinlogPosition p) {
+		InflightMessage m = hash.get(p.toString());
+		assert(m != null);
+
+		m.isComplete = true;
+
+		BinlogPosition completeUntil = null;
+		ListIterator<InflightMessage> iterator = this.list.listIterator();
+		while ( iterator.hasNext() ) {
+			InflightMessage msg = iterator.next();
+			if ( !msg.isComplete )
+				break;
+
+			completeUntil = msg.position;
+			iterator.remove();
+			this.hash.remove(msg.position.toString());
+		}
+
+		return completeUntil;
+	}
+
+	public int size() {
+		return list.size();
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -112,7 +112,13 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 			inflightMessages.addMessage(r.getPosition());
 
 		kafka.send(record, new KafkaCallback(inflightMessages, r.getPosition(), r.isTXCommit(), this.context, key, value));
+	}
 
+	@Override
+	public void writePosition(BinlogPosition p) throws SQLException {
+		// ensure that we don't prematurely advance the binlog pointer.
+		inflightMessages.addMessage(p);
+		inflightMessages.completeMessage(p);
 	}
 
 	private void setDefaults(Properties p) {

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -1,0 +1,56 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.BinlogPosition;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by ben on 5/25/16.
+ */
+public class InflightMessageListTest {
+	static BinlogPosition p1 = BinlogPosition.at(1, "f");
+	static BinlogPosition p2 = BinlogPosition.at(2, "f");
+	static BinlogPosition p3 = BinlogPosition.at(3, "f");
+	InflightMessageList list;
+
+	@Before
+	public void setupBefore() {
+		list = new InflightMessageList();
+		list.addMessage(p1);
+		list.addMessage(p2);
+		list.addMessage(p3);
+	}
+
+	@Test
+	public void testInOrderCompletion() {
+		BinlogPosition ret;
+
+
+		ret = list.completeMessage(p1);
+		assert(ret.equals(p1));
+
+		ret = list.completeMessage(p2);
+		assert(ret.equals(p2));
+
+		ret = list.completeMessage(p3);
+		assert(ret.equals(p3));
+
+		assert(list.size() == 0);
+	}
+
+	@Test
+	public void testOutOfOrderComplete() {
+		BinlogPosition ret;
+
+		ret = list.completeMessage(p3);
+		assert(ret == null);
+
+		ret = list.completeMessage(p2);
+		assert(ret == null);
+
+		ret = list.completeMessage(p1);
+		assertEquals(p3, ret);
+	}
+}


### PR DESCRIPTION
previously there was some possibility of losing data if one partition was master-less, while others were fine.  Now we keep a list of outstanding messages, and set our binlog position as the last continuous
position that's completed.  

@vanchi-zendesk @dadah89 , do you remember talking about binlog positions?  The old code always did `setSync` -- ie after processing DDL the replicator would force the binlog position to be written out to the database -- but I'm really unclear why I thought that was necessary.  Maybe it was that previously it was very expensive (or damaging?) to replay a schema update?  

@zendesk/rules /cc @dasch (some of this is prep-work for independent consumer positions)