### PR TITLE
Fixes for #373 and beyond

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -63,7 +63,8 @@ public class MaxwellReplicator extends RunLoopProcess {
 
 		this.replicator.setLevel2BufferSize(50 * 1024 * 1024);
 
-		this.replicator.setHeartbeatPeriod(0.5f);
+		if ( ctx.shouldHeartbeat() )
+			this.replicator.setHeartbeatPeriod(0.5f);
 
 		this.producer = producer;
 		this.bootstrapper = bootstrapper;
@@ -87,11 +88,13 @@ public class MaxwellReplicator extends RunLoopProcess {
 			replicator.start();
 		}
 
-		Long ms = replicator.millisSinceLastEvent();
-		if ( ms != null && ms > 2000 ) {
-			LOGGER.warn("no heartbeat heard from server in " + ms + "ms.  restarting replication.");
-			replicator.stop(5, TimeUnit.SECONDS);
-			replicator.start();
+		if ( context.shouldHeartbeat() ) {
+			Long ms = replicator.millisSinceLastEvent();
+			if (ms != null && ms > 2000) {
+				LOGGER.warn("no heartbeat heard from server in " + ms + "ms.  restarting replication.");
+				replicator.stop(5, TimeUnit.SECONDS);
+				replicator.start();
+			}
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -206,7 +206,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 				continue;
 			}
 
-			setReplicatorPosition((AbstractRowEvent) v4Event);
+			setReplicatorPosition((AbstractBinlogEventV4) v4Event);
 
 			switch(v4Event.getHeader().getEventType()) {
 				case MySQLConstants.WRITE_ROWS_EVENT:

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -206,6 +206,8 @@ public class MaxwellReplicator extends RunLoopProcess {
 				continue;
 			}
 
+			setReplicatorPosition((AbstractRowEvent) v4Event);
+
 			switch(v4Event.getHeader().getEventType()) {
 				case MySQLConstants.WRITE_ROWS_EVENT:
 				case MySQLConstants.WRITE_ROWS_EVENT_V2:
@@ -224,8 +226,6 @@ public class MaxwellReplicator extends RunLoopProcess {
 						for ( RowMap r : event.jsonMaps() )
 							buffer.add(r);
 					}
-
-					setReplicatorPosition(event);
 
 					break;
 				case MySQLConstants.TABLE_MAP_EVENT:


### PR DESCRIPTION
Primarily this fixes #373 by disabling heartbeating on 5.1, but I also found and fixed a separate issue, where we were dumbly rewinding the replicator position after the call to `getTransactionRows` had pushed it forward; see the two separate commits in this PR if you want to see the issues separately.

@zendesk/rules 

