### PR TITLE
WIP: Schema store refactor

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -20,7 +20,7 @@ import com.google.code.or.common.util.MySQLConstants;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
-import com.zendesk.maxwell.schema.MysqlSavedSchema;
+import com.zendesk.maxwell.schema.SchemaStore;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.ddl.SchemaChange;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
@@ -31,7 +31,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 	private final long MAX_TX_ELEMENTS = 10000;
 	String filePath, fileName;
 	private long rowEventsProcessed;
-	protected MysqlSavedSchema savedSchema;
+	protected SchemaStore schemaStore;
 
 	private MaxwellFilter filter;
 
@@ -47,8 +47,9 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellReplicator.class);
 
-	public MaxwellReplicator(MysqlSavedSchema savedSchema, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
-		this.savedSchema = savedSchema;
+	public MaxwellReplicator(SchemaStore schemaStore, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
+		this.schemaStore = schemaStore;
+		this.schemaStore.initPosition(start);
 
 		this.binlogEventListener = new MaxwellBinlogEventListener(queue);
 
@@ -320,51 +321,13 @@ public class MaxwellReplicator extends RunLoopProcess {
 		String dbName = event.getDatabaseName().toString();
 		String sql = event.getSql().toString();
 
-		List<SchemaChange> changes = SchemaChange.parse(dbName, sql);
-
-		if ( changes == null || changes.size() == 0 )
-			return;
-
-		ArrayList<ResolvedSchemaChange> resolvedSchemaChanges = new ArrayList<>();
-
-		Schema updatedSchema = getSchema();
-
-		for ( SchemaChange change : changes ) {
-			if ( !change.isBlacklisted(this.filter) ) {
-				ResolvedSchemaChange resolved = change.resolve(updatedSchema);
-				if ( resolved != null ) {
-					resolved.apply(updatedSchema);
-
-					resolvedSchemaChanges.add(resolved);
-				}
-			} else {
-				LOGGER.debug("ignoring blacklisted schema change");
-			}
-		}
-
-		if ( resolvedSchemaChanges.size() > 0 ) {
-			BinlogPosition p = eventBinlogPosition(event);
-			LOGGER.info("storing schema @" + p + " after applying \"" + sql.replace('\n', ' ') + "\"");
-
-			saveSchema(updatedSchema, resolvedSchemaChanges, p);
-		}
-	}
-
-	private void saveSchema(Schema updatedSchema, List<ResolvedSchemaChange> changes, BinlogPosition p) throws SQLException {
+		schemaStore.processSQL(sql, dbName, eventBinlogPosition(event));
 		tableCache.clear();
-
-		if ( !this.context.getReplayMode() ) {
-			try (Connection c = this.context.getMaxwellConnection()) {
-				this.savedSchema = this.savedSchema.createDerivedSchema(updatedSchema, p, changes);
-				this.savedSchema.save(c);
-			}
-
-			this.producer.writePosition(p);
-		}
+		this.producer.writePosition(p);
 	}
 
 	public Schema getSchema() {
-		return this.savedSchema.getSchema();
+		return this.schemaStore.getSchema();
 	}
 
 	public void setFilter(MaxwellFilter filter) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -22,6 +22,7 @@ import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaStore;
 import com.zendesk.maxwell.schema.Table;
+import com.zendesk.maxwell.schema.SchemaStoreException;
 import com.zendesk.maxwell.schema.ddl.SchemaChange;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 
@@ -316,14 +317,15 @@ public class MaxwellReplicator extends RunLoopProcess {
 	}
 
 
-	private void processQueryEvent(QueryEvent event) throws InvalidSchemaError, SQLException, IOException {
+	private void processQueryEvent(QueryEvent event) throws SchemaStoreException, InvalidSchemaError, SQLException, IOException {
 		// get charset of the alter event somehow? or just ignore it.
 		String dbName = event.getDatabaseName().toString();
 		String sql = event.getSql().toString();
+		BinlogPosition position = eventBinlogPosition(event);
 
-		schemaStore.processSQL(sql, dbName, eventBinlogPosition(event));
+		schemaStore.processSQL(sql, dbName, position);
 		tableCache.clear();
-		this.producer.writePosition(p);
+		this.producer.writePosition(position);
 	}
 
 	public Schema getSchema() {

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -32,6 +32,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 	private final long MAX_TX_ELEMENTS = 10000;
 	String filePath, fileName;
 	private long rowEventsProcessed;
+	private Schema schema;
 	protected SchemaStore schemaStore;
 
 	private MaxwellFilter filter;
@@ -50,7 +51,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 	public MaxwellReplicator(SchemaStore schemaStore, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
 		this.schemaStore = schemaStore;
-		this.schemaStore.initPosition(start);
+		this.schema = schemaStore.getSchema(start);
 
 		this.binlogEventListener = new MaxwellBinlogEventListener(queue);
 
@@ -323,13 +324,13 @@ public class MaxwellReplicator extends RunLoopProcess {
 		String sql = event.getSql().toString();
 		BinlogPosition position = eventBinlogPosition(event);
 
-		schemaStore.processSQL(sql, dbName, position);
+		schemaStore.processSQL(schema, sql, dbName, position);
 		tableCache.clear();
 		this.producer.writePosition(position);
 	}
 
 	public Schema getSchema() {
-		return this.schemaStore.getSchema();
+		return schema;
 	}
 
 	public void setFilter(MaxwellFilter filter) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -33,7 +33,9 @@ public class MaxwellReplicator extends RunLoopProcess {
 	String filePath, fileName;
 	private long rowEventsProcessed;
 	private Schema schema;
+
 	protected SchemaStore schemaStore;
+	protected SavedSchema savedSchema;
 
 	private MaxwellFilter filter;
 
@@ -51,7 +53,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 	public MaxwellReplicator(SchemaStore schemaStore, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
 		this.schemaStore = schemaStore;
-		this.schema = schemaStore.getSchema(start);
+		this.savedSchema = schemaStore.getSavedSchema(start);
 
 		this.binlogEventListener = new MaxwellBinlogEventListener(queue);
 
@@ -324,7 +326,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 		String sql = event.getSql().toString();
 		BinlogPosition position = eventBinlogPosition(event);
 
-		schemaStore.processSQL(schema, sql, dbName, position);
+		schemaStore.processSQL(savedSchema, sql, dbName, position);
 		tableCache.clear();
 		this.producer.writePosition(position);
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
@@ -1,0 +1,29 @@
+package com.zendesk.maxwell.schema;
+
+import java.sql.SQLException;
+import java.sql.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaCapturer;
+
+public abstract class AbstractSchemaStore implements SchemaStore {
+	static final Logger LOGGER = LoggerFactory.getLogger(AbstractSchemaStore.class);
+	protected final MaxwellContext context;
+
+	protected AbstractSchemaStore(MaxwellContext context) {
+		this.context = context;
+	}
+
+	protected Schema captureSchema() throws SQLException {
+		try(Connection connection = context.getReplicationConnection()) {
+			LOGGER.info("Maxwell is capturing initial schema");
+			SchemaCapturer capturer = new SchemaCapturer(connection, this.context.getCaseSensitivity());
+			return capturer.capture();
+		}
+	}
+}
+
+

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -20,7 +20,7 @@ import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-public class MysqlSavedSchema {
+public class MysqlSavedSchema implements SavedSchema {
 	static int SchemaStoreVersion = 1;
 
 	private Schema schema;

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -290,7 +290,7 @@ public class MysqlSavedSchema {
 
 		Long firstSchemaId = schemaChain.removeFirst();
 
-		/* do the "full" restore */
+		/* do the "full" restore of the schema snapshot */
 		MysqlSavedSchema firstSchema = new MysqlSavedSchema(serverID, sensitivity);
 		firstSchema.restoreFromSchemaID(conn, firstSchemaId);
 		Schema schema = firstSchema.getSchema();
@@ -299,7 +299,7 @@ public class MysqlSavedSchema {
 		int count = 0;
 		long startTime = System.currentTimeMillis();
 
-		/* now walk the chain and play each schema's delta */
+		/* now walk the chain and play each schema's deltas on top of the snapshot */
 		for ( Long id : schemaChain ) {
 			List<ResolvedSchemaChange> deltas = parseDeltas((String) schemas.get(id).get("deltas"));
 			for ( ResolvedSchemaChange delta : deltas ) {

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -1,0 +1,81 @@
+package com.zendesk.maxwell.schema;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.BinlogPosition;
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+import com.zendesk.maxwell.schema.ddl.SchemaChange;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.zendesk.maxwell.schema.SchemaScavenger.LOGGER;
+
+public class MysqlSchemaStore implements SchemaStore {
+	private final MaxwellContext context;
+	private MysqlSavedSchema savedSchema;
+
+	public MysqlSchemaStore(MaxwellContext context) {
+		this.context = context;
+	}
+
+	public void initPosition(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
+		try ( Connection conn = context.getMaxwellConnection() ) {
+			savedSchema = MysqlSavedSchema.restore(conn, this.context);
+			if ( savedSchema == null ) {
+				// capture, save.
+			}
+		} catch (SQLException e) {
+			throw new SchemaStoreException(e);
+		}
+	}
+
+	public Schema getSchema() {
+		return savedSchema.getSchema();
+	}
+
+
+	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
+		List<SchemaChange> changes = SchemaChange.parse(currentDatabase, sql);
+
+		if ( changes == null || changes.size() == 0 )
+			return new List<>();
+
+		ArrayList<ResolvedSchemaChange> resolvedSchemaChanges = new ArrayList<>();
+
+		Schema updatedSchema = getSchema();
+
+		for ( SchemaChange change : changes ) {
+			if ( !change.isBlacklisted(this.context.getFilter()) ) {
+				ResolvedSchemaChange resolved = change.resolve(updatedSchema);
+				if ( resolved != null ) {
+					resolved.apply(updatedSchema);
+
+					resolvedSchemaChanges.add(resolved);
+				}
+			} else {
+				LOGGER.debug("ignoring blacklisted schema change");
+			}
+		}
+
+		if ( resolvedSchemaChanges.size() > 0 ) {
+			LOGGER.info("storing schema @" + position + " after applying \"" + sql.replace('\n', ' ') + "\"");
+
+			saveSchema(updatedSchema, resolvedSchemaChanges, position);
+		}
+		return resolvedSchemaChanges;
+	}
+
+	private void saveSchema(Schema updatedSchema, List<ResolvedSchemaChange> changes, BinlogPosition p) throws SQLException {
+		if ( this.context.getReplayMode() )
+			return;
+
+		try (Connection c = this.context.getMaxwellConnection()) {
+			this.savedSchema = this.savedSchema.createDerivedSchema(updatedSchema, p, changes);
+			this.savedSchema.save(c);
+		}
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -21,7 +21,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore {
 		super(context);
 	}
 
-	public void getSchema(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
+	public Schema getSchema(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
 		try ( Connection conn = context.getMaxwellConnection() ) {
 			savedSchema = MysqlSavedSchema.restore(this.context, position);
 			if ( savedSchema == null ) {
@@ -29,16 +29,14 @@ public class MysqlSchemaStore extends AbstractSchemaStore {
 				savedSchema = new MysqlSavedSchema(context, capturedSchema);
 				savedSchema.save(conn);
 			}
+
+			return savedSchema.getSchema();
 		} catch (SQLException e) {
 			throw new SchemaStoreException(e);
 		}
 	}
 
-
-	/*
-		parse 
-	 */
-	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Schema schema, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
+	public List<ResolvedSchemaChange> processSQL(Schema schema, String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
 		List<SchemaChange> changes = SchemaChange.parse(currentDatabase, sql);
 
 		if ( changes == null || changes.size() == 0 )

--- a/src/main/java/com/zendesk/maxwell/schema/SavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SavedSchema.java
@@ -1,0 +1,26 @@
+package com.zendesk.maxwell.schema;
+
+import java.util.List;
+import com.zendesk.maxwell.BinlogPosition;
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+
+public interface SavedSchema {
+	public BinlogPosition getPosition();
+	public Schema getSchema();
+
+	/**
+	 * Process a DDL statement
+	 *
+	 * Parse the given SQL, applying the changes to supplied schema parameter, and returning
+	 * a list of ResolvedSchemaChange objects (which may be serialized to JSON).
+	 * Should modify the internal schema.
+	 *
+	 * @param schema The schema at the time the DDL statement was encountered
+	 * @param sql The SQL of the DDL statement
+	 * @param currentDatabase The "contextual database" of the DDL statement
+	 * @param position The position of the DDL statement
+	 * @return A list of the schema changes parsed from the SQL.
+	 */
+	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+}

--- a/src/main/java/com/zendesk/maxwell/schema/Schema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Schema.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.schema;
 
+import com.zendesk.maxwell.BinlogPosition;
 import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
@@ -11,17 +12,20 @@ public class Schema {
 	private final ArrayList<Database> databases;
 	private final String charset;
 	private final CaseSensitivity sensitivity;
+	private final BinlogPosition position;
 
-	public Schema(List<Database> databases, String charset, CaseSensitivity sensitivity) {
+	public Schema(List<Database> databases, String charset, CaseSensitivity sensitivity, BinlogPosition position) {
 		this.sensitivity = sensitivity;
 		this.charset = charset;
 		this.databases = new ArrayList<>();
+		this.position = position;
 
 		for ( Database d : databases )
 			addDatabase(d);
 	}
 
 	public List<Database> getDatabases() { return this.databases; }
+	public BinlogPosition getBinlogPosition() { return this.position; }
 
 	public List<String> getDatabaseNames () {
 		ArrayList<String> names = new ArrayList<String>();

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -10,13 +10,13 @@ import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.zendesk.maxwell.BinlogPosition;
 import com.zendesk.maxwell.CaseSensitivity;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
-import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 public class SchemaCapturer {
 	private final Connection connection;
@@ -45,11 +45,11 @@ public class SchemaCapturer {
 		this.includeDatabases.add(dbName);
 	}
 
-	public Schema capture() throws SQLException, InvalidSchemaError {
+	public Schema capture() throws SQLException {
 		LOGGER.debug("Capturing schema");
 		ArrayList<Database> databases = new ArrayList<>();
 
-
+		BinlogPosition position = BinlogPosition.capture(connection);
 		ResultSet rs = connection.createStatement().executeQuery("SELECT * from INFORMATION_SCHEMA.SCHEMATA");
 
 		while ( rs.next() ) {
@@ -66,7 +66,7 @@ public class SchemaCapturer {
 		}
 
 		LOGGER.debug("Finished capturing schema");
-		return new Schema(databases, captureDefaultCharset(), this.sensitivity);
+		return new Schema(databases, captureDefaultCharset(), this.sensitivity, position);
 	}
 
 	private String captureDefaultCharset() throws SQLException {
@@ -81,7 +81,7 @@ public class SchemaCapturer {
 			+ "JOIN  information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS CCSA"
 			+ " ON TABLES.TABLE_COLLATION = CCSA.COLLATION_NAME WHERE TABLES.TABLE_SCHEMA = ?";
 
-	private Database captureDatabase(String dbName, String dbCharset) throws SQLException, InvalidSchemaError {
+	private Database captureDatabase(String dbName, String dbCharset) throws SQLException {
 		PreparedStatement p = connection.prepareStatement(tblSQL);
 
 		p.setString(1, dbName);
@@ -98,7 +98,7 @@ public class SchemaCapturer {
 	}
 
 
-	private void captureTable(Table t) throws SQLException, InvalidSchemaError {
+	private void captureTable(Table t) throws SQLException {
 		int i = 0;
 		infoSchemaStmt.setString(1, t.getDatabase());
 		infoSchemaStmt.setString(2, t.getName());
@@ -131,7 +131,7 @@ public class SchemaCapturer {
 			"SELECT column_name, ordinal_position from information_schema.key_column_usage  "
 	      + "WHERE constraint_name = 'PRIMARY' and table_schema = ? and table_name = ?";
 
-	private void captureTablePK(Table t) throws SQLException, InvalidSchemaError {
+	private void captureTablePK(Table t) throws SQLException {
 		PreparedStatement p = connection.prepareStatement(pkSQL);
 		p.setString(1, t.getDatabase());
 		p.setString(2, t.getName());

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -1,0 +1,13 @@
+package com.zendesk.maxwell.schema;
+
+import com.zendesk.maxwell.BinlogPosition;
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+
+import java.util.List;
+
+public interface SchemaStore {
+	void initPosition(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+	Schema getSchema();
+	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException;
+}

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -7,7 +7,6 @@ import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 import java.util.List;
 
 public interface SchemaStore {
-	void initPosition(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
-	Schema getSchema();
-	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException;
+	void getSchema(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -7,6 +7,26 @@ import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 import java.util.List;
 
 public interface SchemaStore {
-	void getSchema(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
-	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+	/**
+	 * Retrieve a Schema for the given binlog position
+	 *
+	 * If no Stored schema is found, this method should capture and save a snapshot
+	 * of the current mysql schema.
+	 * @param position The replicator's position that it wants a schema retrived for
+	 * @return The found schema
+	 */
+	Schema getSchema(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+
+	/**
+	 * Process a DDL statement
+	 *
+	 * Parse the given SQL, applying the changes to supplied schema parameter, and returning
+	 * a list of ResolvedSchemaChange objects (which may be serialized to JSON).
+	 * @param schema The schema at the time the DDL statement was encountered
+	 * @param sql The SQL of the DDL statement
+	 * @param currentDatabase The "contextual database" of the DDL statement
+	 * @param position The position of the DDL statement
+	 * @return A list of the schema changes parsed from the SQL.
+	 */
+	List<ResolvedSchemaChange> processSQL(Schema schema, String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -1,10 +1,9 @@
 package com.zendesk.maxwell.schema;
 
 import com.zendesk.maxwell.BinlogPosition;
-import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
-import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 
 import java.util.List;
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 public interface SchemaStore {
 	/**
@@ -15,18 +14,5 @@ public interface SchemaStore {
 	 * @param position The replicator's position that it wants a schema retrived for
 	 * @return The found schema
 	 */
-	Schema getSchema(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
-
-	/**
-	 * Process a DDL statement
-	 *
-	 * Parse the given SQL, applying the changes to supplied schema parameter, and returning
-	 * a list of ResolvedSchemaChange objects (which may be serialized to JSON).
-	 * @param schema The schema at the time the DDL statement was encountered
-	 * @param sql The SQL of the DDL statement
-	 * @param currentDatabase The "contextual database" of the DDL statement
-	 * @param position The position of the DDL statement
-	 * @return A list of the schema changes parsed from the SQL.
-	 */
-	List<ResolvedSchemaChange> processSQL(Schema schema, String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+	SavedSchema getSchema(BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreException.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreException.java
@@ -2,5 +2,6 @@ package com.zendesk.maxwell.schema;
 
 public class SchemaStoreException extends Exception {
 	public SchemaStoreException (String message) { super(message); }
+	public SchemaStoreException (Exception e) { super(e); }
 	private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreException.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreException.java
@@ -1,0 +1,6 @@
+package com.zendesk.maxwell.schema;
+
+public class SchemaStoreException extends Exception {
+	public SchemaStoreException (String message) { super(message); }
+	private static final long serialVersionUID = 1L;
+}

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -334,7 +334,7 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 
 		lowerCaseServer.boot("--lower-case-table-names=1");
-		MaxwellContext context = MaxwellTestSupport.buildContext(lowerCaseServer.getPort(), null);
+		MaxwellContext context = MaxwellTestSupport.buildContext(lowerCaseServer.getPort(), null, null);
 		SchemaStoreSchema.ensureMaxwellSchema(lowerCaseServer.getConnection(), context.getConfig().databaseName);
 
 		String[] sql = {

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -6,7 +6,7 @@ import com.zendesk.maxwell.bootstrap.SynchronousBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaCapturer;
-import com.zendesk.maxwell.schema.MysqlSavedSchema;
+import com.zendesk.maxwell.schema.MysqlSchemaStore;
 import com.zendesk.maxwell.schema.SchemaStoreSchema;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 import com.zendesk.maxwell.schema.ddl.SchemaChange;
@@ -67,7 +67,7 @@ public class MaxwellTestSupport {
 	}
 
 
-	public static MaxwellContext buildContext(int port, BinlogPosition p) {
+	public static MaxwellContext buildContext(int port, BinlogPosition p, MaxwellFilter filter) {
 		MaxwellConfig config = new MaxwellConfig();
 
 		config.replicationMysql.host = "127.0.0.1";
@@ -82,25 +82,28 @@ public class MaxwellTestSupport {
 
 		config.databaseName = "maxwell";
 
+		config.filter = filter;
 		config.initPosition = p;
 
 		return new MaxwellContext(config);
 	}
 
-	public static List<RowMap>getRowsForSQL(final MysqlIsolatedServer mysql, MaxwellFilter filter, String queries[], String before[]) throws Exception {
-		MaxwellContext context = buildContext(mysql.getPort(), null);
+	private static void clearSchemaStore(MysqlIsolatedServer mysql) throws Exception {
+		mysql.getConnection().prepareStatement("delete from `maxwell`.`schemas`").execute();
+	}
 
-		SchemaCapturer capturer = new SchemaCapturer(mysql.getConnection(), context.getCaseSensitivity());
+	public static List<RowMap>getRowsForSQL(final MysqlIsolatedServer mysql, MaxwellFilter filter, String queries[], String before[]) throws Exception {
+		MaxwellContext context = buildContext(mysql.getPort(), null, filter);
+
+		clearSchemaStore(mysql);
 
 		if ( before != null ) {
 			mysql.executeList(Arrays.asList(before));
 		}
 
 		BinlogPosition start = BinlogPosition.capture(mysql.getConnection());
-
-		Schema initialSchema = capturer.capture();
-		MysqlSavedSchema initialSavedSchema = new MysqlSavedSchema(context, initialSchema, BinlogPosition.capture(mysql.getConnection()));
-		initialSavedSchema.save(context.getMaxwellConnection());
+		MysqlSchemaStore schemaStore = new MysqlSchemaStore(context);
+		schemaStore.initPosition(start);
 
 		mysql.executeList(Arrays.asList(queries));
 
@@ -136,7 +139,7 @@ public class MaxwellTestSupport {
 			}
 		};
 
-		TestMaxwellReplicator p = new TestMaxwellReplicator(initialSavedSchema, producer, bootstrapper, context, start, endPosition);
+		TestMaxwellReplicator p = new TestMaxwellReplicator(schemaStore, producer, bootstrapper, context, start, endPosition);
 
 		p.setFilter(filter);
 
@@ -152,7 +155,7 @@ public class MaxwellTestSupport {
 	}
 
 	public static void testDDLFollowing(MysqlIsolatedServer server, String alters[]) throws Exception {
-		SchemaCapturer capturer = new SchemaCapturer(server.getConnection(), buildContext(server.getPort(), null).getCaseSensitivity());
+		SchemaCapturer capturer = new SchemaCapturer(server.getConnection(), buildContext(server.getPort(), null, null).getCaseSensitivity());
 		Schema topSchema = capturer.capture();
 
 		server.executeList(Arrays.asList(alters));

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -33,10 +33,10 @@ public class MaxwellTestWithIsolatedServer {
 	}
 
 	protected MaxwellContext buildContext() {
-		return MaxwellTestSupport.buildContext(server.getPort(), null);
+		return MaxwellTestSupport.buildContext(server.getPort(), null, null);
 	}
 
 	protected MaxwellContext buildContext(BinlogPosition p) {
-		return MaxwellTestSupport.buildContext(server.getPort(), p);
+		return MaxwellTestSupport.buildContext(server.getPort(), p, null);
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
@@ -24,7 +24,6 @@ public class SchemaScavengerTest extends MaxwellTestWithIsolatedServer {
 		"CREATE TABLE shard_1.pks (id int(11), col2 varchar(255), col3 datetime, PRIMARY KEY(col2, col3, id))"
 	};
 	private Schema schema;
-	private BinlogPosition binlogPosition;
 	private MysqlSavedSchema savedSchema;
 	private SchemaScavenger scavenger;
 
@@ -32,13 +31,12 @@ public class SchemaScavengerTest extends MaxwellTestWithIsolatedServer {
 	public void setUp() throws Exception {
 		server.executeList(schemaSQL);
 		this.schema = new SchemaCapturer(server.getConnection(), CaseSensitivity.CASE_SENSITIVE).capture();
-		this.binlogPosition = BinlogPosition.capture(server.getConnection());
         MaxwellContext context = buildContext();
 
 		this.scavenger = new SchemaScavenger(buildContext().getMaxwellConnectionPool(), context.getConfig().databaseName);
 		Connection conn = server.getConnection();
 		conn.setCatalog(context.getConfig().databaseName);
-		this.savedSchema = new MysqlSavedSchema(context, this.schema, binlogPosition);
+		this.savedSchema = new MysqlSavedSchema(context, this.schema);
 		this.savedSchema.save(conn);
 	}
 

--- a/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
+++ b/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
@@ -3,7 +3,7 @@ package com.zendesk.maxwell;
 import com.google.code.or.binlog.BinlogEventV4;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
-import com.zendesk.maxwell.schema.MysqlSavedSchema;
+import com.zendesk.maxwell.schema.SchemaStore;
 
 import java.util.concurrent.TimeUnit;
 
@@ -14,13 +14,13 @@ public class TestMaxwellReplicator extends MaxwellReplicator {
 	private final BinlogPosition stopAt;
 	private boolean shouldStop;
 
-	public TestMaxwellReplicator(MysqlSavedSchema savedSchema,
+	public TestMaxwellReplicator(SchemaStore schemaStore,
 								 AbstractProducer producer,
 								 AbstractBootstrapper bootstrapper,
 								 MaxwellContext ctx,
 								 BinlogPosition start,
 								 BinlogPosition stop) throws Exception {
-		super(savedSchema, producer, bootstrapper, ctx, start);
+		super(schemaStore, producer, bootstrapper, ctx, start);
 		LOGGER.debug("TestMaxwellReplicator initialized from " + start + " to " + stop);
 		this.stopAt = stop;
 	}


### PR DESCRIPTION
none of this is working, but it's my thinking along lines of moving some of the raw schema storage functionality out of `MaxwellReplicator`.  ideally the MaxwellReplicator has no idea about the nature of how its schemas are stored.  This will get us mileage towards:

- multiple maxwell replicators running inside the same jvm, operating at different positions (with different producers)
- alternative stores for schema and position (some folks would like to store that stuff inside kafka, others might even opt for local disk)

It's still not quite right, as `SchemaStore` still keeps state that's tied to the replicator (it needs access to the previous schema to create delta-snapshots).  Will keep working.  I think it's my reticence to tie a `BinlogPosition` directly to the `Schema` object that's killing all my metaphors.  But I dunno. 

cc @dasch @zendesk/rules 