### PR TITLE
cleanup the old server position after master recovery

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -8,6 +8,7 @@ import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.MaxwellReplicator;
 import com.zendesk.maxwell.recovery.Recovery;
 import com.zendesk.maxwell.recovery.RecoveryInfo;
+import com.zendesk.maxwell.schema.MysqlPositionStore;
 import com.zendesk.maxwell.util.Logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +62,8 @@ public class Maxwell implements Runnable {
 
 	private BinlogPosition attemptMasterRecovery() throws Exception {
 		BinlogPosition recovered = null;
-		RecoveryInfo recoveryInfo = this.context.getRecoveryInfo();
+		MysqlPositionStore positionStore = this.context.getPositionStore();
+		RecoveryInfo recoveryInfo = positionStore.getRecoveryInfo();
 
 		if ( recoveryInfo != null ) {
 			Recovery masterRecovery = new Recovery(
@@ -88,6 +90,8 @@ public class Maxwell implements Runnable {
 				);
 
 				oldServerSchemaStore.clone(context.getServerID(), recovered);
+
+				positionStore.delete(recoveryInfo.serverID, recoveryInfo.clientID, recoveryInfo.position);
 			}
 		}
 		return recovered;

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -164,4 +164,18 @@ public class MysqlPositionStore {
 		}
 		return info;
 	}
+
+	public int delete(Long serverID, String clientID, BinlogPosition position) throws SQLException {
+		try ( Connection c = connectionPool.getConnection()) {
+			PreparedStatement s = c.prepareStatement(
+				"DELETE from `positions` where server_id = ? and client_id = ? and binlog_file = ? and binlog_position = ?"
+			);
+			s.setLong(1, serverID);
+			s.setString(2, clientID);
+			s.setString(3, position.getFile());
+			s.setLong(4, position.getOffset());
+			s.execute();
+			return s.getUpdateCount();
+		}
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
+++ b/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
@@ -176,6 +176,12 @@ public class RecoveryTest extends TestWithNameLogging {
 		}
 		assertEquals(true, foundSchema);
 		maxwell.terminate();
+
+		// assert that we deleted the old position row
+		rs = slaveServer.getConnection().createStatement().executeQuery("select * from maxwell.positions");
+		rs.next();
+		assertEquals(12345, rs.getLong("server_id"));
+		assert(!rs.next());
 	}
 
 


### PR DESCRIPTION
If we don't delete it, everything is fine until we re-promote the old master, at which point we get a poison position and end up in a bad way.  This happened last night.

@zendesk/rules 