### PR TITLE
Separate heartbeats into their own table

### DIFF
--- a/src/main/java/com/zendesk/maxwell/recovery/RecoveryFilter.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/RecoveryFilter.java
@@ -15,6 +15,6 @@ public class RecoveryFilter extends MaxwellFilter {
 
 	@Override
 	public boolean isTableBlacklisted(String databaseName, String tableName) {
-		return !(databaseName.equals(maxwellDatabaseName) && tableName.equals("positions"));
+		return !(databaseName.equals(maxwellDatabaseName) && tableName.equals("heartbeats"));
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -41,9 +41,10 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 	 * Possibly convert a RowMap object into a HeartbeatRowMap
 	 *
 	 * Process a rowmap that represents a write to `maxwell`.`heartbeats`.
-	 * If it's a write for a different client_id, we return just the RowMap,
-	 * which will be ignored.  Otherwise, we transform it into a
-	 * HeartbeatRowMap and set lastHeartbeatRead.
+	 * If it's a write for a different client_id, we return the input (which
+	 * will signify to the rest of the chain to ignore it).  Otherwise, we
+	 * transform it into a HeartbeatRowMap (which will not be output, but will
+	 * advance the binlog position) and set `this.lastHeartbeatRead`
 	 *
 	 * @return either a RowMap or a HeartbeatRowMap
 	 */
@@ -57,6 +58,15 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 		return HeartbeatRowMap.valueOf(row.getDatabase(), row.getPosition(), this.lastHeartbeatRead);
 	}
 
