### PR TITLE
RowMap: toJSON includes binlog position

### DIFF
--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -189,6 +189,7 @@ public class RowMap implements Serializable {
 		g.writeStringField("table", this.table);
 		g.writeStringField("type", this.rowType);
 		g.writeNumberField("ts", this.timestamp);
+		g.writeNumberField("binlog_position", this.nextPosition.getOffset());
 
 		/* TODO: allow xid and commit to be configurable in the output */
 		if ( this.xid != null )

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -410,4 +410,9 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	}
 
+	@Test
+	public void testOutputBinlogPosition() throws Exception {
+		runJSON("/json/test_binlog_position");
+	}
+
 }

--- a/src/test/resources/sql/json/test_binlog_position
+++ b/src/test/resources/sql/json/test_binlog_position
@@ -1,0 +1,5 @@
+CREATE DATABASE `test_binlog_position`
+create table `test_binlog_position`.`bposition` ( textcol text )
+use test_binlog_position
+insert into `bposition` set `textcol` = 'kk';
+-> {"database": "test_binlog_position", "table": "bposition", "type": "insert", binlog_position: "/\\d+/", "data": {"textcol": "kk"} }


### PR DESCRIPTION
/cc @zendesk/rules

### Description

By consequence messages sent by MaxwellKafkaProducer will include the binlog position.

I refactored json tests to support pattern matching, instead of changing the json files expectations to include the specific binlog position (locally positions had numbers like 18645, 20004, 21497, etc). MaxwellIntegrationTest tests were 100ms slower (they take more than 16s). My worry was making the tests too brittle (seems like binlog_position will change frequently).

### Risks
* Low.