### PR TITLE
fixes for issue #437

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ChangeColumnMod.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ChangeColumnMod.java
@@ -16,8 +16,7 @@ class ChangeColumnMod extends ColumnMod {
 	@Override
 	public void apply(Table table) throws InvalidSchemaError {
 		int idx = originalIndex(table);
-		table.removeColumn(idx);
-		table.addColumn(position.index(table, idx), this.definition);
+		table.changeColumn(idx, position, definition);
 	}
 }
 

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -153,7 +153,8 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		   "create TABLE `test_pks_3` ( id int(11) unsigned primary KEY, str varchar(255) )",
 		   "create TABLE `test_pks_4` ( id int(11) unsigned primary KEY, str varchar(255) )",
 		   "alter TABLE `test_pks_3` drop primary key, add primary key(str)",
-		   "alter TABLE `test_pks_4` drop primary key"
+		   "alter TABLE `test_pks_4` drop primary key",
+		   "alter TABLE `test_pks` change id renamed_id int(11) unsigned"
 		};
 
 		testIntegration(sql);


### PR DESCRIPTION
1 - copy pkList when cloning table; otherwise we end up mutating the old
one.

2 - deal with the fact that CHANGE COLUMN will keep something in the PK

@zendesk/rules #437 