### PR TITLE
Issue #427: add partitioning by column

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -84,7 +84,12 @@ password=maxwell
 # which transactions keep ordering with respect to each other.  Generally
 # here you're making a trade-off between inter-row consistency and balanced
 # partitions.
-#kafka_partition_by=database # [database, table, primary_key]
+#kafka_partition_by=database # [database, table, primary_key, column]
+
+# required when using kafka_partition_by=column
+# otherwise the partitioner will revert to table
+# can be a single or multiple columns, e.g. aggregate_id or aggregate_id,event_type
+#kafka_partition_columns=
 
 # how maxwell writes its kafka key.
 #

--- a/config.properties.example
+++ b/config.properties.example
@@ -91,6 +91,11 @@ password=maxwell
 # can be a single or multiple columns, e.g. aggregate_id or aggregate_id,event_type
 #kafka_partition_columns=
 
+# required when using kafka_partition_by=column
+# the fallback partitioning behavior when the specified column(s) do not exist
+# can be any one of [database, table, primary_key]
+#kafka_partition_by_fallback=database
+
 # how maxwell writes its kafka key.
 #
 # 'hash' looks like:

--- a/docs/docs/kafka.md
+++ b/docs/docs/kafka.md
@@ -33,7 +33,10 @@ A binlog event's partition is determined by the selected hash function and hash 
 
 The HASH_FUNCTION is either java's _hashCode_ or _murmurhash3_. The default HASH_FUNCTION is _hashCode_. Murmurhash3 may be set with the `kafka_partition_hash` option. The seed value for the murmurhash function is hardcoded to 25342 in the MaxwellKafkaPartitioner class.
  
-The HASH_STRING may be (_database_, _table_, _primary_key_).  The default HASH_STRING is the _database_. The partitioning field can be configured using the `kafka_partition_by` option.    
+The HASH_STRING may be (_database_, _table_, _primary_key_, _column_).  The default HASH_STRING is the _database_. The partitioning field can be configured using the `kafka_partition_by` option.
+
+When using `kafka_partition_by`=_column_ you must set `kafka_partition_columns` with the column name(s) to partition by (e.g. `kafka_partition_columns`=user_id or `kafka_partition_columns`=user_id,create_date). You must also set `kafka_partiton_by_fallback`. This may be (_database_, _table_, _primary_key_). It is used when the column(s) specified does not exist in the current row. The default is _database_.
+When partitioning by _column_ Maxwell will treat the values for the specified columns as strings, concatenate them and use that value to partition the data. The above example, partitioning by user_id + create_date would have a partition key similar to _1178532016-10-10 18:29:04_.
 
 Maxwell will discover the number of partitions in its kafka topic upon boot.  This means that you should pre-create your kafka topics,
 and with at least as many partitions as you have logical databases:

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import joptsimple.*;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +29,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public String producerType;
 	public String kafkaPartitionHash;
 	public String kafkaPartitionKey;
+	public String kafkaPartitionColumns;
 	public String bootstrapperType;
 	public int bufferedProducerSize;
 
@@ -83,7 +85,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "producer", "producer type: stdout|file|kafka" ).withRequiredArg();
 		parser.accepts( "output_file", "output file for 'file' producer" ).withRequiredArg();
 		parser.accepts( "kafka.bootstrap.servers", "at least one kafka server, formatted as HOST:PORT[,HOST:PORT]" ).withRequiredArg();
-		parser.accepts( "kafka_partition_by", "database|table|primary_key, kafka producer assigns partition by hashing the specified parameter").withRequiredArg();
+		parser.accepts( "kafka_partition_by", "database|table|primary_key|column, kafka producer assigns partition by hashing the specified parameter").withRequiredArg();
 		parser.accepts( "kafka_partition_hash", "default|murmur3, hash function for partitioning").withRequiredArg();
 		parser.accepts( "kafka_topic", "optionally provide a topic name to push to. default: maxwell").withOptionalArg();
 		parser.accepts( "kafka_key_format", "how to format the kafka key; array|hash").withOptionalArg();
