### PR TITLE
stop trying to be clever about exceptions

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -43,14 +43,10 @@ class KafkaCallback implements Callback {
 	@Override
 	public void onCompletion(RecordMetadata md, Exception e) {
 		if ( e != null ) {
+			LOGGER.error(e.getClass().getSimpleName() + " @ " + position + " -- " + key);
+			LOGGER.error(e.getLocalizedMessage());
 			if ( e instanceof RecordTooLargeException ) {
-				LOGGER.error("RecordTooLargeException @ " + position + " -- " + key);
-				LOGGER.error(e.getLocalizedMessage());
 				LOGGER.error("Considering raising max.request.size broker-side.");
-
-				markCompleted();
-			} else {
-				throw new RuntimeException(e);
 			}
 		} else {
 			if ( LOGGER.isDebugEnabled()) {
@@ -59,9 +55,8 @@ class KafkaCallback implements Callback {
 				LOGGER.debug("   " + position);
 				LOGGER.debug("");
 			}
-
-			markCompleted();
 		}
+		markCompleted();
 	}
 
 	private void markCompleted() {


### PR DESCRIPTION
the original intention of throwing RuntimeException was to crash
maxwell, but that's not what happened.  What happened was that the kafka
producer ended up eating the error, leaving us in a state where we were
keeping endless amounts of InflightMessage objects, as well as not
advancing the binlog poisition.

@zendesk/rules
