### PR TITLE
remove never-used row-filtering functionality

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -22,8 +22,6 @@ public class MaxwellFilter {
 
 	private final ArrayList<Pattern> excludeColumns = new ArrayList<>();
 
-	private final HashMap<String, Integer> rowFilter = new HashMap<>();
-
 	public MaxwellFilter() { }
 	public MaxwellFilter(String includeDatabases,
 						 String excludeDatabases,
@@ -117,10 +115,6 @@ public class MaxwellFilter {
 
 	}
 
-	public void addRowConstraint(String field, Integer value) {
-		rowFilter.put(field, value);
-	}
-
 	private boolean matchesIncludeExcludeList(List<Pattern> includeList, List<Pattern> excludeList, String name) {
 		if ( includeList.size() > 0 ) {
 			boolean found = false;
@@ -150,40 +144,10 @@ public class MaxwellFilter {
 		return matchesIncludeExcludeList(includeTables, excludeTables, tableName);
 	}
 
-	public boolean matchesRow(AbstractRowsEvent e, Row r) {
-		for (Map.Entry<String, Integer> entry : rowFilter.entrySet()) {
-			Column c = e.findColumn(entry.getKey(), r);
-			if ( c == null )
-				return false;
-
-			if ( c.getValue() == entry.getValue() ) {
-				continue; // null or same instance
-			}
-
-			if ( c.getValue() == null || entry.getValue() == null ) {
-				return false; // one side is null
-			}
-
-			if ( !c.getValue().equals(entry.getValue())) {
-				return false;
-			}
-
-		}
-		return true;
-	}
-
-	private boolean matchesAnyRows(AbstractRowsEvent e) {
-		for (Row r : e.getRows()) {
-			if ( matchesRow(e, r) )
-				return true;
-		}
-		return false;
-	}
-
 	public boolean matches(AbstractRowsEvent e) {
 		String database = e.getTable().getDatabase();
 		String table = e.getTable().getName();
-		return matchesDatabase(database) && matchesTable(table) && matchesAnyRows(e);
+		return matchesDatabase(database) && matchesTable(table);
 	}
 
 	public boolean isDatabaseBlacklisted(String databaseName) {
@@ -201,11 +165,5 @@ public class MaxwellFilter {
 
 	public ArrayList<Pattern> getExcludeColumns() {
 		return excludeColumns;
-	}
-
-	private void throwUnlessEmpty(HashSet<String> set, String objType) {
-		if ( set.size() != 0 ) {
-			throw new IllegalArgumentException("A " + objType + " filter may only be inclusive or exclusive");
-		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractRowsEvent.java
@@ -93,26 +93,6 @@ public abstract class AbstractRowsEvent extends AbstractRowEvent {
 	public abstract List<Row> getRows();
 	public abstract String sqlOperationString();
 
-	private LinkedList<Row> filteredRows;
-	private boolean performedFilter = false;
-
-	protected List<Row> filteredRows() {
-		if ( this.filter == null )
-			return getRows();
-
-		if ( performedFilter )
-			return filteredRows;
-
-		filteredRows = new LinkedList<>();
-		for ( Row r : getRows()) {
-			if ( this.filter.matchesRow(this, r) )
-				filteredRows.add(r);
-		}
-		performedFilter = true;
-
-		return filteredRows;
-	}
-
 	private void appendColumnNames(StringBuilder sql)
 	{
 		sql.append(" (");
@@ -128,7 +108,7 @@ public abstract class AbstractRowsEvent extends AbstractRowEvent {
 
 	public String toSQL() {
 		StringBuilder sql = new StringBuilder();
-		List<Row> rows = filteredRows();
+		List<Row> rows = getRows();
 
 		if ( rows.isEmpty() )
 			return null;
@@ -194,9 +174,7 @@ public abstract class AbstractRowsEvent extends AbstractRowEvent {
 	public List<RowMap> jsonMaps() {
 		ArrayList<RowMap> list = new ArrayList<>();
 
-		for ( Iterator<Row> ri = filteredRows().iterator() ; ri.hasNext(); ) {
-			Row r = ri.next();
-
+		for ( Row r : getRows() ) {
 			RowMap rowMap;
 			if (this.filter != null && this.filter.hasExcludeColumns())
 				rowMap = buildRowMap(this.filter.getExcludeColumns());

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -280,6 +280,7 @@ public class MaxwellReplicator extends RunLoopProcess {
 					String table = event.getTable().name;
 					String database = event.getDatabase();
 
+					/* always pass bootstrap rows through */
 					Boolean isSystemWhitelisted = database.equals(this.maxwellSchemaDatabaseName)
 							&& table.equals("bootstrap");
 

--- a/src/main/java/com/zendesk/maxwell/replication/UpdateRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/UpdateRowsEvent.java
@@ -55,29 +55,10 @@ public class UpdateRowsEvent extends AbstractRowsEvent {
 		return "update";
 	}
 
-	private LinkedList<Pair<Row>> filteredRowsBeforeAndAfter;
-	private boolean performedBeforeAndAfterFilter;
-
-	private List<Pair<Row>> filteredRowsBeforeAndAfter() {
-		if ( this.filter == null)
-			return event.getRows();
-
-		if ( performedBeforeAndAfterFilter )
-			return filteredRowsBeforeAndAfter;
-
-		filteredRowsBeforeAndAfter = new LinkedList<>();
-		for ( Pair<Row> p : event.getRows()) {
-			if ( this.filter.matchesRow(this, p.getAfter()) )
-				filteredRowsBeforeAndAfter.add(p);
-		}
-		performedBeforeAndAfterFilter = true;
-		return filteredRowsBeforeAndAfter;
-	}
-
 	@Override
 	public List<RowMap> jsonMaps() {
 		ArrayList<RowMap> list = new ArrayList<>();
-		for (Pair<Row> p : filteredRowsBeforeAndAfter() ) {
+		for (Pair<Row> p : event.getRows() ) {
 			Row after = p.getAfter();
 			Row before = p.getBefore();
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -55,44 +55,6 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
-	public void testRowFilter() throws Exception {
-		List<RowMap> list;
-		String input[] = {"insert into minimal set account_id = 1000, text_field='hello'",
-						  "insert into minimal set account_id = 2000, text_field='goodbye'"};
-
-		list = getRowsForSQL(input);
-		assertThat(list.size(), is(2));
-
-		MaxwellFilter filter = new MaxwellFilter();
-
-		@SuppressWarnings("UnnecessaryBoxing")
-		Integer filterValue = new Integer(2000); // make sure we're using a different instance of the filter value
-
-		filter.addRowConstraint("account_id", filterValue);
-
-		list = getRowsForSQL(filter, input);
-		assertThat(list.size(), is(1));
-
-		RowMap jsonMap = list.get(0);
-
-		assertThat((Long) jsonMap.getData("account_id"), is(2000L));
-		assertThat((String) jsonMap.getData("text_field"), is("goodbye"));
-	}
-
-	@Test
-	public void testRowFilterOnNonExistentFields() throws Exception {
-		List<RowMap> list;
-		String input[] = {"insert into minimal set account_id = 1000, text_field='hello'",
-						  "insert into minimal set account_id = 2000, text_field='goodbye'"};
-
-		MaxwellFilter filter = new MaxwellFilter();
-		filter.addRowConstraint("piggypiggy", 2000);
-
-		list = getRowsForSQL(filter, input);
-		assertThat(list.size(), is(0));
-	}
-
-	@Test
 	public void testOutputConfig() throws Exception {
 		List<RowMap> list;
 		String input[] = {"insert into minimal set account_id =1, text_field='hello'"};


### PR DESCRIPTION
This came over as part of the imported exodus code base, and we shlepped it along for some time but never really had a request (or a need) to wire it into the frontend.  It was intended to filter out rows based on column-values.

@zendesk/rules 

