### PR TITLE
explicitly ignore the strangely-missing ha_health_check table

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -277,10 +277,17 @@ public class MaxwellReplicator extends RunLoopProcess {
 						continue;
 					}
 
-					Boolean isSystemWhitelisted = event.getDatabase().equals(this.maxwellSchemaDatabaseName)
-							&& event.getTable().name.equals("bootstrap");
+					String table = event.getTable().name;
+					String database = event.getDatabase();
 
-					if ( event.matchesFilter() || isSystemWhitelisted ) {
+					Boolean isSystemWhitelisted = database.equals(this.maxwellSchemaDatabaseName)
+							&& table.equals("bootstrap");
+
+					/* there's an odd RDS thing, I guess, where ha_health_check doesn't
+					 * show up in INFORMATION_SCHEMA but it's replicated nonetheless. */
+					Boolean isSystemBlacklisted = database.equals("mysql") && table.equals("ha_health_check");
+
+					if ( !isSystemBlacklisted && (event.matchesFilter() || isSystemWhitelisted) ) {
 						for ( RowMap r : event.jsonMaps() )
 							buffer.add(r);
 					}

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -307,6 +307,17 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertThat(list.get(2).isTXCommit(), is(true));
 	}
 
+	@Test
+	public void testSystemBlacklist() throws Exception  {
+		String sql[] = {
+			"create table mysql.ha_health_check ( id int )",
+			"insert into mysql.ha_health_check set id = 1"
+		};
+
+		List<RowMap> list = getRowsForSQL(sql);
+		assertThat(list.size(), is(0));
+	}
+
 	String testTransactions[] = {
 			"create table if not exists minimal ( account_id int, text_field text )",
 			"BEGIN",


### PR DESCRIPTION
I guess it doesn't appear in INFORMATION_SCHEMA tables.

addresses #469.