### PR TITLE
(master-recovery part 4) two refactors

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -32,7 +32,7 @@ public class Maxwell {
 		this.context.probeConnections();
 
 		try ( Connection connection = this.context.getReplicationConnection();
-			  Connection rawConnection = this.context.getMaxwellConnectionWithoutDatabase() ) {
+			  Connection rawConnection = this.context.getRawMaxwellConnection() ) {
 			MaxwellMysqlStatus.ensureReplicationMysqlState(connection);
 			MaxwellMysqlStatus.ensureMaxwellMysqlState(rawConnection);
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -188,6 +188,8 @@ public class MaxwellConfig extends AbstractConfig {
 		this.replicationMysql   = parseMysqlConfig("replication_", options, properties);
 
 		this.databaseName       = fetchOption("schema_database", options, properties, "maxwell");
+		this.maxwellMysql.database = this.databaseName;
+
 		this.producerType       = fetchOption("producer", options, properties, "stdout");
 		this.bootstrapperType   = fetchOption("bootstrapper", options, properties, "async");
 		this.clientID           = fetchOption("client_id", options, properties, "maxwell");
@@ -310,10 +312,13 @@ public class MaxwellConfig extends AbstractConfig {
 				usageForOptions("Please specify all of: replication_host, replication_user, replication_password", "--replication");
 			}
 
-			this.replicationMysql = new MaxwellMysqlConfig(this.maxwellMysql.host,
-									this.maxwellMysql.port,
-									this.maxwellMysql.user,
-									this.maxwellMysql.password);
+			this.replicationMysql = new MaxwellMysqlConfig(
+				this.maxwellMysql.host,
+				this.maxwellMysql.port,
+				null,
+				this.maxwellMysql.user,
+				this.maxwellMysql.password
+			);
 
 			this.replicationMysql.jdbcOptions = this.maxwellMysql.jdbcOptions;
 		}

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -27,7 +27,7 @@ public class MaxwellContext {
 
 	private final ConnectionPool replicationConnectionPool;
 	private final ConnectionPool maxwellConnectionPool;
-	private final ConnectionPool maxwellConnectionPoolWithoutDatabase;
+	private final ConnectionPool rawMaxwellConnectionPool;
 	private final MaxwellConfig config;
 	private PositionStoreThread positionStoreThread;
 	private Long serverID;
@@ -43,7 +43,7 @@ public class MaxwellContext {
 		this.replicationConnectionPool = new ConnectionPool("ReplicationConnectionPool", 10, 0, 10,
 				config.replicationMysql.getConnectionURI(), config.replicationMysql.user, config.replicationMysql.password);
 
-		this.maxwellConnectionPoolWithoutDatabase = new ConnectionPool("MaxellConnectionPoolWithoutDatabase", 1, 2, 100,
+		this.rawMaxwellConnectionPool = new ConnectionPool("RawMaxwellConenectionPool", 1, 2, 100,
 			config.maxwellMysql.getConnectionURI(false), config.maxwellMysql.user, config.maxwellMysql.password);
 
 		this.maxwellConnectionPool = new ConnectionPool("MaxwellConnectionPool", 10, 0, 10,
@@ -63,10 +63,14 @@ public class MaxwellContext {
 	}
 
 	public ConnectionPool getReplicationConnectionPool() { return replicationConnectionPool; }
-	public ConnectionPool getMaxwellConnectionPool() { return this.maxwellConnectionPool; }
+	public ConnectionPool getMaxwellConnectionPool() { return maxwellConnectionPool; }
 
 	public Connection getMaxwellConnection() throws SQLException {
 		return this.maxwellConnectionPool.getConnection();
+	}
+
+	public Connection getRawMaxwellConnection() throws SQLException {
+		return rawMaxwellConnectionPool.getConnection();
 	}
 
 	public void start() {

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -29,10 +29,12 @@ public class MaxwellContext {
 	private final ConnectionPool maxwellConnectionPool;
 	private final ConnectionPool rawMaxwellConnectionPool;
 	private final MaxwellConfig config;
+	private MysqlPositionStore positionStore;
 	private PositionStoreThread positionStoreThread;
 	private Long serverID;
 	private BinlogPosition initialPosition;
 	private CaseSensitivity caseSensitivity;
+	private AbstractProducer producer;
 
 	private Integer mysqlMajorVersion;
 	private Integer mysqlMinorVersion;
@@ -41,9 +43,9 @@ public class MaxwellContext {
 		this.config = config;
 
 		this.replicationConnectionPool = new ConnectionPool("ReplicationConnectionPool", 10, 0, 10,
-				config.replicationMysql.getConnectionURI(), config.replicationMysql.user, config.replicationMysql.password);
+				config.replicationMysql.getConnectionURI(false), config.replicationMysql.user, config.replicationMysql.password);
 
-		this.rawMaxwellConnectionPool = new ConnectionPool("RawMaxwellConenectionPool", 1, 2, 100,
+		this.rawMaxwellConnectionPool = new ConnectionPool("RawMaxwellConnectionPool", 1, 2, 100,
 			config.maxwellMysql.getConnectionURI(false), config.maxwellMysql.user, config.maxwellMysql.password);
 
 		this.maxwellConnectionPool = new ConnectionPool("MaxwellConnectionPool", 10, 0, 10,
@@ -246,7 +248,7 @@ public class MaxwellContext {
 	}
 
 	public void probeConnections() throws SQLException {
-		probePool(this.maxwellConnectionPool, this.config.maxwellMysql.getConnectionURI());
+		probePool(this.rawMaxwellConnectionPool, this.config.maxwellMysql.getConnectionURI(false));
 
 		if ( this.maxwellConnectionPool != this.replicationConnectionPool )
 			probePool(this.replicationConnectionPool, this.config.replicationMysql.getConnectionURI());

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -12,6 +12,7 @@ public class MaxwellMysqlConfig {
 
 	public String host;
 	public Integer port;
+	public String database;
 	public String user;
 	public String password;
 	public ArrayList<String> jdbcOptions = new ArrayList<String>();
@@ -19,13 +20,15 @@ public class MaxwellMysqlConfig {
 	public MaxwellMysqlConfig() {
 		this.host = null;
 		this.port = null;
+		this.database = null;
 		this.user = null;
 		this.password = null;
 	}
 
-	public MaxwellMysqlConfig(String host, Integer port, String user, String password) {
+	public MaxwellMysqlConfig(String host, Integer port, String database, String user, String password) {
 		this.host = host;
 		this.port = port;
+		this.database = database;
 		this.user = user;
 		this.password = password;
 	}
@@ -41,10 +44,15 @@ public class MaxwellMysqlConfig {
 		}
 	}
 
-	public String getConnectionURI() {
-		return "jdbc:mysql://" + host + ":" + port + "?" +
-				StringUtils.join(this.jdbcOptions.toArray(), "&");
+	public String getConnectionURI(boolean includeDatabase) {
+		String uri = "jdbc:mysql://" + host + ":" + port;
+		if (database != null && includeDatabase )
+			uri += "/" + database;
+		uri += "?" + StringUtils.join(this.jdbcOptions.toArray(), "&");
+		return uri;
 	}
+
+	public String getConnectionURI() { return getConnectionURI(true); }
 
 	@Override
 	public boolean equals(Object obj) {

--- a/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
@@ -20,7 +20,7 @@ import snaq.db.ConnectionPool;
 public abstract class AbstractSchemaStore {
 	static final Logger LOGGER = LoggerFactory.getLogger(AbstractSchemaStore.class);
 	private final ConnectionPool replicationConnectionPool;
-	private final CaseSensitivity caseSensitivity;
+	protected final CaseSensitivity caseSensitivity;
 	private final MaxwellFilter filter;
 
 	protected AbstractSchemaStore(ConnectionPool replicationConnectionPool,

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -16,14 +16,12 @@ import snaq.db.ConnectionPool;
 public class MysqlPositionStore {
 	static final Logger LOGGER = LoggerFactory.getLogger(MysqlPositionStore.class);
 	private final Long serverID;
-	private String schemaDatabaseName;
 	private String clientID;
 	private final ConnectionPool connectionPool;
 
-	public MysqlPositionStore(ConnectionPool pool, Long serverID, String dbName, String clientID) {
+	public MysqlPositionStore(ConnectionPool pool, Long serverID, String clientID) {
 		this.connectionPool = pool;
 		this.serverID = serverID;
-		this.schemaDatabaseName = dbName;
 		this.clientID = clientID;
 	}
 
@@ -44,10 +42,10 @@ public class MysqlPositionStore {
 				+ lastHeartbeatSQL
 				+ "binlog_file = ?, binlog_position=?";
 
-		try( Connection c = getConnection() ){
+		try( Connection c = connectionPool.getConnection() ){
 			PreparedStatement s = c.prepareStatement(sql);
 
-			LOGGER.debug("Writing binlog position to " + this.schemaDatabaseName + ".positions: " + newPosition);
+			LOGGER.debug("Writing binlog position to " + c.getCatalog() + ".positions: " + newPosition);
 			s.setLong(1, serverID);
 			s.setString(2, newPosition.getFile());
 			s.setLong(3, newPosition.getOffset());
@@ -60,7 +58,7 @@ public class MysqlPositionStore {
 	}
 
 	public void heartbeat() throws Exception {
-		try ( Connection c = getConnection() ) {
+		try ( Connection c = connectionPool.getConnection() ) {
 			heartbeat(c);
 		}
 	}
@@ -115,7 +113,7 @@ public class MysqlPositionStore {
 	}
 
 	public BinlogPosition get() throws SQLException {
-		try ( Connection c = getConnection() ) {
+		try ( Connection c = connectionPool.getConnection() ) {
 			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? and client_id = ?");
 			s.setLong(1, serverID);
 			s.setString(2, clientID);
@@ -126,11 +124,5 @@ public class MysqlPositionStore {
 
 			return new BinlogPosition(rs.getLong("binlog_position"), rs.getString("binlog_file"));
 		}
-	}
-
-	private Connection getConnection() throws SQLException {
-		Connection conn = this.connectionPool.getConnection();
-		conn.setCatalog(this.schemaDatabaseName);
-		return conn;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -265,10 +265,12 @@ public class MysqlSavedSchema {
 		return restore(context.getMaxwellConnectionPool(), context.getServerID(), context.getCaseSensitivity(), context.getInitialPosition());
 	}
 
-	public static MysqlSavedSchema restore(ConnectionPool pool,
-										   Long serverID,
-										   CaseSensitivity caseSensitivity,
-										   BinlogPosition targetPosition) throws SQLException, InvalidSchemaError {
+	public static MysqlSavedSchema restore(
+		ConnectionPool pool,
+		Long serverID,
+		CaseSensitivity caseSensitivity,
+		BinlogPosition targetPosition
+	) throws SQLException, InvalidSchemaError {
 		try ( Connection conn = pool.getConnection() ) {
 			Long schemaID = findSchema(conn, targetPosition, serverID);
 			if (schemaID == null)

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -15,7 +15,6 @@ import java.util.List;
 public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore {
 	private final ConnectionPool maxwellConnectionPool;
 	private final BinlogPosition initialPosition;
-	private final CaseSensitivity caseSensitivity;
 	private final Long serverID;
 	private final boolean replayMode;
 
@@ -29,7 +28,6 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 							MaxwellFilter filter,
 							boolean replayMode) {
 		super(replicationConnectionPool, caseSensitivity, filter);
-		this.caseSensitivity = caseSensitivity;
 		this.serverID = serverID;
 		this.maxwellConnectionPool = maxwellConnectionPool;
 		this.initialPosition = initialPosition;

--- a/src/main/java/com/zendesk/maxwell/schema/ReadOnlyMysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ReadOnlyMysqlPositionStore.java
@@ -11,8 +11,8 @@ import java.util.concurrent.TimeoutException;
  * useful for "replay" mode.
  */
 public class ReadOnlyMysqlPositionStore extends MysqlPositionStore {
-	public ReadOnlyMysqlPositionStore(ConnectionPool pool, Long serverID, String dbName, String clientID) {
-		super(pool, serverID, dbName, clientID);
+	public ReadOnlyMysqlPositionStore(ConnectionPool pool, Long serverID, String clientID) {
+		super(pool, serverID, clientID);
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaScavenger.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaScavenger.java
@@ -15,17 +15,13 @@ public class SchemaScavenger extends RunLoopProcess implements Runnable {
 	static final Logger LOGGER = LoggerFactory.getLogger(SchemaScavenger.class);
 	private static final long MAX_ROWS_PER_SECOND = 500;
 	private final ConnectionPool connectionPool;
-	private final String schemaDatabaseName;
 
-	public SchemaScavenger(ConnectionPool pool, String dbName) {
+	public SchemaScavenger(ConnectionPool pool) {
 		this.connectionPool = pool;
-		this.schemaDatabaseName = dbName;
 	}
 
 	private Connection getConnection() throws SQLException {
-		Connection conn = this.connectionPool.getConnection();
-		conn.setCatalog(this.schemaDatabaseName);
-		return conn;
+		return this.connectionPool.getConnection();
 	}
 
 	private List<Long> getDeletedSchemas() throws SQLException {

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -41,9 +41,12 @@ public class SchemaStoreSchema {
 		BufferedReader r = new BufferedReader(new InputStreamReader(schemaSQL));
 		String sql = "", line;
 
-		connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS `" + schemaDatabaseName + "`");
-		if (!connection.getCatalog().equals(schemaDatabaseName))
-			connection.setCatalog(schemaDatabaseName);
+		if ( schemaDatabaseName != null ) {
+			connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS `" + schemaDatabaseName + "`");
+			if (!connection.getCatalog().equals(schemaDatabaseName))
+				connection.setCatalog(schemaDatabaseName);
+		}
+
 		while ((line = r.readLine()) != null) {
 			sql += line + "\n";
 		}
@@ -65,7 +68,7 @@ public class SchemaStoreSchema {
 		for the time being, when we detect other schemas we will simply wipe them down.
 		in the future, this is our moment to pick up where the master left off.
 	*/
-	public static void handleMasterChange(Connection c, Long serverID, String schemaDatabaseName) throws SQLException {
+	public static void handleMasterChange(Connection c, Long serverID) throws SQLException {
 		PreparedStatement s = c.prepareStatement(
 				"SELECT id from `schemas` WHERE server_id != ? and deleted = 0"
 		);
@@ -106,15 +109,15 @@ public class SchemaStoreSchema {
 		c.createStatement().execute(sql);
 	}
 
-	public static void upgradeSchemaStoreSchema(Connection c, String schemaDatabaseName) throws SQLException, IOException {
+	public static void upgradeSchemaStoreSchema(Connection c) throws SQLException, IOException {
 		if ( !getTableColumns("schemas", c).containsKey("deleted") ) {
 			performAlter(c, "alter table `schemas` add column deleted tinyint(1) not null default 0");
 		}
 
 		if ( !getMaxwellTables(c).contains("bootstrap") )  {
-			LOGGER.info("adding `" + schemaDatabaseName + "`.`bootstrap` to the schema.");
+			LOGGER.info("adding bootstrap tables to the maxwell schema.");
 			InputStream is = MysqlSavedSchema.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql");
-			executeSQLInputStream(c, is, schemaDatabaseName);
+			executeSQLInputStream(c, is, null);
 		}
 
 		if ( !getTableColumns("bootstrap", c).containsKey("total_rows") ) {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,6 +9,9 @@
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
+   <Logger name="snaq.db.ConnectionPool.RawMaxwellConnectionPool" level="off" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
    <Logger name="snaq.db.ConnectionPool.MaxwellConnectionPool" level="off" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -404,7 +404,7 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		String[] opts = {"--jdbc_options= netTimeoutForStreamingResults=123& profileSQL=true  ", "--host=no-soup-spoons"};
 		MaxwellConfig config = new MaxwellConfig(opts);
 		assertEquals(config.maxwellMysql.getConnectionURI(),
-				"jdbc:mysql://no-soup-spoons:3306?zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
+				"jdbc:mysql://no-soup-spoons:3306/maxwell?zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
 		assertEquals(config.replicationMysql.getConnectionURI(),
 				"jdbc:mysql://no-soup-spoons:3306?zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
 

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -91,7 +91,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 		Connection conn = context.getMaxwellConnection();
 		this.savedSchema.save(conn);
 
-		SchemaStoreSchema.handleMasterChange(conn, 123456L, dbName);
+		SchemaStoreSchema.handleMasterChange(conn, 123456L);
 
 		ResultSet rs = conn.createStatement().executeQuery("SELECT * from `schemas`");
 		assertThat(rs.next(), is(true));
@@ -133,6 +133,6 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 		c.createStatement().executeUpdate("alter table `maxwell`.`schemas` drop column deleted, " +
 				"drop column base_schema_id, drop column deltas, drop column version, drop column position_sha");
 		c.createStatement().executeUpdate("alter table maxwell.positions drop column client_id");
-		SchemaStoreSchema.upgradeSchemaStoreSchema(c, "maxwell"); // just verify no-crash.
+		SchemaStoreSchema.upgradeSchemaStoreSchema(c); // just verify no-crash.
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
+++ b/src/test/java/com/zendesk/maxwell/SchemaScavengerTest.java
@@ -35,7 +35,7 @@ public class SchemaScavengerTest extends MaxwellTestWithIsolatedServer {
 		this.binlogPosition = BinlogPosition.capture(server.getConnection());
         MaxwellContext context = buildContext();
 
-		this.scavenger = new SchemaScavenger(buildContext().getMaxwellConnectionPool(), context.getConfig().databaseName);
+		this.scavenger = new SchemaScavenger(buildContext().getMaxwellConnectionPool());
 		Connection conn = server.getConnection();
 		conn.setCatalog(context.getConfig().databaseName);
 		this.savedSchema = new MysqlSavedSchema(context, this.schema, binlogPosition);

--- a/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 	private MysqlPositionStore buildStore() throws Exception {
 		MaxwellContext context = buildContext();
-		return new MysqlPositionStore(context.getMaxwellConnectionPool(), context.getServerID(), "maxwell", "maxwell");
+		return new MysqlPositionStore(context.getMaxwellConnectionPool(), context.getServerID(), "maxwell");
 	}
 
 	@Test


### PR DESCRIPTION
1.  In order to be able to create the `maxwell` database on first-run, we had made it so that the connection pool returned a connection that had no database selected.  This is necessary for initialization, but meant we were passing the database name around everywhere.  This fixes that so there's a special connection pool we use to create the maxwell database, but everyone else uses a database that's properly wired up with a database name.

2.  Remove `MaxwellContext` from some low-level interfaces.  `MaxwellContext` is a super-convenient bundle of objects, but creating one is a pain, and makes re-use a pain.   Here we make a couple of objects (`MaxwellReplicator`, `SchemaStore`) usable with the component objects instead of the bundled `Context`.  

@zendesk/rules 