### PR TITLE
Move filter building into config class

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -45,7 +45,7 @@ public class Maxwell {
 
 		this.context.probeConnections();
 
-		try ( Connection connection = this.context.getReplicationConnectionPool().getConnection(); Connection schemaConnection = context.getMaxwellConnectionPool().getConnection() ) {
+		try ( Connection connection = this.context.getReplicationConnection(); Connection schemaConnection = context.getMaxwellConnectionPool().getConnection() ) {
 			MaxwellMysqlStatus.ensureReplicationMysqlState(connection);
 			MaxwellMysqlStatus.ensureMaxwellMysqlState(schemaConnection);
 
@@ -77,12 +77,7 @@ public class Maxwell {
 
 		bootstrapper.resume(producer, p);
 
-		try {
-			p.setFilter(context.buildFilter());
-		} catch (MaxwellInvalidFilterException e) {
-			LOGGER.error("Invalid maxwell filter", e);
-			System.exit(1);
-		}
+		p.setFilter(context.getFilter());
 
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 			@Override

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -15,6 +15,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public MaxwellMysqlConfig replicationMysql;
 
 	public MaxwellMysqlConfig maxwellMysql;
+	public MaxwellFilter filter;
 
 	public String databaseName;
 
@@ -326,6 +327,20 @@ public class MaxwellConfig extends AbstractConfig {
 
 		if ( this.databaseName == null) {
 			this.databaseName = "maxwell";
+		}
+
+		try {
+			this.filter = new MaxwellFilter(
+					includeDatabases,
+					excludeDatabases,
+					includeTables,
+					excludeTables,
+					blacklistDatabases,
+					blacklistTables,
+					excludeColumns
+			);
+		} catch (MaxwellInvalidFilterException e) {
+			usage("Invalid filter options: " + e.getLocalizedMessage());
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -49,8 +49,8 @@ public class MaxwellContext {
 		return this.config;
 	}
 
-	public ConnectionPool getReplicationConnectionPool() {
-		return this.replicationConnectionPool;
+	public Connection getReplicationConnection() throws SQLException {
+		return this.replicationConnectionPool.getConnection();
 	}
 
 	public ConnectionPool getMaxwellConnectionPool() { return this.maxwellConnectionPool; }
@@ -127,7 +127,7 @@ public class MaxwellContext {
 		if ( this.serverID != null)
 			return this.serverID;
 
-		try ( Connection c = getReplicationConnectionPool().getConnection() ) {
+		try ( Connection c = getReplicationConnection() ) {
 			ResultSet rs = c.createStatement().executeQuery("SELECT @@server_id as server_id");
 			if ( !rs.next() ) {
 				throw new RuntimeException("Could not retrieve server_id!");
@@ -142,7 +142,7 @@ public class MaxwellContext {
 		if ( this.caseSensitivity != null )
 			return this.caseSensitivity;
 
-		try ( Connection c = getReplicationConnectionPool().getConnection()) {
+		try ( Connection c = getReplicationConnection()) {
 			ResultSet rs = c.createStatement().executeQuery("select @@lower_case_table_names");
 			if ( !rs.next() )
 				throw new RuntimeException("Could not retrieve @@lower_case_table_names!");
@@ -191,16 +191,9 @@ public class MaxwellContext {
 
 	}
 
-	public MaxwellFilter buildFilter() throws MaxwellInvalidFilterException {
-		return new MaxwellFilter(config.includeDatabases,
-			config.excludeDatabases,
-			config.includeTables,
-			config.excludeTables,
-			config.blacklistDatabases,
-			config.blacklistTables,
-			config.excludeColumns);
+	public MaxwellFilter getFilter() {
+		return config.filter;
 	}
-
 
 	public boolean getReplayMode() {
 		return this.config.replayMode;

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -86,7 +86,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 	}
 
 	protected Connection getConnection() throws SQLException {
-		Connection conn = context.getReplicationConnectionPool().getConnection();
+		Connection conn = context.getReplicationConnection();
 		conn.setCatalog(context.getConfig().databaseName);
 		return conn;
 	}
@@ -133,7 +133,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 
 	@Override
 	public void resume(AbstractProducer producer, MaxwellReplicator replicator) throws Exception {
-		try ( Connection connection = context.getMaxwellConnectionPool().getConnection() ) {
+		try ( Connection connection = context.getMaxwellConnection() ) {
 			// This update resets all rows of incomplete bootstraps to their original state.
 			// These updates are treated as fresh bootstrap requests and trigger a restart
 			// of the bootstrap process from the beginning.

--- a/src/main/java/com/zendesk/maxwell/schema/Schema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Schema.java
@@ -60,15 +60,6 @@ public class Schema {
 		this.databases.add(d);
 	}
 
-	public Schema copy() {
-		ArrayList<Database> newDBs = new ArrayList<>();
-		for ( Database d : this.databases ) {
-			newDBs.add(d.copy());
-		}
-
-		return new Schema(newDBs, this.charset, this.sensitivity);
-	}
-
 	private void diffDBList(List<String> diff, Schema a, Schema b, String nameA, String nameB, boolean recurse) {
 		for ( Database d : a.databases ) {
 			Database matchingDB = b.findDatabase(d.getName());


### PR DESCRIPTION
This gives error messages at the right point in the code, and stops `maxwellFilterException` from propogating out everywhere.

also move getReplicationConnectionPool to getReplicationConnection.

@zendesk/rules 
