### PR TITLE
add option to ignore ddl statement parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Travis Image.
+
 <div id="maxwell-header">
   <h2>Maxwell = Mysql + Kafka</h2>
 </div>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Travis Image.
-
 <div id="maxwell-header">
   <h2>Maxwell = Mysql + Kafka</h2>
 </div>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -37,10 +37,12 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public BinlogPosition initPosition;
 	public boolean replayMode;
+	public boolean ignoreDDL;
 
 	public MaxwellConfig() { // argv is only null in tests
 		this.kafkaProperties = new Properties();
 		this.replayMode = false;
+		this.ignoreDDL = false;
 		this.replicationMysql = new MaxwellMysqlConfig();
 		this.maxwellMysql = new MaxwellMysqlConfig();
 		setup(null, null); // setup defaults
@@ -104,7 +106,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "exclude_columns", "exclude these columns, formatted as exclude_columns=col1,col2" ).withOptionalArg();
 		parser.accepts( "blacklist_dbs", "ignore data AND schema changes to these databases, formatted as blacklist_dbs=db1,db2. See the docs for details before setting this!").withOptionalArg();
 		parser.accepts( "blacklist_tables", "ignore data AND schema changes to these tables, formatted as blacklist_tables=tb1,tb2. See the docs for details before setting this!").withOptionalArg();
-
+		parser.accepts( "ignore_ddl", "ignore DDL statements").withOptionalArg();
 		parser.accepts( "__separator_7" );
 
 		parser.accepts( "help", "display help").forHelp();
@@ -244,6 +246,10 @@ public class MaxwellConfig extends AbstractConfig {
 		if ( options != null && options.has("replay")) {
 			this.replayMode = true;
 		}
+		if ( options != null && options.has("ignore_ddl")) {
+			this.ignoreDDL = true;
+		}
+
 	}
 
 	private Properties parseFile(String filename, Boolean abortOnMissing) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -341,9 +341,11 @@ public class MaxwellReplicator extends RunLoopProcess {
 		String sql = event.getSql().toString();
 		BinlogPosition position = eventBinlogPosition(event);
 
-		schemaStore.processSQL(sql, dbName, position);
-		tableCache.clear();
-		this.producer.writePosition(position);
+		if (!this.context.getConfig().ignoreDDL) {
+			schemaStore.processSQL(sql, dbName, position);
+			tableCache.clear();
+			this.producer.writePosition(position);
+		}
 	}
 
 	public Schema getSchema() throws SchemaStoreException {


### PR DESCRIPTION
DDL parsing is mandatory in current code, any parsing error will cause maxwell replicator fatal error and stop execution. 

In most cases, DDL parsing are successful, but some exotic DDL statement does cause parsing issue. maybe in near future mysql will have more minor SQL syntax changes and cause maxwell DDL parsing error.  
Maybe we could add a option to ignore DDL parsing?  

I think it is "safe" option for stable production system(**actually no DDL changes in our production system**) but with multiple tenement. other users's exotic DDL changes may have a impact to maxwell normal execution.

```
3:50:50,710 INFO  AbstractSchemaStore - storing schema @BinlogPosition[mysql-bin.003981:29180028] after applying "DROP TABLE IF EXISTS `xxx_asset_access_audit` /* generated by server */"
23:50:50,777 ERROR MysqlParserListener - (creation_engine ENGINE = `InnoDB`)
23:50:50,777 ERROR SchemaChange - Error parsing SQL: 'CREATE TABLE `xxx_asset_access_audit` (
        `id` int(11) NOT NULL,
        `partner_id` varchar(31) NOT NULL ,
        `partner_product_id` varchar(31) NOT NULL ,
        `log_date` datetime NOT NULL ,
        `batch_id` varchar(64) NOT NULL ,
        `order_id` varchar(64) NOT NULL ,
        `audit_status` tinyint(4) NOT NULL ,
        `audit_reason` varchar(255) DEFAULT NULL ,
        `remark` varchar(255) DEFAULT ',
        `is_deleted` char(1) NOT NULL DEFAULT 'N' ,
        `gmt_created` datetime NOT NULL ,
        `creator` varchar(32) NOT NULL ,
        `gmt_modified` datetime NOT NULL ,
        `modifier` varchar(32) NOT NULL ,
        PRIMARY KEY (`id`),
        UNIQUE `UN_ORDER` (`partner_product_id`, `batch_id`, `order_id`) comment ''
) ENGINE=`InnoDB` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci ROW_FORMAT=COMPACT  CHECKSUM=0 DELAY_KEY_WRITE=0'
com.zendesk.maxwell.schema.ddl.MaxwellSQLSyntaxError: `InnoDB`
        at com.zendesk.maxwell.schema.ddl.MysqlParserListener.visitErrorNode(MysqlParserListener.java:84)
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:41)
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:52)
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:52)
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:52)
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:52)
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:52)
        at com.zendesk.maxwell.schema.ddl.SchemaChange.parseSQL(SchemaChange.java:79)
        at com.zendesk.maxwell.schema.ddl.SchemaChange.parse(SchemaChange.java:91)
        at com.zendesk.maxwell.schema.AbstractSchemaStore.resolveSQL(AbstractSchemaStore.java:33)
        at com.zendesk.maxwell.schema.MysqlSchemaStore.processSQL(MysqlSchemaStore.java:47)
        at com.zendesk.maxwell.MaxwellReplicator.processQueryEvent(MaxwellReplicator.java:344)
        at com.zendesk.maxwell.MaxwellReplicator.getRow(MaxwellReplicator.java:321)
        at com.zendesk.maxwell.MaxwellReplicator.work(MaxwellReplicator.java:113)
        at com.zendesk.maxwell.RunLoopProcess.runLoop(RunLoopProcess.java:32)
        at com.zendesk.maxwell.Maxwell.run(Maxwell.java:76)
        at com.zendesk.maxwell.Maxwell.main(Maxwell.java:82)
23:50:50,823 INFO  PositionStoreThread - Storing final position: BinlogPosition[mysql-bin.003981:29179353]
```