### PR TITLE
Add an option to include the server and thread ID in the output

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -94,7 +94,8 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "output_binlog_position", "produced records include binlog position; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_commit_info", "produced records include commit and xid; [true|false]. default: true" ).withOptionalArg();
 		parser.accepts( "output_nulls", "produced records include fields with NULL values [true|false]. default: true" ).withOptionalArg();
-		parser.accepts( "output_thread_info", "produced records include server_id and thread_id; [true|false]. default: false" ).withOptionalArg();
+		parser.accepts( "output_server_id", "produced records include server_id; [true|false]. default: false" ).withOptionalArg();
+		parser.accepts( "output_thread_id", "produced records include thread_id; [true|false]. default: false" ).withOptionalArg();
 
 		parser.accepts( "__separator_5" );
 
@@ -278,7 +279,8 @@ public class MaxwellConfig extends AbstractConfig {
 		outputConfig.includesBinlogPosition = fetchBooleanOption("output_binlog_position", options, properties, false);
 		outputConfig.includesCommitInfo = fetchBooleanOption("output_commit_info", options, properties, true);
 		outputConfig.includesNulls = fetchBooleanOption("output_nulls", options, properties, true);
-		outputConfig.includesThreadInfo = fetchBooleanOption("output_thread_info", options, properties, false);
+		outputConfig.includesServerId = fetchBooleanOption("output_server_id", options, properties, false);
+		outputConfig.includesThreadId = fetchBooleanOption("output_thread_id", options, properties, false);
 	}
 
 	private Properties parseFile(String filename, Boolean abortOnMissing) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -94,6 +94,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "output_binlog_position", "produced records include binlog position; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_commit_info", "produced records include commit and xid; [true|false]. default: true" ).withOptionalArg();
 		parser.accepts( "output_nulls", "produced records include fields with NULL values [true|false]. default: true" ).withOptionalArg();
+		parser.accepts( "output_thread_info", "produced records include server_id and thread_id; [true|false]. default: false" ).withOptionalArg();
 
 		parser.accepts( "__separator_5" );
 
@@ -277,6 +278,7 @@ public class MaxwellConfig extends AbstractConfig {
 		outputConfig.includesBinlogPosition = fetchBooleanOption("output_binlog_position", options, properties, false);
 		outputConfig.includesCommitInfo = fetchBooleanOption("output_commit_info", options, properties, true);
 		outputConfig.includesNulls = fetchBooleanOption("output_nulls", options, properties, true);
+		outputConfig.includesThreadInfo = fetchBooleanOption("output_thread_info", options, properties, false);
 	}
 
 	private Properties parseFile(String filename, Boolean abortOnMissing) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellReplicator.java
