### PR TITLE
refactor ColumnDef operations into their own class

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -55,7 +55,7 @@ public class Table {
 	@JsonIgnore
 	public List<StringColumnDef> getStringColumns() {
 		ArrayList<StringColumnDef> list = new ArrayList<>();
-		for ( ColumnDef c : columns.getList() ) {
+		for ( ColumnDef c : columns ) {
 			if ( c instanceof StringColumnDef )
 				list.add((StringColumnDef) c);
 		}

--- a/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
+++ b/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
@@ -11,7 +11,7 @@ public class TableColumnList implements Iterable<ColumnDef> {
 
 	public TableColumnList(List<ColumnDef> columns) {
 		this.columns = columns;
-		this.columnOffsetMap = null;
+		initColumnOffsetMap();
 		renumberColumns();
 	}
 
@@ -25,7 +25,6 @@ public class TableColumnList implements Iterable<ColumnDef> {
 
 	public synchronized int indexOf(String name) {
 		String lcName = name.toLowerCase();
-		initColumnOffsetMap();
 
 		if ( this.columnOffsetMap.containsKey(lcName) ) {
 			return this.columnOffsetMap.get(lcName);

--- a/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
+++ b/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
@@ -1,0 +1,84 @@
+package com.zendesk.maxwell.schema;
+
+import java.util.*;
+
+import com.zendesk.maxwell.schema.columndef.ColumnDef;
+
+
+public class TableColumnList implements Iterable<ColumnDef> {
+	private final List<ColumnDef> columns;
+	private HashMap<String, Integer> columnOffsetMap;
+
+	public TableColumnList(List<ColumnDef> columns) {
+		this.columns = columns;
+		this.columnOffsetMap = null;
+		renumberColumns();
+	}
+
+	public Iterator<ColumnDef> iterator() {
+		return columns.iterator();
+	}
+
+	public List<ColumnDef> getList() {
+		return columns;
+	}
+
+	public synchronized int indexOf(String name) {
+		String lcName = name.toLowerCase();
+		initColumnOffsetMap();
+
+		if ( this.columnOffsetMap.containsKey(lcName) ) {
+			return this.columnOffsetMap.get(lcName);
+		} else {
+			return -1;
+		}
+	}
+
+	public ColumnDef findByName(String name) {
+		int index = indexOf(name);
+		if ( index == -1 )
+			return null;
+		else
+			return columns.get(index);
+	}
+
+	public synchronized void add(int index, ColumnDef definition) {
+		columns.add(index, definition);
+		initColumnOffsetMap();
+		renumberColumns();
+	}
+
+	public synchronized ColumnDef remove(int index) {
+		ColumnDef c = columns.remove(index);
+		initColumnOffsetMap();
+		renumberColumns();
+		return c;
+	}
+
+	public synchronized ColumnDef get(int index) {
+		return columns.get(index);
+	}
+
+	public int size() {
+		return columns.size();
+	}
+
+	private void initColumnOffsetMap() {
+		this.columnOffsetMap = new HashMap<>();
+		int i = 0;
+
+		for(ColumnDef c : columns) {
+			this.columnOffsetMap.put(c.getName().toLowerCase(), i++);
+		}
+	}
+
+	private void renumberColumns() {
+		int i = 0 ;
+		for ( ColumnDef c : columns ) {
+			c.setPos(i++);
+		}
+	}
+}
+
+
+

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -146,6 +146,16 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
+	public void testModifyAndMoveColumn() throws Exception {
+		String sql[] = {
+			"CREATE TABLE t ( a varchar(255), b int)",
+			"ALTER TABLE t modify column a varchar(255) after b"
+		};
+		testIntegration(sql);
+
+	}
+
+	@Test
 	public void testPKs() throws Exception {
 		String sql[] = {
 		   "create TABLE `test_pks` ( id int(11) unsigned primary KEY, str varchar(255) )",


### PR DESCRIPTION
Mostly this is about hiding a bunch of the details of column positions and numbering from Table.  Initially I just wanted to address #468, but this is the second bug in that section of code,
so I went to go make that better.

@zendesk/rules 