### PR TITLE
[#431] Correctly include kafka jars when running from release tarball

### DIFF
--- a/bin/maxwell
+++ b/bin/maxwell
@@ -13,9 +13,9 @@ CLASSPATH=$CLASSPATH:$base_dir/target/classes:../open-replicator/target/classes
 
 for file in lib/*.jar target/dependency/*.jar
 do
-  if [[ "$@" == *--kafka0.8* ]] && [[ ! $file == "target/dependency/kafka-clients-$KAFKA_09_VERSION.jar" ]]; then
+  if [[ "$@" == *--kafka0.8* ]] && [[ ! $file == *kafka-clients-$KAFKA_09_VERSION.jar* ]]; then
     CLASSPATH=$CLASSPATH:$file
-  elif [[ ! "$@" == *--kafka0.8* ]] && [[ ! $file == "target/dependency/kafka-clients-$KAFKA_08_VERSION.jar" ]]; then
+  elif [[ ! "$@" == *--kafka0.8* ]] && [[ ! $file == *kafka-clients-$KAFKA_08_VERSION.jar* ]]; then
     CLASSPATH=$CLASSPATH:$file
   fi
 done

--- a/bin/maxwell-bootstrap
+++ b/bin/maxwell-bootstrap
@@ -13,9 +13,9 @@ CLASSPATH=$CLASSPATH:$base_dir/target/classes:../open-replicator/target/classes
 
 for file in lib/*.jar target/dependency/*.jar
 do
-  if [[ "$@" == *--kafka0.8* ]] && [[ ! $file == "target/dependency/kafka-clients-$KAFKA_09_VERSION.jar" ]]; then
+  if [[ "$@" == *--kafka0.8* ]] && [[ ! $file == *kafka-clients-$KAFKA_09_VERSION.jar* ]]; then
     CLASSPATH=$CLASSPATH:$file
-  elif [[ ! "$@" == *--kafka0.8* ]] && [[ ! $file == "target/dependency/kafka-clients-$KAFKA_08_VERSION.jar" ]]; then
+  elif [[ ! "$@" == *--kafka0.8* ]] && [[ ! $file == *kafka-clients-$KAFKA_08_VERSION.jar* ]]; then
     CLASSPATH=$CLASSPATH:$file
   fi
 done


### PR DESCRIPTION
/cc @zendesk/rules @xmlking

### Description

Fixes #431.

Please check I got path right this time!

```
$ bash -x bin/maxwell
+ CLASSPATH=':bin/../target/classes:../open-replicator/target/classes:lib/antlr4-runtime-4.5.jar:lib/commons-codec-1.5.jar:lib/commons-lang3-3.4.jar:lib/dbpool-7.0-jdk7.jar:lib/jackson-annotations-2.6.0.jar:lib/jackson-core-2.6.3.jar:lib/jackson-databind-2.6.3.jar:lib/jopt-simple-4.9.jar:lib/jts-1.13.jar:lib/kafka-clients-0.9.0.1.jar:lib/log4j-api-2.1.jar:lib/log4j-core-2.1.jar:lib/log4j-slf4j-impl-2.1.jar:lib/log4j-staticshutdown-1.1.0.jar:lib/lz4-1.2.0.jar:lib/maxwell-1.2.0.jar:lib/mysql-connector-java-5.1.39.jar:lib/open-replicator-1.5.0.jar:lib/org.abego.treelayout.core-1.0.1.jar:lib/slf4j-api-1.7.6.jar:lib/snappy-java-1.1.1.7.jar:target/dependency/*.jar'
+ '[' -z /usr/lib/jvm/java-1.7.0-openjdk-amd64 ']'
+ JAVA=/usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java
+ exec /usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp ':bin/../target/classes:../open-replicator/target/classes:lib/antlr4-runtime-4.5.jar:lib/commons-codec-1.5.jar:lib/commons-lang3-3.4.jar:lib/dbpool-7.0-jdk7.jar:lib/jackson-annotations-2.6.0.jar:lib/jackson-core-2.6.3.jar:lib/jackson-databind-2.6.3.jar:lib/jopt-simple-4.9.jar:lib/jts-1.13.jar:lib/kafka-clients-0.9.0.1.jar:lib/log4j-api-2.1.jar:lib/log4j-core-2.1.jar:lib/log4j-slf4j-impl-2.1.jar:lib/log4j-staticshutdown-1.1.0.jar:lib/lz4-1.2.0.jar:lib/maxwell-1.2.0.jar:lib/mysql-connector-java-5.1.39.jar:lib/open-replicator-1.5.0.jar:lib/org.abego.treelayout.core-1.0.1.jar:lib/slf4j-api-1.7.6.jar:lib/snappy-java-1.1.1.7.jar:target/dependency/*.jar' com.zendesk.maxwell.Maxwell
```

```
$ bash -x bin/maxwell --kafka0.8
+ CLASSPATH=':bin/../target/classes:../open-replicator/target/classes:lib/antlr4-runtime-4.5.jar:lib/commons-codec-1.5.jar:lib/commons-lang3-3.4.jar:lib/dbpool-7.0-jdk7.jar:lib/jackson-annotations-2.6.0.jar:lib/jackson-core-2.6.3.jar:lib/jackson-databind-2.6.3.jar:lib/jopt-simple-4.9.jar:lib/jts-1.13.jar:lib/kafka-clients-0.8.2.2.jar:lib/log4j-api-2.1.jar:lib/log4j-core-2.1.jar:lib/log4j-slf4j-impl-2.1.jar:lib/log4j-staticshutdown-1.1.0.jar:lib/lz4-1.2.0.jar:lib/maxwell-1.2.0.jar:lib/mysql-connector-java-5.1.39.jar:lib/open-replicator-1.5.0.jar:lib/org.abego.treelayout.core-1.0.1.jar:lib/slf4j-api-1.7.6.jar:lib/snappy-java-1.1.1.7.jar:target/dependency/*.jar'
+ '[' -z /usr/lib/jvm/java-1.7.0-openjdk-amd64 ']'
+ JAVA=/usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java
+ exec /usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp ':bin/../target/classes:../open-replicator/target/classes:lib/antlr4-runtime-4.5.jar:lib/commons-codec-1.5.jar:lib/commons-lang3-3.4.jar:lib/dbpool-7.0-jdk7.jar:lib/jackson-annotations-2.6.0.jar:lib/jackson-core-2.6.3.jar:lib/jackson-databind-2.6.3.jar:lib/jopt-simple-4.9.jar:lib/jts-1.13.jar:lib/kafka-clients-0.8.2.2.jar:lib/log4j-api-2.1.jar:lib/log4j-core-2.1.jar:lib/log4j-slf4j-impl-2.1.jar:lib/log4j-staticshutdown-1.1.0.jar:lib/lz4-1.2.0.jar:lib/maxwell-1.2.0.jar:lib/mysql-connector-java-5.1.39.jar:lib/open-replicator-1.5.0.jar:lib/org.abego.treelayout.core-1.0.1.jar:lib/slf4j-api-1.7.6.jar:lib/snappy-java-1.1.1.7.jar:target/dependency/*.jar' com.zendesk.maxwell.Maxwell --kafka0.8
```

Dev:
```
$ bash -x bin/maxwell
+ CLASSPATH=':bin/../target/classes:../open-replicator/target/classes:lib/*.jar:target/dependency/antlr4-runtime-4.5.jar:target/dependency/commons-codec-1.5.jar:target/dependency/commons-lang3-3.4.jar:target/dependency/dbpool-7.0-jdk7.jar:target/dependency/jackson-annotations-2.6.0.jar:target/dependency/jackson-core-2.6.3.jar:target/dependency/jackson-databind-2.6.3.jar:target/dependency/jopt-simple-4.9.jar:target/dependency/jts-1.13.jar:target/dependency/kafka-clients-0.9.0.1.jar:target/dependency/log4j-api-2.1.jar:target/dependency/log4j-core-2.1.jar:target/dependency/log4j-slf4j-impl-2.1.jar:target/dependency/log4j-staticshutdown-1.1.0.jar:target/dependency/lz4-1.2.0.jar:target/dependency/mysql-connector-java-5.1.39.jar:target/dependency/open-replicator-1.5.0.jar:target/dependency/org.abego.treelayout.core-1.0.1.jar:target/dependency/slf4j-api-1.7.6.jar:target/dependency/snappy-java-1.1.1.7.jar'
+ '[' -z /usr/lib/jvm/java-1.7.0-openjdk-amd64 ']'
+ JAVA=/usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java
+ exec /usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp ':bin/../target/classes:../open-replicator/target/classes:lib/*.jar:target/dependency/antlr4-runtime-4.5.jar:target/dependency/commons-codec-1.5.jar:target/dependency/commons-lang3-3.4.jar:target/dependency/dbpool-7.0-jdk7.jar:target/dependency/jackson-annotations-2.6.0.jar:target/dependency/jackson-core-2.6.3.jar:target/dependency/jackson-databind-2.6.3.jar:target/dependency/jopt-simple-4.9.jar:target/dependency/jts-1.13.jar:target/dependency/kafka-clients-0.9.0.1.jar:target/dependency/log4j-api-2.1.jar:target/dependency/log4j-core-2.1.jar:target/dependency/log4j-slf4j-impl-2.1.jar:target/dependency/log4j-staticshutdown-1.1.0.jar:target/dependency/lz4-1.2.0.jar:target/dependency/mysql-connector-java-5.1.39.jar:target/dependency/open-replicator-1.5.0.jar:target/dependency/org.abego.treelayout.core-1.0.1.jar:target/dependency/slf4j-api-1.7.6.jar:target/dependency/snappy-java-1.1.1.7.jar' com.zendesk.maxwell.Maxwell
```

```
$ bash -x bin/maxwell --kafka0.8
+ CLASSPATH=':bin/../target/classes:../open-replicator/target/classes:lib/*.jar:target/dependency/antlr4-runtime-4.5.jar:target/dependency/commons-codec-1.5.jar:target/dependency/commons-lang3-3.4.jar:target/dependency/dbpool-7.0-jdk7.jar:target/dependency/jackson-annotations-2.6.0.jar:target/dependency/jackson-core-2.6.3.jar:target/dependency/jackson-databind-2.6.3.jar:target/dependency/jopt-simple-4.9.jar:target/dependency/jts-1.13.jar:target/dependency/kafka-clients-0.8.2.2.jar:target/dependency/log4j-api-2.1.jar:target/dependency/log4j-core-2.1.jar:target/dependency/log4j-slf4j-impl-2.1.jar:target/dependency/log4j-staticshutdown-1.1.0.jar:target/dependency/lz4-1.2.0.jar:target/dependency/mysql-connector-java-5.1.39.jar:target/dependency/open-replicator-1.5.0.jar:target/dependency/org.abego.treelayout.core-1.0.1.jar:target/dependency/slf4j-api-1.7.6.jar:target/dependency/snappy-java-1.1.1.7.jar'
+ '[' -z /usr/lib/jvm/java-1.7.0-openjdk-amd64 ']'
+ JAVA=/usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java
+ exec /usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp ':bin/../target/classes:../open-replicator/target/classes:lib/*.jar:target/dependency/antlr4-runtime-4.5.jar:target/dependency/commons-codec-1.5.jar:target/dependency/commons-lang3-3.4.jar:target/dependency/dbpool-7.0-jdk7.jar:target/dependency/jackson-annotations-2.6.0.jar:target/dependency/jackson-core-2.6.3.jar:target/dependency/jackson-databind-2.6.3.jar:target/dependency/jopt-simple-4.9.jar:target/dependency/jts-1.13.jar:target/dependency/kafka-clients-0.8.2.2.jar:target/dependency/log4j-api-2.1.jar:target/dependency/log4j-core-2.1.jar:target/dependency/log4j-slf4j-impl-2.1.jar:target/dependency/log4j-staticshutdown-1.1.0.jar:target/dependency/lz4-1.2.0.jar:target/dependency/mysql-connector-java-5.1.39.jar:target/dependency/open-replicator-1.5.0.jar:target/dependency/org.abego.treelayout.core-1.0.1.jar:target/dependency/slf4j-api-1.7.6.jar:target/dependency/snappy-java-1.1.1.7.jar' com.zendesk.maxwell.Maxwell --kafka0.8
```

### Risks
* Low. Might load wrong kafka client library (maxwell should work with both).