### PR TITLE
Ignore test dbs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN curl -sLo - https://github.com/zendesk/maxwell/releases/download/v"$MAXWELL_
   | tar --strip-components=1 -zxvf -
 
 RUN echo "$MAXWELL_VERSION" > /REVISION
-CMD bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT
+CMD bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT $MAXWELL_OPTIONS


### PR DESCRIPTION
When Maxwell is restarted after running tests in other projects, it takes a long to catch up and takes a core of the Docker VM. This 'fixes' the issue by ignoring the test dbs.

It does  seem a bit odd to hard code like this. I wasn't sure how to nicely extract it. Maybe add `$MAXWELL_OPTIONS` and let people inject whatever options they like? Thoughts?

@kunday @osheroff 