### PR TITLE
add backquote to db name in sql

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtility.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtility.java
@@ -153,7 +153,7 @@ public class MaxwellBootstrapUtility {
 
 	private Long calculateRowCount(Connection connection, String db, String table) throws SQLException {
 		LOGGER.info("counting rows");
-		String sql = String.format("select count(*) from %s.%s", db, table);
+		String sql = String.format("select count(*) from `%s`.%s", db, table);
 		PreparedStatement preparedStatement = connection.prepareStatement(sql);
 		ResultSet resultSet = preparedStatement.executeQuery();
 		resultSet.next();

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -183,9 +183,9 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		Statement statement = createBatchStatement(connection);
 		String pk = schema.findDatabase(databaseName).findTable(tableName).getPKString();
 		if ( pk != null && !pk.equals("") ) {
-			return statement.executeQuery(String.format("select * from %s.%s order by %s", databaseName, tableName, pk));
+			return statement.executeQuery(String.format("select * from `%s`.%s order by %s", databaseName, tableName, pk));
 		} else {
-			return statement.executeQuery(String.format("select * from %s.%s", databaseName, tableName));
+			return statement.executeQuery(String.format("select * from `%s`.%s", databaseName, tableName));
 		}
 	}
 


### PR DESCRIPTION
**maxwell-bootstrap** will generate sql with syntax error if database name contains "-". i.e. "test-db".
I added backquote to database part in sql template to resolve this issue.
