### PR TITLE
fix parsing issue for CHARSET ASCII

### DIFF
--- a/src/main/antlr4/imports/mysql_idents.g4
+++ b/src/main/antlr4/imports/mysql_idents.g4
@@ -21,7 +21,7 @@ string_literal: (STRING_LITERAL | DBL_STRING_LITERAL);
 
 string: (IDENT | STRING_LITERAL);
 integer: INTEGER_LITERAL;
-charset_name: (IDENT | string_literal | QUOTED_IDENT | BINARY);
+charset_name: (IDENT | string_literal | QUOTED_IDENT | BINARY | ASCII);
 
 default_character_set: DEFAULT? charset_token '='? charset_name collation?;
 default_collation: DEFAULT? collation;

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -39,8 +39,8 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 			"alter table shard_2.weird_rename rename to lowball", // renames to shard_1.lowball
 
 			"create table shard_1.testDrop ( id int(11) )",
-			"drop table shard_1.testDrop"
-
+			"drop table shard_1.testDrop",
+			"create table test.c ( v varchar(255) charset ascii )"
 		};
 		testIntegration(sql);
 	}


### PR DESCRIPTION
"ASCII" here, if unquoted, was coming in as the ASCII token rather than becoming part of `charset_name`.

@zendesk/rules