### PR TITLE
#362: preserve case of columns as they came in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
       <version>5.1.39</version>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -1,7 +1,7 @@
 package com.zendesk.maxwell;
 
 import java.util.ArrayList;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import joptsimple.OptionSet;
 

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -105,7 +105,7 @@ public class RowMap implements Serializable {
 				if ( data.containsKey(pk) )
 					pkValue = data.get(pk);
 
-				g.writeObjectField("pk." + pk, pkValue);
+				g.writeObjectField("pk." + pk.toLowerCase(), pkValue);
 			}
 		}
 
@@ -128,7 +128,7 @@ public class RowMap implements Serializable {
 				pkValue = data.get(pk);
 
 			g.writeStartObject();
-			g.writeObjectField(pk, pkValue);
+			g.writeObjectField(pk.toLowerCase(), pkValue);
 			g.writeEndObject();
 		}
 		g.writeEndArray();

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.schema.columndef.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class MysqlSavedSchema {
-	static int SchemaStoreVersion = 1;
+	static int SchemaStoreVersion = 2;
 
 	private Schema schema;
 	private BinlogPosition position;

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -499,9 +499,11 @@ public class MysqlSavedSchema {
 			/* A little explanation here: we've detected differences in signed-ness between the restored
 			 * and the recaptured schema.  99.9% of the time this will be the result of our capture bug.
 			 *
-			 * We can't however simply re-save the re-captured schema, as we might be behind some DDL updates
-			 * that we'd otherwise lose.  So we leave a marker so that the next time we save the schema, we'll
-			 * purposely break the delta chain and fix the unsigned columns in the database.
+			 * We can't however simply re-save the re-captured schema, as the
+			 * capture might be ahead of some DDL updates that we'd otherwise
+			 * lose.  So we leave a marker so that the next time we save the
+			 * schema, we'll purposely break the delta chain and fix the
+			 * unsigned columns in the database.
 			 * */
 			this.shouldSnapshotNextSchema = true;
 		}
@@ -515,7 +517,7 @@ public class MysqlSavedSchema {
 			ColumnDef cB = pair.getRight();
 
 			if ( !cA.getName().equals(cB.getName()) ) {
-				LOGGER.info("correcting name of `" + cA.getName() + "` to `" + cB.getName() + "`");
+				LOGGER.info("correcting column case of `" + cA.getName() + "` to `" + cB.getName() + "`.  Will save a full schema snapshot after the new DDL update is processed.");
 				caseDiffs++;
 				cA.setName(cB.getName());
 			}

--- a/src/main/java/com/zendesk/maxwell/schema/Schema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Schema.java
@@ -1,7 +1,9 @@
 package com.zendesk.maxwell.schema;
 
 import com.zendesk.maxwell.CaseSensitivity;
+import com.zendesk.maxwell.schema.columndef.ColumnDef;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,4 +93,29 @@ public class Schema {
 	public CaseSensitivity getCaseSensitivity() {
 		return sensitivity;
 	};
+
+	public List<Pair<ColumnDef, ColumnDef>> matchColumns(Schema thatSchema) {
+		ArrayList<Pair<ColumnDef, ColumnDef>> list = new ArrayList<>();
+
+		for ( Database thisDatabase : this.getDatabases() ) {
+			Database thatDatabase = thatSchema.findDatabase(thisDatabase.getName());
+
+			if ( thatDatabase == null )
+				continue;
+
+			for ( Table thisTable : thisDatabase.getTableList() ) {
+				Table thatTable = thatDatabase.findTable(thisTable.getName());
+
+				if ( thatTable == null )
+					continue;
+
+				for ( ColumnDef thisColumn : thisTable.getColumnList() ) {
+					ColumnDef thatColumn = thatTable.findColumn(thisColumn.getName());
+					if ( thatColumn != null )
+						list.add(Pair.of(thisColumn, thatColumn));
+				}
+			}
+		}
+		return list;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.zendesk.maxwell.CaseSensitivity;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -11,7 +11,7 @@ import java.io.InputStreamReader;
 import java.io.BufferedReader;
 import java.io.IOException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -20,6 +20,7 @@ public class Table {
 	private List<ColumnDef> columnList;
 	public String charset;
 	private List<String> pkColumnNames;
+	private List<String> normalizedPKColumnNames;
 
 	private HashMap<String, Integer> columnOffsetMap;
 	@JsonIgnore
@@ -71,7 +72,7 @@ public class Table {
 		int i = 0;
 
 		for(ColumnDef c : columnList) {
-			this.columnOffsetMap.put(c.getName(), i++);
+			this.columnOffsetMap.put(c.getName().toLowerCase(), i++);
 		}
 	}
 
@@ -87,14 +88,11 @@ public class Table {
 	}
 
 	public ColumnDef findColumn(String name) {
-		String lcName = name.toLowerCase();
-
-		for (ColumnDef c : columnList )  {
-			if ( c.getName().equals(lcName) )
-				return c;
-		}
-
-		return null;
+		int index = findColumnIndex(name);
+		if ( index == -1 )
+			return null;
+		else
+			return columnList.get(index);
 	}
 
 	public ColumnDef findColumnOrThrow(String name) throws InvalidSchemaError {
@@ -232,8 +230,11 @@ public class Table {
 	}
 
 	public void removeColumn(int idx) {
+		removePKColumn(columnList.get(idx).getName());
+
 		this.columnList.remove(idx);
 		this.columnOffsetMap = null;
+
 		renumberColumns();
 	}
 
@@ -247,7 +248,7 @@ public class Table {
 
 	@JsonProperty("primary-key")
 	public List<String> getPKList() {
-		return this.pkColumnNames;
+		return normalizedColumnNames();
 	}
 
 	@JsonIgnore
@@ -259,9 +260,40 @@ public class Table {
 	}
 
 	@JsonProperty("primary-key")
-	public void setPKList(List<String> pkColumnNames) {
-		this.pkColumnNames = new ArrayList<>();
-		for ( String c : pkColumnNames )
-			this.pkColumnNames.add(c.toLowerCase());
+	public synchronized void setPKList(List<String> pkColumnNames) {
+		this.pkColumnNames = pkColumnNames;
+		this.normalizedPKColumnNames = null;
+	}
+
+	private synchronized void removePKColumn(String name) {
+		int pkIndex = getPKList().indexOf(name);
+		if ( pkIndex != -1 ) {
+			this.pkColumnNames.remove(pkIndex);
+			this.normalizedPKColumnNames = null;
+		}
+	}
+
+	private synchronized List<String> normalizedColumnNames() {
+		/*
+		   primary keys may come in with different casing than the column names.
+		   convert the list of primary keys to match the column casing.
+
+		   we do this normalization lazily, as when a Table object is being deserialized
+		   from JSON, there may be no column definitions present when the setPKList() function is called.
+		   ugly!
+		 */
+		if ( this.normalizedPKColumnNames == null ) {
+			this.normalizedPKColumnNames = new ArrayList<>(this.pkColumnNames.size());
+
+			for (String name : pkColumnNames) {
+				ColumnDef cd = findColumn(name);
+
+				if ( cd == null )
+					throw new RuntimeException("Couldn't find column for primary-key: " + name);
+
+				this.normalizedPKColumnNames.add(cd.getName());
+			}
+		}
+		return this.normalizedPKColumnNames;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -5,7 +5,7 @@ import java.util.*;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 
 import com.zendesk.maxwell.schema.columndef.EnumeratedColumnDef;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 import com.zendesk.maxwell.schema.columndef.StringColumnDef;

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -14,7 +14,7 @@ public abstract class ColumnDef {
 
 	public ColumnDef() { }
 	public ColumnDef(String name, String type, int pos) {
-		this.name = name.toLowerCase();
+		this.name = name;
 		this.type = type;
 		this.pos = pos;
 	}
@@ -162,6 +162,10 @@ public abstract class ColumnDef {
 			default:
 				return type;
 		}
+	}
+
+	public void setName(String name) {
+		this.name = name;
 	}
 
 	public String getName() {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
@@ -3,7 +3,7 @@ package com.zendesk.maxwell.schema.columndef;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.google.code.or.common.util.MySQLConstants;
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -4,7 +4,6 @@ import java.nio.charset.Charset;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang.StringEscapeUtils;
 
 import com.google.code.or.common.util.MySQLConstants;
 
@@ -81,7 +80,7 @@ public class StringColumnDef extends ColumnDef {
 	}
 
 	private String quoteString(String s) {
-		String escaped = StringEscapeUtils.escapeSql(s);
+		String escaped = s.replaceAll("'", "''");
 		escaped = escaped.replaceAll("\n", "\\\\n");
 		escaped = escaped.replaceAll("\r", "\\\\r");
 		return "'" + escaped + "'";

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -378,6 +378,11 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		runJSON("/json/test_gis");
 	}
 
+	@Test
+	public void testColumnCase() throws Exception {
+		runJSON("/json/test_column_case");
+	}
+
 	static String[] createDBSql = {
 			"CREATE database if not exists `foo`",
 			"CREATE TABLE if not exists `foo`.`ordered_output` ( id int, account_id int, user_id int )"

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -2,7 +2,7 @@ package com.zendesk.maxwell;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.List;
 import java.util.regex.*;

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestJSON.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestJSON.java
@@ -6,7 +6,7 @@ import java.io.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -10,7 +10,7 @@ import com.zendesk.maxwell.schema.MysqlSchemaStore;
 import com.zendesk.maxwell.schema.SchemaStoreSchema;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 import com.zendesk.maxwell.schema.ddl.SchemaChange;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.nio.file.Files;

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -2,7 +2,7 @@ package com.zendesk.maxwell;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 import java.sql.Connection;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/zendesk/maxwell/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaCaptureTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.*;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/resources/sql/json/test_column_case
+++ b/src/test/resources/sql/json/test_column_case
@@ -1,0 +1,5 @@
+create database case_columns;
+use case_columns;
+create table case_columns.test_case(ID int(10) unsigned not null auto_increment primary key, bar_FIELD varchar(255));
+insert into test_case set bar_field='bar';
+  -> {database:"case_columns", table: "test_case", type: "insert", data: {"ID": 1, "bar_FIELD": "bar"}}


### PR DESCRIPTION
Instead of downcasing all fields as they come in, preserve the original casing of the field, only doing case-insensitive compares on lookup.

primary keys stay downcased; it's probably better to keep kafka keys static than to preserve original casing there.

@zendesk/rules 

note: some sections best viewed with `?w=1`