### PR TITLE
master recovery tweaks

### DIFF
--- a/docs/docs/compat.md
+++ b/docs/docs/compat.md
@@ -21,11 +21,22 @@ from normal Maxwell operation in that:
 
 ### Master recovery
 ***
-Currently Maxwell is not very smart about master recovery or detecting a promoted slave; if it determines
-that the server_id has changed between runs, Maxwell will simply delete its old schema cache and binlog position
-and start again.  We plan on improving master recovery in future releases.
 
-If you know the starting position of your new master, you can start the new Maxwell process with the
-`--init_position` flag, which will ensure that no gap appears in a master failover.
+As of 1.2.0, maxwell includes experimental support for master position recovery.  It works like this:
+
+- maxwell writes heartbeats into the binlogs (via the `positions` table)
+- maxwell reads its own heartbeats, using them as a secondary position guide
+- if maxwell boots and can't find its position matching the `server_id` it's
+  connecting to, it will look for a row in `maxwell.positions` from a different
+  server_id.
+- if it finds that row, it will scan backwards in the binary logs of the new
+  master until it finds that heartbeat.
+
+Notes:
+- master recovery is not compatible with separate schema-store hosts and
+  replication-hosts, due to the heartbeat mechanism.
+- this code should be considered alpha-quality.
+- on highly active servers, as much as 1 second of data may be duplicated.
+
 
 

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -12,6 +12,7 @@ option                                        | description | default
 --schema_database                             | database name where maxwell stores schema and state | maxwell
 --client_id                                   | unique (string) identifier for this maxwell instance| maxwell
 --replica_server_id                           | unique (long) identifier for this maxwell instance | 6379 (see notes)
+--master_recovery                             | enable experimental master recovery code | false
 &nbsp;
 --producer PRODUCER                           | what type of producer to use: [stdout, kafka, file, profiler] | stdout
 --output_file                                 | if using the file producer, write JSON rows to this path |

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -105,6 +105,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "max_schemas", "deprecated.").withOptionalArg();
 		parser.accepts( "init_position", "initial binlog position, given as BINLOG_FILE:POSITION").withRequiredArg();
 		parser.accepts( "replay", "replay mode, don't store any information to the server");
+		parser.accepts( "master_recovery", "(experimental) enable master position recovery code");
 
 		parser.accepts( "__separator_7" );
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -144,10 +144,12 @@ public class MysqlPositionStore {
 
 		while ( rs.next() ) {
 			Long server_id = rs.getLong("server_id");
-			Long last_heartbeat_read = rs.getLong("last_heartbeat_read");
 			BinlogPosition position = BinlogPosition.at(rs.getLong("binlog_position"), rs.getString("binlog_file"));
+			Long last_heartbeat_read = rs.getLong("last_heartbeat_read");
 
-			if ( info != null ) {
+			if ( rs.wasNull() ) {
+				LOGGER.warn("master recovery is ignorning position with NULL heartbeat");
+			} else if ( info != null ) {
 				LOGGER.error("found multiple binlog positions for cluster.  Not attempting position recovery.");
 				LOGGER.error("found a row for server_id: " + info.serverID);
 				LOGGER.error("also found a row for server_id: " + server_id);


### PR DESCRIPTION
- document command line flag, add secontion to docs
- only send heartbeat if position advanced substantially since last
  heartbeat.  Prevents us from endlessly moving the binlog position
  forward.

@zendesk/rules