### PR TITLE
further on at-least-once delivery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
     	<groupId>org.apache.kafka</groupId>
     	<artifactId>kafka-clients</artifactId>
-    	<version>0.8.2.0</version>
+    	<version>0.8.2.2</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
I was tinkering this weekend and figured out that if a message errored we sort of just continued on, not checkpointing binlog positions, until we maybe ran out of kafka buffer room or memory or whatever.

So I'm setting up some defaults -- if we try to send a message that's too big, we'll drop and log.  We'll do one retry by default.  Any other exception and we'll simply crash maxwell, as it's probably the safest thing to do. 

@dasch @zendesk/rules 

PS: I did discover a totally pathological case, where if you send `kill -STOP` to a broker, the producer gets stuck in a state in which it never times out and never errors.  I'm not sure how close to any real failure scenario this is.