### PR TITLE
Schema store refactor

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -12,28 +12,14 @@ import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaCapturer;
-import com.zendesk.maxwell.schema.MysqlSavedSchema;
+import com.zendesk.maxwell.schema.MysqlSchemaStore;
 import com.zendesk.maxwell.schema.SchemaStoreSchema;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 public class Maxwell {
-	private MysqlSavedSchema savedSchema;
 	private MaxwellConfig config;
 	private MaxwellContext context;
 	static final Logger LOGGER = LoggerFactory.getLogger(Maxwell.class);
-
-	private void initFirstRun(Connection connection, Connection schemaConnection) throws SQLException, IOException, InvalidSchemaError {
-		LOGGER.info("Maxwell is capturing initial schema");
-		SchemaCapturer capturer = new SchemaCapturer(connection, this.context.getCaseSensitivity());
-		Schema schema = capturer.capture();
-
-		BinlogPosition pos = BinlogPosition.capture(connection);
-
-		this.savedSchema = new MysqlSavedSchema(this.context.getServerID(), this.context.getCaseSensitivity(), schema, pos);
-		this.savedSchema.save(schemaConnection);
-
-		this.context.setPosition(pos);
-	}
 
 	private void run(String[] argv) throws Exception {
 		this.config = new MaxwellConfig(argv);
@@ -55,15 +41,8 @@ public class Maxwell {
 
 			SchemaStoreSchema.handleMasterChange(schemaConnection, context.getServerID(), this.config.databaseName);
 
-			if ( this.context.getInitialPosition() != null ) {
-				String producerClass = this.context.getProducer().getClass().getSimpleName();
-
-				LOGGER.info("Maxwell is booting (" + producerClass + "), starting at " + this.context.getInitialPosition());
-
-				this.savedSchema = MysqlSavedSchema.restore(schemaConnection, this.context);
-			} else {
-				initFirstRun(connection, schemaConnection);
-			}
+			String producerClass = this.context.getProducer().getClass().getSimpleName();
+			LOGGER.info("Maxwell is booting (" + producerClass + "), starting at " + this.context.getInitialPosition());
 		} catch ( SQLException e ) {
 			LOGGER.error("SQLException: " + e.getLocalizedMessage());
 			LOGGER.error(e.getLocalizedMessage());
@@ -73,7 +52,8 @@ public class Maxwell {
 		AbstractProducer producer = this.context.getProducer();
 		AbstractBootstrapper bootstrapper = this.context.getBootstrapper();
 
-		final MaxwellReplicator p = new MaxwellReplicator(this.savedSchema, producer, bootstrapper, this.context, this.context.getInitialPosition());
+		MysqlSchemaStore mysqlSchemaStore = new MysqlSchemaStore(this.context);
+		final MaxwellReplicator p = new MaxwellReplicator(mysqlSchemaStore, producer, bootstrapper, this.context, this.context.getInitialPosition());
 
 		bootstrapper.resume(producer, p);
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -97,6 +97,14 @@ public class MaxwellContext {
 			return this.initialPosition;
 
 		this.initialPosition = getMysqlPositionStore().get();
+
+		if ( this.initialPosition == null ) {
+			try ( Connection connection = getReplicationConnection() ) {
+				this.initialPosition = BinlogPosition.capture(connection);
+				this.setPosition(this.initialPosition);
+			}
+		}
+
 		return this.initialPosition;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -22,6 +22,7 @@ import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.MysqlSavedSchema;
 import com.zendesk.maxwell.schema.Table;
+import com.zendesk.maxwell.schema.SchemaStoreException;
 import com.zendesk.maxwell.schema.ddl.SchemaChange;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 
@@ -315,7 +316,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 	}
 
 
-	private void processQueryEvent(QueryEvent event) throws InvalidSchemaError, SQLException, IOException {
+	private void processQueryEvent(QueryEvent event) throws SchemaStoreException, InvalidSchemaError, SQLException {
 		// get charset of the alter event somehow? or just ignore it.
 		String dbName = event.getDatabaseName().toString();
 		String sql = event.getSql().toString();

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -20,7 +20,7 @@ import com.google.code.or.common.util.MySQLConstants;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Schema;
-import com.zendesk.maxwell.schema.MysqlSavedSchema;
+import com.zendesk.maxwell.schema.SchemaStore;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.SchemaStoreException;
 import com.zendesk.maxwell.schema.ddl.SchemaChange;
@@ -32,7 +32,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 	private final long MAX_TX_ELEMENTS = 10000;
 	String filePath, fileName;
 	private long rowEventsProcessed;
-	protected MysqlSavedSchema savedSchema;
+	protected SchemaStore schemaStore;
 
 	private MaxwellFilter filter;
 
@@ -48,9 +48,8 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellReplicator.class);
 
-	public MaxwellReplicator(MysqlSavedSchema savedSchema, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
-		this.savedSchema = savedSchema;
-
+	public MaxwellReplicator(SchemaStore schemaStore, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, BinlogPosition start) throws Exception {
+		this.schemaStore = schemaStore;
 		this.binlogEventListener = new MaxwellBinlogEventListener(queue);
 
 		this.replicator = new OpenReplicator();
@@ -320,52 +319,15 @@ public class MaxwellReplicator extends RunLoopProcess {
 		// get charset of the alter event somehow? or just ignore it.
 		String dbName = event.getDatabaseName().toString();
 		String sql = event.getSql().toString();
+		BinlogPosition position = eventBinlogPosition(event);
 
-		List<SchemaChange> changes = SchemaChange.parse(dbName, sql);
-
-		if ( changes == null || changes.size() == 0 )
-			return;
-
-		ArrayList<ResolvedSchemaChange> resolvedSchemaChanges = new ArrayList<>();
-
-		Schema updatedSchema = getSchema();
-
-		for ( SchemaChange change : changes ) {
-			if ( !change.isBlacklisted(this.filter) ) {
-				ResolvedSchemaChange resolved = change.resolve(updatedSchema);
-				if ( resolved != null ) {
-					resolved.apply(updatedSchema);
-
-					resolvedSchemaChanges.add(resolved);
-				}
-			} else {
-				LOGGER.debug("ignoring blacklisted schema change");
-			}
-		}
-
-		if ( resolvedSchemaChanges.size() > 0 ) {
-			BinlogPosition p = eventBinlogPosition(event);
-			LOGGER.info("storing schema @" + p + " after applying \"" + sql.replace('\n', ' ') + "\"");
-
-			saveSchema(updatedSchema, resolvedSchemaChanges, p);
-		}
-	}
-
-	private void saveSchema(Schema updatedSchema, List<ResolvedSchemaChange> changes, BinlogPosition p) throws SQLException {
+		schemaStore.processSQL(sql, dbName, position);
 		tableCache.clear();
-
-		if ( !this.context.getReplayMode() ) {
-			try (Connection c = this.context.getMaxwellConnection()) {
-				this.savedSchema = this.savedSchema.createDerivedSchema(updatedSchema, p, changes);
-				this.savedSchema.save(c);
-			}
-
-			this.producer.writePosition(p);
-		}
+		this.producer.writePosition(position);
 	}
 
-	public Schema getSchema() {
-		return this.savedSchema.getSchema();
+	public Schema getSchema() throws SchemaStoreException {
+		return this.schemaStore.getSchema();
 	}
 
 	public void setFilter(MaxwellFilter filter) {

--- a/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
@@ -2,14 +2,18 @@ package com.zendesk.maxwell.schema;
 
 import java.sql.SQLException;
 import java.sql.Connection;
+import java.util.List;
+import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zendesk.maxwell.MaxwellContext;
-import com.zendesk.maxwell.schema.Schema;
-import com.zendesk.maxwell.schema.SchemaCapturer;
+import com.zendesk.maxwell.BinlogPosition;
+import com.zendesk.maxwell.schema.ddl.SchemaChange;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
-public abstract class AbstractSchemaStore implements SchemaStore {
+public abstract class AbstractSchemaStore {
 	static final Logger LOGGER = LoggerFactory.getLogger(AbstractSchemaStore.class);
 	protected final MaxwellContext context;
 
@@ -23,6 +27,29 @@ public abstract class AbstractSchemaStore implements SchemaStore {
 			SchemaCapturer capturer = new SchemaCapturer(connection, this.context.getCaseSensitivity());
 			return capturer.capture();
 		}
+	}
+
+	protected List<ResolvedSchemaChange> resolveSQL(Schema schema, String sql, String currentDatabase) throws InvalidSchemaError {
+		List<SchemaChange> changes = SchemaChange.parse(currentDatabase, sql);
+
+		if ( changes == null || changes.size() == 0 )
+			return new ArrayList<>();
+
+		ArrayList<ResolvedSchemaChange> resolvedSchemaChanges = new ArrayList<>();
+
+		for ( SchemaChange change : changes ) {
+			if ( !change.isBlacklisted(this.context.getFilter()) ) {
+				ResolvedSchemaChange resolved = change.resolve(schema);
+				if ( resolved != null ) {
+					resolved.apply(schema);
+
+					resolvedSchemaChanges.add(resolved);
+				}
+			} else {
+				LOGGER.debug("ignoring blacklisted schema change");
+			}
+		}
+		return resolvedSchemaChanges;
 	}
 }
 

--- a/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
@@ -1,0 +1,29 @@
+package com.zendesk.maxwell.schema;
+
+import java.sql.SQLException;
+import java.sql.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaCapturer;
+
+public abstract class AbstractSchemaStore implements SchemaStore {
+	static final Logger LOGGER = LoggerFactory.getLogger(AbstractSchemaStore.class);
+	protected final MaxwellContext context;
+
+	protected AbstractSchemaStore(MaxwellContext context) {
+		this.context = context;
+	}
+
+	protected Schema captureSchema() throws SQLException {
+		try(Connection connection = context.getReplicationConnection()) {
+			LOGGER.info("Maxwell is capturing initial schema");
+			SchemaCapturer capturer = new SchemaCapturer(connection, this.context.getCaseSensitivity());
+			return capturer.capture();
+		}
+	}
+}
+
+

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -1,0 +1,93 @@
+package com.zendesk.maxwell.schema;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.BinlogPosition;
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+import com.zendesk.maxwell.schema.ddl.SchemaChange;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.zendesk.maxwell.schema.SchemaScavenger.LOGGER;
+
+public class MysqlSchemaStore extends AbstractSchemaStore {
+	private MysqlSavedSchema savedSchema;
+
+	public MysqlSchemaStore(MaxwellContext context) {
+		super(context);
+	}
+
+	public Schema getSchema() throws SchemaStoreException {
+		if ( savedSchema == null )
+			savedSchema = restoreOrCaptureSchema();
+		return savedSchema.getSchema();
+	}
+
+	private MysqlSavedSchema restoreOrCaptureSchema() throws SchemaStoreException {
+		try ( Connection conn = context.getMaxwellConnection() ) {
+			MysqlSavedSchema savedSchema = MysqlSavedSchema.restore(this.context, this.context.getInitialPosition());
+			if ( savedSchema == null ) {
+				Schema capturedSchema = captureSchema();
+				savedSchema = new MysqlSavedSchema(context, capturedSchema, this.context.getInitialPosition());
+				savedSchema.save(conn);
+			}
+			return savedSchema;
+		} catch (SQLException e) {
+			throw new SchemaStoreException(e);
+		} catch (InvalidSchemaError e) {
+			throw new SchemaStoreException(e);
+		}
+	}
+
+
+	/* TODO: much of this should be abstract */
+	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
+		List<SchemaChange> changes = SchemaChange.parse(currentDatabase, sql);
+
+		if ( changes == null || changes.size() == 0 )
+			return new ArrayList<>();
+
+		ArrayList<ResolvedSchemaChange> resolvedSchemaChanges = new ArrayList<>();
+
+		Schema updatedSchema = getSchema();
+
+		for ( SchemaChange change : changes ) {
+			if ( !change.isBlacklisted(this.context.getFilter()) ) {
+				ResolvedSchemaChange resolved = change.resolve(updatedSchema);
+				if ( resolved != null ) {
+					resolved.apply(updatedSchema);
+
+					resolvedSchemaChanges.add(resolved);
+				}
+			} else {
+				LOGGER.debug("ignoring blacklisted schema change");
+			}
+		}
+
+		if ( resolvedSchemaChanges.size() > 0 ) {
+			LOGGER.info("storing schema @" + position + " after applying \"" + sql.replace('\n', ' ') + "\"");
+
+			try {
+				saveSchema(updatedSchema, resolvedSchemaChanges, position);
+			} catch (SQLException e) {
+				throw new SchemaStoreException(e);
+			}
+		}
+		return resolvedSchemaChanges;
+	}
+
+	private void saveSchema(Schema updatedSchema, List<ResolvedSchemaChange> changes, BinlogPosition p) throws SQLException {
+		/* TODO: replay mode should trigger a null schema-store */
+		if ( this.context.getReplayMode() )
+			return;
+
+		try (Connection c = this.context.getMaxwellConnection()) {
+			this.savedSchema = this.savedSchema.createDerivedSchema(updatedSchema, p, changes);
+			this.savedSchema.save(c);
+		}
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
-import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 public class SchemaCapturer {
 	private final Connection connection;
@@ -45,10 +44,9 @@ public class SchemaCapturer {
 		this.includeDatabases.add(dbName);
 	}
 
-	public Schema capture() throws SQLException, InvalidSchemaError {
+	public Schema capture() throws SQLException {
 		LOGGER.debug("Capturing schema");
 		ArrayList<Database> databases = new ArrayList<>();
-
 
 		ResultSet rs = connection.createStatement().executeQuery("SELECT * from INFORMATION_SCHEMA.SCHEMATA");
 
@@ -81,7 +79,7 @@ public class SchemaCapturer {
 			+ "JOIN  information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS CCSA"
 			+ " ON TABLES.TABLE_COLLATION = CCSA.COLLATION_NAME WHERE TABLES.TABLE_SCHEMA = ?";
 
-	private Database captureDatabase(String dbName, String dbCharset) throws SQLException, InvalidSchemaError {
+	private Database captureDatabase(String dbName, String dbCharset) throws SQLException {
 		PreparedStatement p = connection.prepareStatement(tblSQL);
 
 		p.setString(1, dbName);
@@ -98,7 +96,7 @@ public class SchemaCapturer {
 	}
 
 
-	private void captureTable(Table t) throws SQLException, InvalidSchemaError {
+	private void captureTable(Table t) throws SQLException {
 		int i = 0;
 		infoSchemaStmt.setString(1, t.getDatabase());
 		infoSchemaStmt.setString(2, t.getName());
@@ -131,7 +129,7 @@ public class SchemaCapturer {
 			"SELECT column_name, ordinal_position from information_schema.key_column_usage  "
 	      + "WHERE constraint_name = 'PRIMARY' and table_schema = ? and table_name = ?";
 
-	private void captureTablePK(Table t) throws SQLException, InvalidSchemaError {
+	private void captureTablePK(Table t) throws SQLException {
 		PreparedStatement p = connection.prepareStatement(pkSQL);
 		p.setString(1, t.getDatabase());
 		p.setString(2, t.getName());

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -1,0 +1,30 @@
+package com.zendesk.maxwell.schema;
+
+import com.zendesk.maxwell.BinlogPosition;
+import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+
+import java.util.List;
+
+public interface SchemaStore {
+	/**
+	 * Retrieve the current schema
+	 *
+	 * If no Stored schema is found, this method should capture and save a snapshot
+	 * of the current mysql schema.
+	 * @return The schema, either retrieved from storage or captured.
+	 */
+	Schema getSchema() throws SchemaStoreException;
+
+	/**
+	 * Process a DDL statement
+	 *
+	 * Parse the given SQL, applying the changes to the schema.  Returns
+	 * a list of ResolvedSchemaChange objects, representing the DDL that was applied (if any)
+	 * @param sql The SQL of the DDL statement
+	 * @param currentDatabase The "contextual database" of the DDL statement
+	 * @param position The position of the DDL statement
+	 * @return A list of the schema changes parsed from the SQL.
+	 */
+	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+}

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreException.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreException.java
@@ -1,0 +1,7 @@
+package com.zendesk.maxwell.schema;
+
+public class SchemaStoreException extends Exception {
+	public SchemaStoreException (String message) { super(message); }
+	public SchemaStoreException (Exception e) { super(e); }
+	private static final long serialVersionUID = 1L;
+}

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -334,7 +334,7 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 
 		lowerCaseServer.boot("--lower-case-table-names=1");
-		MaxwellContext context = MaxwellTestSupport.buildContext(lowerCaseServer.getPort(), null);
+		MaxwellContext context = MaxwellTestSupport.buildContext(lowerCaseServer.getPort(), null, null);
 		SchemaStoreSchema.ensureMaxwellSchema(lowerCaseServer.getConnection(), context.getConfig().databaseName);
 
 		String[] sql = {

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -33,10 +33,10 @@ public class MaxwellTestWithIsolatedServer {
 	}
 
 	protected MaxwellContext buildContext() {
-		return MaxwellTestSupport.buildContext(server.getPort(), null);
+		return MaxwellTestSupport.buildContext(server.getPort(), null, null);
 	}
 
 	protected MaxwellContext buildContext(BinlogPosition p) {
-		return MaxwellTestSupport.buildContext(server.getPort(), p);
+		return MaxwellTestSupport.buildContext(server.getPort(), p, null);
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -44,7 +44,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 	public void testSave() throws SQLException, IOException, InvalidSchemaError {
 		this.savedSchema.save(context.getMaxwellConnection());
 
-		MysqlSavedSchema restoredSchema = MysqlSavedSchema.restore(context.getMaxwellConnection(), context);
+		MysqlSavedSchema restoredSchema = MysqlSavedSchema.restore(context, context.getInitialPosition());
 		List<String> diff = this.schema.diff(restoredSchema.getSchema(), "captured schema", "restored schema");
 		assertThat(StringUtils.join(diff, "\n"), diff.size(), is(0));
 	}
@@ -53,7 +53,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 	public void testRestorePK() throws Exception {
 		this.savedSchema.save(context.getMaxwellConnection());
 
-		MysqlSavedSchema restoredSchema = MysqlSavedSchema.restore(context.getMaxwellConnection(), context);
+		MysqlSavedSchema restoredSchema = MysqlSavedSchema.restore(context, context.getInitialPosition());
 		Table t = restoredSchema.getSchema().findDatabase("shard_1").findTable("pks");
 
 		assertThat(t.getPKList(), is(not(nullValue())));
@@ -94,7 +94,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 		c.createStatement().executeUpdate("update maxwell.schemas set version = 0 where id = " + this.savedSchema.getSchemaID());
 		c.createStatement().executeUpdate("update maxwell.columns set is_signed = 1 where name = 'badcol'");
 
-		MysqlSavedSchema restored = MysqlSavedSchema.restore(context.getMaxwellConnection(), context);
+		MysqlSavedSchema restored = MysqlSavedSchema.restore(context, context.getInitialPosition());
 		IntColumnDef cd = (IntColumnDef) restored.getSchema().findDatabase("shard_1").findTable("signed").findColumn("badcol");
 		assertThat(cd.isSigned(), is(false));
 	}

--- a/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
+++ b/src/test/java/com/zendesk/maxwell/TestMaxwellReplicator.java
@@ -3,7 +3,7 @@ package com.zendesk.maxwell;
 import com.google.code.or.binlog.BinlogEventV4;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
-import com.zendesk.maxwell.schema.MysqlSavedSchema;
+import com.zendesk.maxwell.schema.SchemaStore;
 
 import java.util.concurrent.TimeUnit;
 
@@ -14,13 +14,13 @@ public class TestMaxwellReplicator extends MaxwellReplicator {
 	private final BinlogPosition stopAt;
 	private boolean shouldStop;
 
-	public TestMaxwellReplicator(MysqlSavedSchema savedSchema,
+	public TestMaxwellReplicator(SchemaStore schemaStore,
 								 AbstractProducer producer,
 								 AbstractBootstrapper bootstrapper,
 								 MaxwellContext ctx,
 								 BinlogPosition start,
 								 BinlogPosition stop) throws Exception {
-		super(savedSchema, producer, bootstrapper, ctx, start);
+		super(schemaStore, producer, bootstrapper, ctx, start);
 		LOGGER.debug("TestMaxwellReplicator initialized from " + start + " to " + stop);
 		this.stopAt = stop;
 	}


### PR DESCRIPTION
This is the final resting place of https://github.com/zendesk/maxwell/pull/356.  It removes direct responsibility for Schema processing from MaxwellReplicator, which instead delegates the work of processing SQL changes and storing updates to the `SchemaStore` interface. 

This is done with an eye towards multiple consumers in the same JVM.

@zendesk/rules 