+	/**
+	 * Parse a DDL statement and output the results to the producer
+	 *
+	 * @param dbName The database "context" under which the SQL is to be processed.  think "use db; alter table foo ..."
+	 * @param sql The DDL SQL to be processed
+	 * @param schemaStore A SchemaStore object to which we delegate the parsing of the sql
+	 * @param position The position that the SQL happened at
+	 * @param timestmap The timestamp of the SQL binlog event
+	 */
 	protected void processQueryEvent(String dbName, String sql, SchemaStore schemaStore, BinlogPosition position, Long timestamp) throws Exception {
 		List<ResolvedSchemaChange> changes =  schemaStore.processSQL(sql, dbName, position);
 		for ( ResolvedSchemaChange change : changes ) {
@@ -70,13 +80,23 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 			this.producer.writePosition(position);
 	}
 
+	/**
+	 * Should we output an event for the given database and table?
+	 *
+	 * Here we check against a whitelist/blacklist/filter.  The whitelist
+	 * passes updates to `maxwell.bootstrap` through (those are control
+	 * mechanisms for bootstrap), the blacklist gets rid of the
+	 * `ha_health_check` table which shows up oddly in Amazon RDS.
+	 *
+	 * @param database The database of the DML
+	 * @param table The table of the DML
+	 * @param filter A table-filter, or null
+	 * @return Whether we should write the event to the producer
+	 */
 	protected boolean shouldOutputEvent(String database, String table, MaxwellFilter filter) {
-		/* always pass bootstrap rows through */
 		Boolean isSystemWhitelisted = database.equals(this.maxwellSchemaDatabaseName)
 			&& table.equals("bootstrap");
 
-		/* there's an odd RDS thing, I guess, where ha_health_check doesn't
-		 * show up in INFORMATION_SCHEMA but it's replicated nonetheless. */
 		Boolean isSystemBlacklisted = database.equals("mysql") && table.equals("ha_health_check");
 		if ( isSystemBlacklisted )
 			return false;
@@ -90,13 +110,18 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 	 * Get the last heartbeat that the replicator has processed.
 	 *
 	 * We pass along the value of the heartbeat to the producer inside the row map.
-	 * @return the millisecond value ot fhte last heartbeat
+	 * @return the millisecond value ot the last heartbeat read
 	 */
 
 	public Long getLastHeartbeatRead() {
 		return lastHeartbeatRead;
 	}
 
+	/**
+	 * get a single row from the replicator and pass it to the producer or bootstrapper.
+	 *
+	 * This is the top-level function in the run-loop.
+	 */
 	public void work() throws Exception {
 		RowMap row = getRow();
 
@@ -117,6 +142,13 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 			bootstrapper.work(row, producer, this);
 	}
 
+	/**
+	 * Is this RowMap an update to one of maxwell's own tables?
+	 *
+	 * If so we will often suppress the output.
+	 * @param row The RowMap in question
+	 * @return whether the update is something maxwell itself generated
+	 */
 	protected boolean isMaxwellRow(RowMap row) {
 		return row.getDatabase().equals(this.maxwellSchemaDatabaseName);
 	}

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -47,7 +47,7 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 	 *
 	 * @return either a RowMap or a HeartbeatRowMap
 	 */
-	private RowMap processHeartbeats(RowMap row) throws SQLException {
+	protected RowMap processHeartbeats(RowMap row) throws SQLException {
 		String hbClientID = (String) row.getData("client_id");
 		if ( !Objects.equals(hbClientID, this.clientID) )
 			return row; // plain row -- do not process.

--- a/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
@@ -28,4 +28,9 @@ public class HeartbeatRowMap extends RowMap {
 	public String toJSON() throws IOException {
 		return null;
 	}
+
+	@Override
+	public boolean isTXCommit() {
+		return true;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -62,6 +62,7 @@ public class SchemaStoreSchema {
 		LOGGER.info("Creating " + schemaDatabaseName + " database");
 		executeSQLInputStream(connection, SchemaStoreSchema.class.getResourceAsStream("/sql/maxwell_schema.sql"), schemaDatabaseName);
 		executeSQLInputStream(connection, SchemaStoreSchema.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql"), schemaDatabaseName);
+		executeSQLInputStream(connection, SchemaStoreSchema.class.getResourceAsStream("/sql/maxwell_schema_heartbeats.sql"), schemaDatabaseName);
 	}
 
 	private static HashMap<String, String> getTableColumns(String table, Connection c) throws SQLException {
@@ -89,11 +90,12 @@ public class SchemaStoreSchema {
 	}
 
 	public static void upgradeSchemaStoreSchema(Connection c) throws SQLException, IOException {
+		ArrayList<String> maxwellTables = getMaxwellTables(c);
 		if ( !getTableColumns("schemas", c).containsKey("deleted") ) {
 			performAlter(c, "alter table `schemas` add column deleted tinyint(1) not null default 0");
 		}
 
-		if ( !getMaxwellTables(c).contains("bootstrap") )  {
+		if ( !maxwellTables.contains("bootstrap") )  {
 			LOGGER.info("adding bootstrap tables to the maxwell schema.");
 			InputStream is = MysqlSavedSchema.class.getResourceAsStream("/sql/maxwell_schema_bootstrap.sql");
 			executeSQLInputStream(c, is, null);
@@ -143,6 +145,12 @@ public class SchemaStoreSchema {
 		if ( !schemaColumns.containsKey("position_sha") ) {
 			performAlter(c, "alter table `schemas` add column `position_sha` char(40) charset 'latin1' null default null, add unique index(`position_sha`)");
 			backfillPositionSHAs(c);
+		}
+
+		if ( !maxwellTables.contains("heartbeats") )  {
+			LOGGER.info("adding heartbeats table to the maxwell schema.");
+			InputStream is = MysqlSavedSchema.class.getResourceAsStream("/sql/maxwell_schema_heartbeats.sql");
+			executeSQLInputStream(c, is, null);
 		}
 	}
 

--- a/src/main/resources/sql/maxwell_schema_heartbeats.sql
+++ b/src/main/resources/sql/maxwell_schema_heartbeats.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS `heartbeats` (
+  server_id int unsigned not null,
+  client_id varchar(255) charset latin1 not null default 'maxwell',
+  heartbeat bigint null default null,
+  primary key(server_id, client_id)
+);

--- a/src/main/resources/sql/maxwell_schema_heartbeats.sql
+++ b/src/main/resources/sql/maxwell_schema_heartbeats.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `heartbeats` (
   server_id int unsigned not null,
   client_id varchar(255) charset latin1 not null default 'maxwell',
-  heartbeat bigint null default null,
+  heartbeat bigint not null,
   primary key(server_id, client_id)
 );

--- a/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
@@ -33,10 +33,10 @@ public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 		Long preHeartbeat = System.currentTimeMillis();
 		store.heartbeat();
 
-		ResultSet rs = server.getConnection().createStatement().executeQuery("select * from maxwell.positions");
+		ResultSet rs = server.getConnection().createStatement().executeQuery("select * from maxwell.heartbeats");
 		rs.next();
 
-		assertThat(rs.getLong("heartbeat_at") >= preHeartbeat, is(true));
+		assertThat(rs.getLong("heartbeat") >= preHeartbeat, is(true));
 
 	}
 


### PR DESCRIPTION
This is something I should have done from the beginning; representing heartbeats as an update to the `positions` table meant we couldn't start heartbeating until we had a binlog position.  This was a real hassle for tests, and ultimately made the code much much less clean.

@zendesk/rules