### PR TITLE
let HeartbeatRowMap advance the binlog position

### DIFF
--- a/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
@@ -28,4 +28,9 @@ public class HeartbeatRowMap extends RowMap {
 	public String toJSON() throws IOException {
 		return null;
 	}
+
+	@Override
+	public boolean isTXCommit() {
+		return true;
+	}
 }


### PR DESCRIPTION
this will cause an extra update to `positions` -- the flow now will go 

1.  Reading data triggers a position update
2.  This causes a heartbeat to send
3.  This advances the binlog position, and we update again.  Note that we do *not* send a heartbeat here.

But this should be more correct.  In particular, this should stabilize `RecoveryTest` immensely.

@zendesk/rules 