### PR TITLE
Do some work on Maxwell memory pressure

### DIFF
--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -37,7 +37,7 @@ public class RowMap implements Serializable {
 
 	private static final JsonFactory jsonFactory = new JsonFactory();
 
-	private long approximateSize = 0;
+	private long approximateSize;
 
 	private static final ThreadLocal<ByteArrayOutputStream> byteArrayThreadLocal =
 			new ThreadLocal<ByteArrayOutputStream>(){
@@ -244,15 +244,14 @@ public class RowMap implements Serializable {
 	}
 
 	private long approximateKVSize(String key, Object value) {
-		this.approximateSize += 40; // overhead.  Whynot.
-		this.approximateSize += key.getBytes().length;
-
-		long length;
+		long length = 0;
+		length += 40; // overhead.  Whynot.
+		length += key.length() * 2;
 
 		if ( value instanceof String ) {
-			length = ((String) value).getBytes().length * 2;
+			length += ((String) value).length() * 2;
 		} else {
-			length = 64;
+			length += 64;
 		}
 
 		return length;

--- a/src/main/java/com/zendesk/maxwell/RowMapBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/RowMapBuffer.java
@@ -5,15 +5,54 @@ import com.zendesk.maxwell.util.ListWithDiskBuffer;
 import java.io.IOException;
 
 public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
+	private static long FlushOutputStreamBytes = 10000000;
 	private Long xid;
+	private long memorySize = 0;
+	private long outputStreamCacheSize = 0;
+	private final long maxMemory;
 
-	public RowMapBuffer(long maxInMemoryElements) throws IOException {
+	public RowMapBuffer(long maxInMemoryElements) {
 		super(maxInMemoryElements);
+		this.maxMemory = (long) (Runtime.getRuntime().maxMemory() * 0.25);
+	}
+
+	public RowMapBuffer(long maxInMemoryElements, long maxMemory) {
+		super(maxInMemoryElements);
+		this.maxMemory = maxMemory;
+	}
+
+	@Override
+	public void add(RowMap rowMap) throws IOException {
+		this.memorySize += rowMap.getApproximateSize();
+		super.add(rowMap);
+	}
+
+	@Override
+	protected boolean shouldBuffer() {
+		return memorySize > maxMemory;
+	}
+
+	@Override
+	protected RowMap evict() throws IOException {
+		RowMap r = super.evict();
+		this.memorySize -= r.getApproximateSize();
+
+		/* For performance reasons, the output stream will hold on to cached objects.
+		 * There's probably a smarter thing to do (write our own serdes, maybe?), but
+		 * for now we forcibly flush its cache when it gets too big. */
+		this.outputStreamCacheSize += r.getApproximateSize();
+		if ( this.outputStreamCacheSize > FlushOutputStreamBytes ) {
+			resetOutputStreamCaches();
+			this.outputStreamCacheSize = 0;
+		}
+
+		return r;
 	}
 
 	public RowMap removeFirst() throws IOException, ClassNotFoundException {
 		RowMap r = super.removeFirst(RowMap.class);
 		r.setXid(this.xid);
+
 		return r;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -128,13 +128,12 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 		if ( r.isTXCommit() )
 			inflightMessages.addMessage(r.getPosition());
 
-		KafkaCallback callback;
 
-		/* if debug logging isn't enabled, try to release refs to key / value for memory conversation */
-		if ( KafkaCallback.LOGGER.isDebugEnabled() )
-			callback = new KafkaCallback(inflightMessages, r.getPosition(), r.isTXCommit(), this.context, key, value);
-		else
-			callback = new KafkaCallback(inflightMessages, r.getPosition(), r.isTXCommit(), this.context, null, null);
+		/* if debug logging isn't enabled, release the reference to `value`, which can ease memory pressure somewhat */
+		if ( !KafkaCallback.LOGGER.isDebugEnabled() )
+			value = null;
+
+		KafkaCallback callback = new KafkaCallback(inflightMessages, r.getPosition(), r.isTXCommit(), this.context, key, value);
 
 		kafka.send(record, callback);
 	}

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -19,7 +19,7 @@ public class ListWithDiskBuffer<T> {
 	private ObjectInputStream is;
 	private ObjectOutputStream os;
 
-	public ListWithDiskBuffer(long maxInMemoryElements) throws IOException {
+	public ListWithDiskBuffer(long maxInMemoryElements) {
 		this.maxInMemoryElements = maxInMemoryElements;
 		list = new LinkedList<>();
 	}
@@ -27,25 +27,18 @@ public class ListWithDiskBuffer<T> {
 	public void add(T element) throws IOException {
 		list.add(element);
 
-		while (this.list.size() > maxInMemoryElements) {
-			if ( file == null ) {
-				file = File.createTempFile("maxwell", "events");
-				file.deleteOnExit();
-				os = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(file)));
-			}
-
-			if ( elementsInFile == 0 )
-				LOGGER.debug("Overflowed in-memory buffer, spilling over into " + file);
-
-			os.writeObject(this.list.removeFirst());
-
-			elementsInFile++;
-
-			if ( elementsInFile % maxInMemoryElements == 0 )
-				os.reset(); // flush ObjectOutputStream caches
-		}
+		while ( shouldBuffer() )
+			evict();
 	}
-
+//*
+	protected boolean shouldBuffer() {
+		return this.list.size() > maxInMemoryElements;
+	}
+//*
+	protected void resetOutputStreamCaches() throws IOException {
+		os.reset();
+	}
+//*
 	public void flushToDisk() throws IOException {
 		if ( os != null )
 			os.flush();
@@ -92,4 +85,26 @@ public class ListWithDiskBuffer<T> {
 			super.finalize();
 		}
 	}
+
+	protected T evict() throws IOException {
+		if ( file == null ) {
+			file = File.createTempFile("maxwell", "events");
+			file.deleteOnExit();
+			os = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(file)));
+		}
+
+		if ( elementsInFile == 0 )
+			LOGGER.info("Overflowed in-memory buffer, spilling over into " + file);
+
+		T evicted = this.list.removeFirst();
+		os.writeObject(evicted);
+
+		elementsInFile++;
+
+		if ( elementsInFile % maxInMemoryElements == 0 )
+			resetOutputStreamCaches();
+
+		return evicted;
+	}
+
 }

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -30,15 +30,15 @@ public class ListWithDiskBuffer<T> {
 		while ( shouldBuffer() )
 			evict();
 	}
-//*
+
 	protected boolean shouldBuffer() {
 		return this.list.size() > maxInMemoryElements;
 	}
-//*
+
 	protected void resetOutputStreamCaches() throws IOException {
 		os.reset();
 	}
-//*
+
 	public void flushToDisk() throws IOException {
 		if ( os != null )
 			os.flush();

--- a/src/test/java/com/zendesk/maxwell/RowMapBufferTest.java
+++ b/src/test/java/com/zendesk/maxwell/RowMapBufferTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class RowMapBufferTest {
 	@Test
 	public void TestOverflowToDisk() throws Exception {
-		RowMapBuffer buffer = new RowMapBuffer(2);
+		RowMapBuffer buffer = new RowMapBuffer(2, 250); // allow about 250 bytes of memory to be used
 
 		RowMap r;
 		buffer.add(new RowMap("insert", "foo", "bar", 1L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));


### PR DESCRIPTION
Under load in production, it was fairly easy to get Maxwell to run
itself out of memory, especially with a transaction that involves many
>10mb rows.

This changes the way that we flush our list of transactions to disk;
previously we had kept a fixed size nubmer of RowMap objects in memory,
now we make an educated guess about the total size of the in-memory
cache and don't let it grow larger than 25% of heap memory.

There's also a change to the Kafka producer to allow it to release its
keys and values sooner.

With this change, a set of updates that previously required a 4gb heap
to consume now can be safely consumed with Maxwell running at -Xmx300m.

@zendesk/rules 