### PR TITLE
issue #380 -- support a bunch more character encodings

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
@@ -60,8 +61,11 @@ public class StringColumnDef extends ColumnDef {
 		case "ucs2":
 			return Charset.forName("UTF-16");
 		default:
-			LOGGER.warn("warning: unhandled character set '" + charset + "'");
-			return null;
+			try {
+				return Charset.forName(charset.toLowerCase());
+			} catch ( java.nio.charset.UnsupportedCharsetException e ) {
+				throw new RuntimeException("error: unhandled character set '" + charset + "'");
+			}
 		}
 	}
 	@Override

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -256,24 +256,19 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	public void testTransactionID() throws Exception {
 		List<RowMap> list;
 
-		try {
-			server.getConnection().setAutoCommit(false);
-			list = getRowsForSQL(testTransactions);
+		list = getRowsForSQLTransactional(testTransactions);
 
-			assertEquals(4, list.size());
-			for ( RowMap r : list ) {
-				assertNotNull(r.getXid());
-			}
-
-			assertEquals(list.get(0).getXid(), list.get(1).getXid());
-			assertFalse(list.get(0).isTXCommit());
-			assertTrue(list.get(1).isTXCommit());
-
-			assertFalse(list.get(2).isTXCommit());
-			assertTrue(list.get(3).isTXCommit());
-		} finally {
-			server.getConnection().setAutoCommit(true);
+		assertEquals(4, list.size());
+		for ( RowMap r : list ) {
+			assertNotNull(r.getXid());
 		}
+
+		assertEquals(list.get(0).getXid(), list.get(1).getXid());
+		assertFalse(list.get(0).isTXCommit());
+		assertTrue(list.get(1).isTXCommit());
+
+		assertFalse(list.get(2).isTXCommit());
+		assertTrue(list.get(3).isTXCommit());
 	}
 
 	@Test
@@ -342,7 +337,7 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 			"insert into `test`.`tootootwee` set id = 5"
 		};
 
-		List<RowMap> rows = MaxwellTestSupport.getRowsForSQL(lowerCaseServer, null, sql, null);
+		List<RowMap> rows = MaxwellTestSupport.getRowsForSQL(lowerCaseServer, null, sql, null, false);
 		assertThat(rows.size(), is(1));
 		assertThat(rows.get(0).getTable(), is("tootootwee"));
 	}
@@ -371,6 +366,11 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testUCS2() throws Exception {
 		runJSON("/json/test_ucs2");
+	}
+
+	@Test
+	public void testCharsets() throws Exception {
+		runJSON("/json/test_charsets");
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -92,7 +92,7 @@ public class MaxwellTestSupport {
 		mysql.getConnection().prepareStatement("delete from `maxwell`.`schemas`").execute();
 	}
 
-	public static List<RowMap>getRowsForSQL(final MysqlIsolatedServer mysql, MaxwellFilter filter, String queries[], String before[]) throws Exception {
+	public static List<RowMap>getRowsForSQL(final MysqlIsolatedServer mysql, MaxwellFilter filter, String queries[], String before[], boolean transactional) throws Exception {
 		MaxwellContext context = buildContext(mysql.getPort(), null, filter);
 
 		clearSchemaStore(mysql);
@@ -107,7 +107,13 @@ public class MaxwellTestSupport {
 		MysqlSchemaStore schemaStore = new MysqlSchemaStore(context);
 		schemaStore.getSchema();
 
+		if ( transactional )
+			mysql.getConnection().setAutoCommit(false);
+
 		mysql.executeList(Arrays.asList(queries));
+
+		if ( transactional )
+			mysql.getConnection().setAutoCommit(true);
 
 		BinlogPosition endPosition = BinlogPosition.capture(mysql.getConnection());
 
@@ -191,6 +197,6 @@ public class MaxwellTestSupport {
 
 
 	public static  List<RowMap>getRowsForSQL(MysqlIsolatedServer server, MaxwellFilter filter, String queries[]) throws Exception {
-		return getRowsForSQL(server, filter, queries, null);
+		return getRowsForSQL(server, filter, queries, null, false);
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -22,12 +22,17 @@ public class MaxwellTestWithIsolatedServer {
 	}
 
 	protected List<RowMap> getRowsForSQL(MaxwellFilter filter, String[] input, String[] before) throws Exception {
-		return MaxwellTestSupport.getRowsForSQL(server, filter, input, before);
+		return MaxwellTestSupport.getRowsForSQL(server, filter, input, before, false);
 	}
 
 	protected List<RowMap> getRowsForSQL(String[] input) throws Exception {
-		return MaxwellTestSupport.getRowsForSQL(server, null, input, null);
+		return MaxwellTestSupport.getRowsForSQL(server, null, input, null, false);
 	}
+
+	protected List<RowMap> getRowsForSQLTransactional(String[] input) throws Exception {
+		return MaxwellTestSupport.getRowsForSQL(server, null, input, null, true);
+	}
+
 	protected void runJSON(String filename) throws Exception {
 		MaxwellTestJSON.runJSONTestFile(server, filename);
 	}

--- a/src/test/resources/sql/json/test_charsets
+++ b/src/test/resources/sql/json/test_charsets
@@ -1,0 +1,4 @@
+CREATE DATABASE `test_charsets`
+create table `test_charsets`.`c` ( gbk varchar(255) charset 'gbk', big5 varchar(255) charset 'big5' )
+insert into `test_charsets`.`c` set `gbk` = '乪', `big5` = '圖形碼';
+-> {"database": "test_charsets", "table": "c", "type": "insert", "data": {"gbk": "乪", "big5": "圖形碼"} }


### PR DESCRIPTION
those mysql encodings that just naturally line up with java's, we support.

@zendesk/rules