@@ -387,9 +387,11 @@ public class MaxwellReplicator extends RunLoopProcess {
 					break;
 				case MySQLConstants.QUERY_EVENT:
 					QueryEvent qe = (QueryEvent) v4Event;
-					if (qe.getSql().toString().equals("BEGIN"))
+					if (qe.getSql().toString().equals("BEGIN")) {
 						rowBuffer = getTransactionRows();
-					else {
+						rowBuffer.setServerId(qe.getHeader().getServerId());
+						rowBuffer.setThreadId(qe.getThreadId());
+					} else {
 						processQueryEvent((QueryEvent) v4Event);
 						setReplicatorPosition((AbstractBinlogEventV4) v4Event);
 					}

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -30,6 +30,8 @@ public class RowMap implements Serializable {
 
 	private Long xid;
 	private boolean txCommit;
+	private Long serverId;
+	private Long threadId;
 
 	private final LinkedHashMap<String, Object> data;
 	private final LinkedHashMap<String, Object> oldData;
@@ -206,6 +208,17 @@ public class RowMap implements Serializable {
 		if ( outputConfig.includesBinlogPosition )
 			g.writeStringField("position", this.nextPosition.getFile() + ":" + this.nextPosition.getOffset());
 
+
+		if ( outputConfig.includesThreadInfo ) {
+			if (this.serverId != null) {
+				g.writeNumberField("server_id", this.serverId);
+			}
+
+			if (this.threadId != null) {
+				g.writeNumberField("thread_id", this.threadId);
+			}
+		}
+
 		if ( this.excludeColumns != null ) {
 			// NOTE: to avoid concurrent modification.
 			Set<String> keys = new HashSet<String>();
@@ -298,6 +311,22 @@ public class RowMap implements Serializable {
 
 	public boolean isTXCommit() {
 		return this.txCommit;
+	}
+
+	public Long getServerId() {
+		return serverId;
+	}
+
+	public void setServerId(Long serverId) {
+		this.serverId = serverId;
+	}
+
+	public Long getThreadId() {
+		return threadId;
+	}
+
+	public void setThreadId(Long threadId) {
+		this.threadId = threadId;
 	}
 
 	public String getDatabase() {

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -209,14 +209,12 @@ public class RowMap implements Serializable {
 			g.writeStringField("position", this.nextPosition.getFile() + ":" + this.nextPosition.getOffset());
 
 
-		if ( outputConfig.includesThreadInfo ) {
-			if (this.serverId != null) {
-				g.writeNumberField("server_id", this.serverId);
-			}
+		if ( outputConfig.includesServerId && this.serverId != null ) {
+			g.writeNumberField("server_id", this.serverId);
+		}
 
-			if (this.threadId != null) {
-				g.writeNumberField("thread_id", this.threadId);
-			}
+		if ( outputConfig.includesThreadId && this.threadId != null ) {
+			g.writeNumberField("thread_id", this.threadId);
 		}
 
 		if ( this.excludeColumns != null ) {

--- a/src/main/java/com/zendesk/maxwell/RowMapBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/RowMapBuffer.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 	private static long FlushOutputStreamBytes = 10000000;
 	private Long xid;
+	private Long serverId;
+	private Long threadId;
 	private long memorySize = 0;
 	private long outputStreamCacheSize = 0;
 	private final long maxMemory;
@@ -52,11 +54,21 @@ public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 	public RowMap removeFirst() throws IOException, ClassNotFoundException {
 		RowMap r = super.removeFirst(RowMap.class);
 		r.setXid(this.xid);
+		r.setServerId(this.serverId);
+		r.setThreadId(this.threadId);
 
 		return r;
 	}
 
 	public void setXid(Long xid) {
 		this.xid = xid;
+	}
+
+	public void setServerId(Long serverId) {
+		this.serverId = serverId;
+	}
+
+	public void setThreadId(Long threadId) {
+		this.threadId = threadId;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
@@ -4,10 +4,12 @@ public class MaxwellOutputConfig {
 	public boolean includesBinlogPosition;
 	public boolean includesCommitInfo;
 	public boolean includesNulls;
+	public boolean includesThreadInfo;
 
 	public MaxwellOutputConfig() {
 		this.includesBinlogPosition = false;
 		this.includesCommitInfo = true;
 		this.includesNulls = true;
+		this.includesThreadInfo = false;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
@@ -4,12 +4,14 @@ public class MaxwellOutputConfig {
 	public boolean includesBinlogPosition;
 	public boolean includesCommitInfo;
 	public boolean includesNulls;
-	public boolean includesThreadInfo;
+	public boolean includesServerId;
+	public boolean includesThreadId;
 
 	public MaxwellOutputConfig() {
 		this.includesBinlogPosition = false;
 		this.includesCommitInfo = true;
 		this.includesNulls = true;
-		this.includesThreadInfo = false;
+		this.includesServerId = false;
+		this.includesThreadId = false;
 	}
 }


### PR DESCRIPTION
Added an option (--output_thread_info) to include the MySQL server_id and thread_id in the output. We use this for joining maxwell event data against thread data stored elsewhere to add application context to every binlog event.