### PR TITLE
add required lib for 0.10 to work with lz4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
       <artifactId>jts</artifactId>
       <version>1.13</version>
     </dependency>
+    <dependency>
+      <groupId>net.jpountz.lz4</groupId>
+      <artifactId>lz4</artifactId>
+      <version>1.3.0</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
annoying one... 0.9 and 0.8 clients work fine with lz4. 0.10 blows up unless this is included.