@@ -224,10 +226,11 @@ public class MaxwellConfig extends AbstractConfig {
 		this.clientID           = fetchOption("client_id", options, properties, "maxwell");
 		this.replicaServerID    = fetchLongOption("replica_server_id", options, properties, 6379L);
 
-		this.kafkaTopic         = fetchOption("kafka_topic", options, properties, "maxwell");
-		this.kafkaKeyFormat     = fetchOption("kafka_key_format", options, properties, "hash");
-		this.kafkaPartitionKey  = fetchOption("kafka_partition_by", options, properties, "database");
-		this.kafkaPartitionHash = fetchOption("kafka_partition_hash", options, properties, "default");
+		this.kafkaTopic         	= fetchOption("kafka_topic", options, properties, "maxwell");
+		this.kafkaKeyFormat     	= fetchOption("kafka_key_format", options, properties, "hash");
+		this.kafkaPartitionKey  	= fetchOption("kafka_partition_by", options, properties, "database");
+		this.kafkaPartitionColumns  = fetchOption("kafka_partition_columns", options, properties, null);
+		this.kafkaPartitionHash 	= fetchOption("kafka_partition_hash", options, properties, "default");
 
 		String kafkaBootstrapServers = fetchOption("kafka.bootstrap.servers", options, properties, null);
 		if ( kafkaBootstrapServers != null )
@@ -309,8 +312,11 @@ public class MaxwellConfig extends AbstractConfig {
 				this.kafkaPartitionKey = "database";
 			} else if ( !this.kafkaPartitionKey.equals("database")
 					&& !this.kafkaPartitionKey.equals("table")
-					&& !this.kafkaPartitionKey.equals("primary_key") ) {
-				usageForOptions("please specify --kafka_partition_by=database|table|primary_key", "kafka_partition_by");
+					&& !this.kafkaPartitionKey.equals("primary_key")
+					&& !this.kafkaPartitionKey.equals("column") ) {
+				usageForOptions("please specify --kafka_partition_by=database|table|primary_key|column", "kafka_partition_by");
+			} else if ( this.kafkaPartitionKey.equals("column") && StringUtils.isEmpty(this.kafkaPartitionColumns) ) {
+				usageForOptions("please specify --kafka_partition_columns=column1 when using kafka_partition_by=column", "kafka_partition_columns");
 			}
 
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -30,6 +30,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public String kafkaPartitionHash;
 	public String kafkaPartitionKey;
 	public String kafkaPartitionColumns;
+	public String kafkaPartitionFallback;
 	public String bootstrapperType;
 	public int bufferedProducerSize;
 
@@ -230,6 +231,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.kafkaKeyFormat     	= fetchOption("kafka_key_format", options, properties, "hash");
 		this.kafkaPartitionKey  	= fetchOption("kafka_partition_by", options, properties, "database");
 		this.kafkaPartitionColumns  = fetchOption("kafka_partition_columns", options, properties, null);
+		this.kafkaPartitionFallback = fetchOption("kafka_partition_by_fallback", options, properties, null);
 		this.kafkaPartitionHash 	= fetchOption("kafka_partition_hash", options, properties, "default");
 
 		String kafkaBootstrapServers = fetchOption("kafka.bootstrap.servers", options, properties, null);
@@ -317,8 +319,9 @@ public class MaxwellConfig extends AbstractConfig {
 				usageForOptions("please specify --kafka_partition_by=database|table|primary_key|column", "kafka_partition_by");
 			} else if ( this.kafkaPartitionKey.equals("column") && StringUtils.isEmpty(this.kafkaPartitionColumns) ) {
 				usageForOptions("please specify --kafka_partition_columns=column1 when using kafka_partition_by=column", "kafka_partition_columns");
+			} else if ( this.kafkaPartitionKey.equals("column") && StringUtils.isEmpty(this.kafkaPartitionFallback) ) {
+				usageForOptions("please specify --kafka_partition_by_fallback=[database, table, primary_key] when using kafka_partition_by=column", "kafka_partition_by_fallback");
 			}
-
 
 			if ( !this.kafkaKeyFormat.equals("hash") && !this.kafkaKeyFormat.equals("array") )
 				usageForOptions("invalid kafka_key_format: " + this.kafkaKeyFormat, "kafka_key_format");

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -87,6 +87,9 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "output_file", "output file for 'file' producer" ).withRequiredArg();
 		parser.accepts( "kafka.bootstrap.servers", "at least one kafka server, formatted as HOST:PORT[,HOST:PORT]" ).withRequiredArg();
 		parser.accepts( "kafka_partition_by", "database|table|primary_key|column, kafka producer assigns partition by hashing the specified parameter").withRequiredArg();
+		parser.accepts( "kafka_partition_columns", "comma separated list of columns, the columns that should be used for partitioning when kafka_partition_by=column").withRequiredArg();
+		parser.accepts( "kafka_partition_by_fallback", "database|table|primary_key, kafka_partition_by fallback when the using 'column' partitioning and the columsn are not present in the row").withRequiredArg();
+
 		parser.accepts( "kafka_partition_hash", "default|murmur3, hash function for partitioning").withRequiredArg();
 		parser.accepts( "kafka_topic", "optionally provide a topic name to push to. default: maxwell").withOptionalArg();
 		parser.accepts( "kafka_key_format", "how to format the kafka key; array|hash").withOptionalArg();

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -157,7 +157,7 @@ public class RowMap implements Serializable {
 		return keys;
 	}
 
