### PR TITLE
ignore DELETE FROM statements, send out a warning.

### DIFF
--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -229,7 +229,8 @@ public class DDLParserTest {
 			"CREATE TEMPORARY TABLE 172898_16841_transmem SELECT t.* FROM map.transmem AS t",
 			"DROP TEMPORARY TABLE IF EXISTS 172898_16841_transmem",
 			"ALTER TEMPORARY TABLE 172898_16841_transmem ADD something VARCHAR(1)",
-			"/* hi bob */ CREATE EVENT FOO"
+			"/* hi bob */ CREATE EVENT FOO",
+			"DELETE FROM `foo`.`bar`"
 		};
 
 		for ( String s : testSQL ) {


### PR DESCRIPTION
a server configured for row-based replication will still send out DELETE
FROM statements for memory based tables:

"When a master server shuts down and restarts, its MEMORY tables become
empty. To replicate this effect to slaves, the first time that the
master uses a given MEMORY table after startup, it logs an event that
notifies slaves that the table must to be emptied by writing a DELETE
statement for that table to the binary log."

https://dev.mysql.com/doc/refman/5.7/en/replication-features-memory.html

addresses #439 