### PR TITLE
add confluent schema reg support

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -125,6 +125,12 @@ kafka.metadata.fetch.timeout.ms=5000
 kafka.retries=0
 kafka.acks=1
 
+# confluent schema registry specifics
+#kafka.schema.registry.url=http://localhost:8081
+#kafka.key.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
+#kafka.value.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
+
+
 ######### filter stuff ###############
 
 # filter rows out of Maxwell's output.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,24 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>confluent</id>
+      <url>http://packages.confluent.io/maven/</url>
+    </repository>
+  </repositories>
+
   <dependencies>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.7.6</version>
+    </dependency>
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-avro-serializer</artifactId>
+      <version>3.0.1</version>
+    </dependency>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -220,6 +220,9 @@ public class MaxwellContext {
 		case "kafka":
 			this.producer = new MaxwellKafkaProducer(this, this.config.getKafkaProperties(), this.config.kafkaTopic);
 			break;
+		case "kafka-avro":
+			this.producer = new ConfluentAvroProducer(this, this.config.getKafkaProperties(), this.config.kafkaTopic);
+			break;
 		case "profiler":
 			this.producer = new ProfilerProducer(this);
 			break;

--- a/src/main/java/com/zendesk/maxwell/producer/ConfluentAvroProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/ConfluentAvroProducer.java
@@ -1,0 +1,128 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.producer.partitioners.MaxwellKafkaPartitioner;
+import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.row.RowMap.KeyFormat;
+import com.zendesk.maxwell.schema.ddl.DDLMap;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class ConfluentAvroProducer extends AbstractProducer {
+    static final Logger LOGGER = LoggerFactory.getLogger(ConfluentAvroProducer.class);
+
+    private final InflightMessageList inflightMessages;
+    private final KafkaProducer<String, Object> kafka;
+    private String topic;
+    private final String ddlTopic;
+    private final MaxwellKafkaPartitioner partitioner;
+    private final MaxwellKafkaPartitioner ddlPartitioner;
+    private final KeyFormat keyFormat;
+
+    public ConfluentAvroProducer(MaxwellContext context, Properties kafkaProperties, String kafkaTopic) {
+        super(context);
+
+        this.topic = kafkaTopic;
+        if ( this.topic == null ) {
+            this.topic = "maxwell";
+        }
+
+        this.kafka = new KafkaProducer<>(kafkaProperties);
+
+        String hash = context.getConfig().kafkaPartitionHash;
+        String partitionKey = context.getConfig().kafkaPartitionKey;
+        String partitionColumns = context.getConfig().kafkaPartitionColumns;
+        String partitionFallback = context.getConfig().kafkaPartitionFallback;
+        this.partitioner = new MaxwellKafkaPartitioner(hash, partitionKey, partitionColumns, partitionFallback);
+        this.ddlPartitioner = new MaxwellKafkaPartitioner(hash, "database", null,"database");
+        this.ddlTopic =  context.getConfig().ddlKafkaTopic;
+
+        if ( context.getConfig().kafkaKeyFormat.equals("hash") )
+            keyFormat = KeyFormat.HASH;
+        else
+            keyFormat = KeyFormat.ARRAY;
+
+        this.inflightMessages = new InflightMessageList();
+    }
+
+    private Integer getNumPartitions(String topic) {
+        try {
+            return this.kafka.partitionsFor(topic).size(); //returns 1 for new topics
+        } catch (KafkaException e) {
+            LOGGER.error("Topic '" + topic + "' name does not exist. Exception: " + e.getLocalizedMessage());
+            throw e;
+        }
+    }
+
+    private String generateTopic(String topic, RowMap r){
+        return topic.replaceAll("%\\{database\\}", r.getDatabase()).replaceAll("%\\{table\\}", r.getTable());
+    }
+
+    @Override
+    public void push(RowMap r) throws Exception {
+        String key = r.pkToJson(keyFormat);
+        String value = r.toJSON(outputConfig);
+
+        if ( value == null ) { // heartbeat row or other row with suppressed output
+            inflightMessages.addMessage(r.getPosition());
+            BinlogPosition newPosition = inflightMessages.completeMessage(r.getPosition());
+
+            if ( newPosition != null ) {
+                context.setPosition(newPosition);
+            }
+
+            return;
+        }
+
+        KafkaCallback callback;
+        ProducerRecord<String, Object> record;
+        if (r instanceof DDLMap) {
+
+            record = new ProducerRecord<>(this.ddlTopic, this.ddlPartitioner.kafkaPartition(r, getNumPartitions(this.ddlTopic)), key, (Object) value);
+
+            callback = new KafkaCallback(inflightMessages, r.getPosition(), r.isTXCommit(), this.context, key, value);
+        } else {
+            MaxwellEnvelope maxwellEnvelope = new MaxwellEnvelope(
+                    r.getDatabase(),
+                    r.getTable(),
+                    r.getRowType(),
+                    r.getTimestamp(),
+                    r.getXid(),
+                    r.isTXCommit(),
+                    r.getPosition().toString(),
+                    r.getServerId(),
+                    r.getThreadId(),
+                    r.getData(outputConfig.includesNulls),
+                    r.getOldData(outputConfig.includesNulls));
+
+            String topic = generateTopic(this.topic, r);
+            record = new ProducerRecord<>(topic, this.partitioner.kafkaPartition(r, getNumPartitions(topic)), key, (Object) maxwellEnvelope);
+
+            callback = new KafkaCallback(inflightMessages, r.getPosition(), r.isTXCommit(), this.context, key, maxwellEnvelope);
+        }
+
+        if ( r.isTXCommit() )
+            inflightMessages.addMessage(r.getPosition());
+
+
+		/* if debug logging isn't enabled, release the reference to `value`, which can ease memory pressure somewhat */
+        if ( !KafkaCallback.LOGGER.isDebugEnabled() )
+            value = null;
+
+        kafka.send(record, callback);
+    }
+
+    @Override
+    public void writePosition(BinlogPosition p) throws SQLException {
+        // ensure that we don't prematurely advance the binlog pointer.
+        inflightMessages.addMessage(p);
+        inflightMessages.completeMessage(p);
+    }
+}

--- a/src/main/java/com/zendesk/maxwell/producer/KafkaCallback.java
+++ b/src/main/java/com/zendesk/maxwell/producer/KafkaCallback.java
@@ -1,0 +1,58 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.replication.BinlogPosition;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class KafkaCallback implements Callback {
+    public static final Logger LOGGER = LoggerFactory.getLogger(KafkaCallback.class);
+    private InflightMessageList inflightMessages;
+    private final MaxwellContext context;
+    private final BinlogPosition position;
+    private final boolean isTXCommit;
+    private Object data = null;
+    private final String key;
+
+    public KafkaCallback(InflightMessageList inflightMessages, BinlogPosition position, boolean isTXCommit, MaxwellContext c, String key, Object data) {
+        this.inflightMessages = inflightMessages;
+        this.context = c;
+        this.position = position;
+        this.isTXCommit = isTXCommit;
+        this.key = key;
+        this.data = data;
+    }
+
+    @Override
+    public void onCompletion(RecordMetadata md, Exception e) {
+        if ( e != null ) {
+            LOGGER.error(e.getClass().getSimpleName() + " @ " + position + " -- " + key);
+            LOGGER.error(e.getLocalizedMessage());
+            if ( e instanceof RecordTooLargeException) {
+                LOGGER.error("Considering raising max.request.size broker-side.");
+            }
+        } else {
+            if ( LOGGER.isDebugEnabled()) {
+                LOGGER.debug("->  key:" + key + ", partition:" + md.partition() + ", offset:" + md.offset());
+                LOGGER.debug("   " + this.data.toString());
+                LOGGER.debug("   " + position);
+                LOGGER.debug("");
+            }
+        }
+        markCompleted();
+    }
+
+    private void markCompleted() {
+        if ( isTXCommit ) {
+            BinlogPosition newPosition = inflightMessages.completeMessage(position);
+
+            if ( newPosition != null ) {
+                context.setPosition(newPosition);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellEnvelope.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellEnvelope.java
@@ -1,0 +1,145 @@
+package com.zendesk.maxwell.producer;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+
+public class MaxwellEnvelope extends SpecificRecordBase implements SpecificRecord {
+    static final Logger LOGGER = LoggerFactory.getLogger(MaxwellEnvelope.class);
+
+    public static Schema SCHEMA = null;
+
+    private static final InputStream avroSchema = MaxwellEnvelope.class.getResourceAsStream("/avro/MaxwellEnvelope.avro");
+
+    private CharSequence database;
+    private CharSequence table;
+    private CharSequence type;
+    private Long ts;
+    private Long xid;
+    private Boolean commit;
+    private CharSequence position;
+    private Long serverId;
+    private Long threadId;
+    private CharSequence data;
+    private CharSequence old;
+
+    public Schema getSchema() {
+        if (SCHEMA == null) {
+            try {
+                SCHEMA = new Schema.Parser().parse(avroSchema);
+            } catch (java.io.IOException ioe) {
+                LOGGER.error("File '" + avroSchema + "' name does not exist. Exception: " + ioe.getLocalizedMessage());
+                return null;
+            }
+        }
+        return SCHEMA;
+    }
+
+    public MaxwellEnvelope(CharSequence database, CharSequence table, CharSequence type, Long ts, Long xid, Boolean commit, CharSequence position, Long serverId, Long threadId, CharSequence data, CharSequence old) {
+        this.database = database;
+        this.table = table;
+        this.type = type;
+        this.ts = ts;
+        this.xid = xid;
+        this.commit = commit;
+        this.position = position;
+        this.serverId = serverId;
+        this.threadId = threadId;
+        this.data = data;
+        this.old = old;
+    }
+
+    // Used by DatumWriter.  Applications should not call.
+    public java.lang.Object get(int field) {
+        switch (field) {
+            case 0:
+                return this.database;
+            case 1:
+                return this.table;
+            case 2:
+                return this.type;
+            case 3:
+                return this.ts;
+            case 4:
+                return this.xid;
+            case 5:
+                return this.commit;
+            case 6:
+                return this.position;
+            case 7:
+                return this.serverId;
+            case 8:
+                return this.threadId;
+            case 9:
+                return this.data;
+            case 10:
+                return this.old;
+            default:
+                throw new AvroRuntimeException("Bad index found in get(), index is " + field);
+        }
+    }
+
+    // Used by DatumReader.  Applications should not call.
+    @SuppressWarnings(value = "unchecked")
+    public void put(int field, java.lang.Object value) {
+        switch (field) {
+            case 0:
+                this.database = (CharSequence) value;
+                break;
+            case 1:
+                this.table = (CharSequence) value;
+                break;
+            case 2:
+                this.type = (CharSequence) value;
+                break;
+            case 3:
+                this.ts = (Long) value;
+                break;
+            case 4:
+                this.xid = (Long) value;
+                break;
+            case 5:
+                this.commit = (Boolean) value;
+                break;
+            case 6:
+                this.position = (CharSequence) value;
+                break;
+            case 7:
+                this.serverId = (Long) value;
+                break;
+            case 8:
+                this.threadId = (Long) value;
+                break;
+            case 9:
+                this.data = (CharSequence) value;
+                break;
+            case 10:
+                this.old = (CharSequence) value;
+                break;
+            default:
+                throw new AvroRuntimeException("Bad index");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MaxwellEnvelope{" +
+                "database=" + database +
+                ", table=" + table +
+                ", type=" + type +
+                ", ts=" + ts +
+                ", xid=" + xid +
+                ", commit=" + commit +
+                ", position=" + position +
+                ", serverId=" + serverId +
+                ", threadId=" + threadId +
+                ", data=" + data +
+                ", old=" + old +
+                '}';
+    }
+}

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -186,7 +186,10 @@ public class RowMap implements Serializable {
 
 	private void writeMapToJSON(String jsonMapName, LinkedHashMap<String, Object> data, boolean includeNullField) throws IOException {
 		JsonGenerator generator = jsonGeneratorThreadLocal.get();
-		generator.writeObjectFieldStart(jsonMapName); // start of jsonMapName: {
+
+		if (jsonMapName != null) {
+			generator.writeObjectFieldStart(jsonMapName); // start of jsonMapName: {
+		}
 
 		for ( String key: data.keySet() ) {
 			Object value = data.get(key);
@@ -207,7 +210,9 @@ public class RowMap implements Serializable {
 			}
 		}
 
-		generator.writeEndObject(); // end of 'jsonMapName: { }'
+		if (jsonMapName != null) {
+			generator.writeEndObject(); // end of 'jsonMapName: { }'
+		}
 	}
 
 	public String toJSON() throws IOException {
@@ -283,6 +288,17 @@ public class RowMap implements Serializable {
 		return this.data.get(key);
 	}
 
+	public String getData(Boolean includeNulls) throws IOException  {
+		JsonGenerator g = jsonGeneratorThreadLocal.get();
+
+		g.writeStartObject();
+		writeMapToJSON(null, this.data, includeNulls);
+		g.writeEndObject(); // end of row
+		g.flush();
+
+		return jsonFromStream();
+	}
+
 
 	public long getApproximateSize() {
 		return approximateSize;
@@ -310,6 +326,21 @@ public class RowMap implements Serializable {
 
 	public Object getOldData(String key) {
 		return this.oldData.get(key);
+	}
+
+	public String getOldData(Boolean includeNulls) throws IOException  {
+		if ( this.oldData.isEmpty() ) {
+			return null;
+		} else {
+			JsonGenerator g = jsonGeneratorThreadLocal.get();
+
+			g.writeStartObject();
+			writeMapToJSON(null, this.oldData, includeNulls);
+			g.writeEndObject(); // end of row
+			g.flush();
+
+			return jsonFromStream();
+		}
 	}
 
 	public void putOldData(String key, Object value) {

--- a/src/main/resources/avro/MaxwellEnvelope.avro
+++ b/src/main/resources/avro/MaxwellEnvelope.avro
@@ -1,0 +1,63 @@
+{
+    "type":"record",
+    "name":"MaxwellEnvelope",
+    "namespace":"MaxwellEnvelope.avro",
+    "fields":[
+        {
+            "name":"database",
+            "type":"string",
+            "doc":"The source database for the data."
+        },
+        {
+            "name":"table",
+            "type":"string",
+            "doc":"The source table for the data."
+        },
+        {
+            "name":"type",
+            "type":"string",
+            "doc":"The type of operation (insert, update, delete)."
+        },
+        {
+            "name":"ts",
+            "type":"long",
+            "doc":"The timestamp Maxwell populated the RowMap structure."
+        },
+        {
+            "name":"xid",
+            "type":"long",
+            "doc":"The MySQL transaction id."
+        },
+        {
+            "name":"commit",
+            "type":"boolean",
+            "doc":"If this data was committed (always true)."
+        },
+        {
+            "name":"position",
+            "type":"string",
+            "doc":"The current binlog and its position."
+        },
+        {
+            "name":"server_id",
+            "type":"long",
+            "doc":"The MySQL server_id."
+        },
+        {
+            "name":"thread_id",
+            "type":"long",
+            "doc":"The id of the Maxwell thread used to process this row."
+        },
+        {
+            "name":"data",
+            "type":"string",
+            "doc":"The row data."
+        },
+        {
+            "name":"old",
+            "type":["null","string"],
+            "default": "null",
+            "doc":"The old row data. i.e. the row data before the current row state."
+        }
+    ]
+}


### PR DESCRIPTION
step 1 of adding support for avro + confluent schema reg. step 2 would be dynamic schemas for the actual data, but i'm not sure i'll have time to tackle that one soon.
this isn't complete (it is fully functional), but i'd like a sanity check. there are a few things i'm not in love with. the biggest offender being the avro + confluent deps that add a lot of bloat (new jars listed below). other things like the static nature of the fields in avro schema which rm's some of the output flexibilty, bug me, but could be justifiable.
new jars:
 - avro-1.7.6.jar
 - common-config-3.0.1.jar
 - common-utils-3.0.1.jar
 - commons-compress-1.4.1.jar
 - jackson-core-asl-1.9.13.jar
 - jackson-mapper-asl-1.9.13.jar
 - jline-0.9.94.jar
 - kafka-avro-serializer-3.0.1.jar
 - kafka-schema-registry-client-3.0.1.jar
 - netty-3.2.2.Final.jar
 - paranamer-2.3.jar
 - xz-1.0.jar
 - zkclient-0.5.jar
 - zookeeper-3.4.3.jar