-	public String getPartitionKey(List<String> partitionColumns) {
+	public String buildPartitionKey(List<String> partitionColumns) {
 		if (partitionColumns.isEmpty()) {
 			return table;
 		}

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -157,11 +157,7 @@ public class RowMap implements Serializable {
 		return keys;
 	}
 
-	public String buildPartitionKey(List<String> partitionColumns) {
-		if (partitionColumns.isEmpty()) {
-			return table;
-		}
-
+	public String buildPartitionKey(List<String> partitionColumns, String partitionKeyFallback) {
 		String partitionKey="";
 		for (String pc : partitionColumns) {
 			Object pcValue = null;
@@ -171,8 +167,20 @@ public class RowMap implements Serializable {
 				partitionKey += pcValue.toString();
 		}
 		if (partitionKey.isEmpty())
-			return table;
+			return getPartitionKeyFallback(partitionKeyFallback);
 		return partitionKey;
+	}
+
+	private String getPartitionKeyFallback(String partitionKeyFallback) {
+		switch (partitionKeyFallback) {
+			case "table":
+				return this.table;
+			case "primary_key":
+				return pkAsConcatString();
+			case "database":
+			default:
+				return this.database;
+		}
 	}
 
 	private void writeMapToJSON(String jsonMapName, LinkedHashMap<String, Object> data, boolean includeNullField) throws IOException {

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -161,7 +161,7 @@ public class RowMap implements Serializable {
 		if (partitionColumns.isEmpty()) {
 			return table;
 		}
-		// rename keys
+
 		String partitionKey="";
 		for (String pc : partitionColumns) {
 			Object pcValue = null;

--- a/src/main/java/com/zendesk/maxwell/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/RowMap.java
@@ -157,6 +157,24 @@ public class RowMap implements Serializable {
 		return keys;
 	}
 
+	public String getPartitionKey(List<String> partitionColumns) {
+		if (partitionColumns.isEmpty()) {
+			return table;
+		}
+		// rename keys
+		String partitionKey="";
+		for (String pc : partitionColumns) {
+			Object pcValue = null;
+			if (data.containsKey(pc))
+				pcValue = data.get(pc);
+			if (pcValue != null)
+				partitionKey += pcValue.toString();
+		}
+		if (partitionKey.isEmpty())
+			return table;
+		return partitionKey;
+	}
+
 	private void writeMapToJSON(String jsonMapName, LinkedHashMap<String, Object> data, boolean includeNullField) throws IOException {
 		JsonGenerator generator = jsonGeneratorThreadLocal.get();
 		generator.writeObjectFieldStart(jsonMapName); // start of jsonMapName: {

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -93,10 +93,9 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 
 		String hash = context.getConfig().kafkaPartitionHash;
 		String partitionKey = context.getConfig().kafkaPartitionKey;
-		this.partitioner = new MaxwellKafkaPartitioner(hash, partitionKey);
-
-		if ( partitionKey.equals("column") )
-			this.partitioner.setPartitionColumns(context.getConfig().kafkaPartitionColumns);
+		String partitionColumns = context.getConfig().kafkaPartitionColumns;
+		String partitionFallback = context.getConfig().kafkaPartitionFallback;
+		this.partitioner = new MaxwellKafkaPartitioner(hash, partitionKey, partitionColumns, partitionFallback);
 
 		if ( context.getConfig().kafkaKeyFormat.equals("hash") )
 			keyFormat = KeyFormat.HASH;

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -95,6 +95,9 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 		String partitionKey = context.getConfig().kafkaPartitionKey;
 		this.partitioner = new MaxwellKafkaPartitioner(hash, partitionKey);
 
+		if ( partitionKey.equals("column") )
+			this.partitioner.setPartitionColumns(context.getConfig().kafkaPartitionColumns);
+
 		if ( context.getConfig().kafkaKeyFormat.equals("hash") )
 			keyFormat = KeyFormat.HASH;
 		else

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringColumn.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringColumn.java
@@ -13,6 +13,6 @@ public class HashStringColumn implements HashStringProvider {
     }
 
     public String getHashString(RowMap r, List<String> partitionColumns) {
-        return r.getPartitionKey(partitionColumns);
+        return r.buildPartitionKey(partitionColumns);
     }
 }

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringColumn.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringColumn.java
@@ -8,11 +8,7 @@ import java.util.List;
  * Created by smferguson on 10/5/16.
  */
 public class HashStringColumn implements HashStringProvider {
-    public String getHashString(RowMap r) {
-        throw new UnsupportedOperationException("getHashString(RowMap) not implemented for HashStringColumn");
-    }
-
-    public String getHashString(RowMap r, List<String> partitionColumns) {
-        return r.buildPartitionKey(partitionColumns);
+    public String getHashString(RowMap r, List<String> partitionColumns, String partitionKeyFallback) {
+        return r.buildPartitionKey(partitionColumns, partitionKeyFallback);
     }
 }

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringColumn.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringColumn.java
@@ -1,0 +1,18 @@
+package com.zendesk.maxwell.producer.partitioners;
+
+import com.zendesk.maxwell.RowMap;
+
+import java.util.List;
+
+/**
+ * Created by smferguson on 10/5/16.
+ */
+public class HashStringColumn implements HashStringProvider {
+    public String getHashString(RowMap r) {
+        throw new UnsupportedOperationException("getHashString(RowMap) not implemented for HashStringColumn");
+    }
+
+    public String getHashString(RowMap r, List<String> partitionColumns) {
+        return r.getPartitionKey(partitionColumns);
+    }
+}

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringDatabase.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringDatabase.java
@@ -2,11 +2,13 @@ package com.zendesk.maxwell.producer.partitioners;
 
 import com.zendesk.maxwell.RowMap;
 
+import java.util.List;
+
 /**
  * Created by kaufmannkr on 1/18/16.
  */
 public class HashStringDatabase implements HashStringProvider{
-	public String getHashString(RowMap r) {
+	public String getHashString(RowMap r, List<String> partitionColumns, String partitionKeyFallback) {
 		return r.getDatabase();
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringPrimaryKey.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringPrimaryKey.java
@@ -2,11 +2,13 @@ package com.zendesk.maxwell.producer.partitioners;
 
 import com.zendesk.maxwell.RowMap;
 
+import java.util.List;
+
 /**
  * Created by kaufmannkr on 1/18/16.
  */
 public class HashStringPrimaryKey implements HashStringProvider {
-	public String getHashString(RowMap r) {
+	public String getHashString(RowMap r, List<String> partitionColumns, String partitionKeyFallback) {
 		return r.pkAsConcatString();
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringProvider.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringProvider.java
@@ -2,9 +2,11 @@ package com.zendesk.maxwell.producer.partitioners;
 
 import com.zendesk.maxwell.RowMap;
 
+import java.util.List;
+
 /**
  * Created by kaufmannkr on 1/21/16.
  */
 public interface HashStringProvider {
-	String getHashString(RowMap r);
+	String getHashString(RowMap r, List<String> partitionColumns, String partitionKeyFallback);
 }

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringTable.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/HashStringTable.java
@@ -2,11 +2,13 @@ package com.zendesk.maxwell.producer.partitioners;
 
 import com.zendesk.maxwell.RowMap;
 
+import java.util.List;
+
 /**
  * Created by kaufmannkr on 1/18/16.
  */
 public class HashStringTable implements HashStringProvider {
-	public String getHashString(RowMap r) {
+	public String getHashString(RowMap r, List<String> partitionColumns, String partitionKeyFallback) {
 		return r.getTable();
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaPartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaPartitioner.java
@@ -18,7 +18,7 @@ public class MaxwellKafkaPartitioner {
 
 	private String partitionKeyFallback;
 
-	public MaxwellKafkaPartitioner(String hashFunction, String partitionKey, String csvColumns, String partitionKeyFallback) {
+	public MaxwellKafkaPartitioner(String hashFunction, String partitionKey, String csvPartitionColumns, String partitionKeyFallback) {
 		int MURMUR_HASH_SEED = 25342;
 		switch (hashFunction) {
 			case "murmur3": this.hashFunc = new HashFunctionMurmur3(MURMUR_HASH_SEED);
@@ -40,8 +40,8 @@ public class MaxwellKafkaPartitioner {
 				this.provider = new HashStringDatabase();
 				break;
 		}
-		if ( partitionColumns != null )
-			this.partitionColumns = Arrays.asList(csvColumns.split(","));
+		if ( csvPartitionColumns != null )
+			this.partitionColumns = Arrays.asList(csvPartitionColumns.split("\\s*,\\s*"));
 
 		this.partitionKeyFallback = partitionKeyFallback;
 	}


### PR DESCRIPTION
Add partitioning by one or multiple columns. If the column doesn't exist fall back to partitioning by table. I chose table as the fallback because falling back to primary key seemed like it could be dangerous in certain cases (e.g. using mysql as an immutable store - pk has no meaning). I'm not completely sold on this fallback.
The partitioner holds the columns we will try to partition by. I thought about populating the partition columns to the RowMap, but it didn't feel right for the RowMap to be aware partitioning details.