### PR TITLE
remove PK column before we remove from the column-list.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -222,8 +222,9 @@ public class Table {
 	}
 
 	public void removeColumn(int idx) {
-		ColumnDef removed = columns.remove(idx);
-		removePKColumn(removed.getName());
+		ColumnDef toRemove = columns.get(idx);
+		removePKColumn(toRemove.getName());
+		columns.remove(idx);
 	}
 
 	public void changeColumn(int idx, ColumnPosition position, ColumnDef definition) throws InvalidSchemaError {

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -164,7 +164,8 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		   "create TABLE `test_pks_4` ( id int(11) unsigned primary KEY, str varchar(255) )",
 		   "alter TABLE `test_pks_3` drop primary key, add primary key(str)",
 		   "alter TABLE `test_pks_4` drop primary key",
-		   "alter TABLE `test_pks` change id renamed_id int(11) unsigned"
+		   "alter TABLE `test_pks` change id renamed_id int(11) unsigned",
+		   "alter TABLE `test_pks` drop column renamed_id"
 		};
 
 		testIntegration(sql);


### PR DESCRIPTION
Otherwise we could crash, depending on whether we had memoized the column list or not.

Note that I started down a road of refactoring the primary-key list into `TableColumnList`, but I found it to be really, really nasty due to oddities over deserialization (and especially the order in which fields deserialize).

