### PR TITLE
Rework shutdown

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -16,6 +16,7 @@ public class MaxwellMysqlConfig {
 	public String user;
 	public String password;
 	public ArrayList<String> jdbcOptions = new ArrayList<String>();
+	public Integer connectTimeoutMS = 5000;
 
 	public MaxwellMysqlConfig() {
 		this.host = null;
@@ -23,6 +24,10 @@ public class MaxwellMysqlConfig {
 		this.database = null;
 		this.user = null;
 		this.password = null;
+
+		this.jdbcOptions = new ArrayList<>();
+		this.jdbcOptions.add("zeroDateTimeBehavior=convertToNull");
+		this.jdbcOptions.add(String.format("connectTimeout=%d", connectTimeoutMS));
 	}
 
 	public MaxwellMysqlConfig(String host, Integer port, String database, String user, String password) {
@@ -36,8 +41,6 @@ public class MaxwellMysqlConfig {
 	public void setJDBCOptions(String opts) {
 		if (opts == null)
 			return;
-		this.jdbcOptions = new ArrayList<>();
-		this.jdbcOptions.add("zeroDateTimeBehavior=convertToNull");
 
 		for ( String opt : opts.split("&") ) {
 			this.jdbcOptions.add(opt.trim());

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -469,9 +469,9 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		String[] opts = {"--jdbc_options= netTimeoutForStreamingResults=123& profileSQL=true  ", "--host=no-soup-spoons"};
 		MaxwellConfig config = new MaxwellConfig(opts);
 		assertEquals(config.maxwellMysql.getConnectionURI(),
-				"jdbc:mysql://no-soup-spoons:3306/maxwell?zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
+				"jdbc:mysql://no-soup-spoons:3306/maxwell?zeroDateTimeBehavior=convertToNull&connectTimeout=5000&netTimeoutForStreamingResults=123&profileSQL=true");
 		assertEquals(config.replicationMysql.getConnectionURI(),
-				"jdbc:mysql://no-soup-spoons:3306?zeroDateTimeBehavior=convertToNull&netTimeoutForStreamingResults=123&profileSQL=true");
+				"jdbc:mysql://no-soup-spoons:3306?zeroDateTimeBehavior=convertToNull&connectTimeout=5000&netTimeoutForStreamingResults=123&profileSQL=true");
 
 	}
 


### PR DESCRIPTION
1 - make sure we shutdown maxwell before we shutdown log4j.  I think this was the source of some deadlocks.
2 - add a connectTimeout on the jdbc connection so we don't spin endlessly.

@zendesk/rules 

https://github.com/zendesk/maxwell/issues/441
