### PR TITLE
Fix odd ALTER TABLE character set issue

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -62,6 +62,10 @@ public class TableAlter extends SchemaChange {
 		if ( this.pks != null ) {
 			table.setPKList(this.pks);
 		}
+
+		if ( this.defaultCharset != null )
+			table.charset = this.defaultCharset;
+
 		table.setDefaultColumnCharsets();
 
 		return new ResolvedTableAlter(this.database, this.table, oldTable, table);

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -41,7 +41,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 			"create table shard_1.testDrop ( id int(11) )",
 			"drop table shard_1.testDrop",
-			"create table test.c ( v varchar(255) charset ascii )",
+			"create table test.c ( v varchar(255) charset ascii )"
 		};
 		testIntegration(sql);
 	}

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -31,6 +31,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		String sql[] = {
 			"create table shard_1.testAlter ( id int(11) unsigned default 1, str varchar(255) )",
 			"alter table shard_1.testAlter add column barbar tinyint",
+			"alter table shard_1.testAlter add column thiswillbeutf16 text, engine=`innodb` CHARACTER SET utf16",
 			"alter table shard_1.testAlter rename to shard_1.`freedonia`",
 			"rename table shard_1.`freedonia` to shard_1.ducksoup, shard_1.ducksoup to shard_1.`nananana`",
 			"alter table shard_1.nananana drop column barbar",
@@ -40,7 +41,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 			"create table shard_1.testDrop ( id int(11) )",
 			"drop table shard_1.testDrop",
-			"create table test.c ( v varchar(255) charset ascii )"
+			"create table test.c ( v varchar(255) charset ascii )",
 		};
 		testIntegration(sql);
 	}

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -177,6 +177,7 @@ public class DDLParserTest {
 			"alter table t alter column `foo` SET DEFAULT false",
 			"alter table t alter column `foo` drop default",
 			"alter table t CHARACTER SET latin1 COLLATE = 'utf8'",
+			"ALTER TABLE `test` ENGINE=`InnoDB` CHARACTER SET latin1",
 			"alter table t DROP PRIMARY KEY",
 			"alter table t drop index `foo`",
 			"alter table t disable keys",


### PR DESCRIPTION
this also fixes an issue in which we weren't properly setting up the default character set on a table on an ongoing basis (oops.)

@zendesk/rules 

addresses #429 