### PR TITLE
Add HTTP POST Producer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM java:openjdk-7-jre
 ENV MAXWELL_VERSION 1.5.2
+ENV ENDPOINT http://requestb.in/xr9aegxr
 
 RUN mkdir /app
 
@@ -9,4 +10,4 @@ RUN tar -zxf maxwell-"$MAXWELL_VERSION".tar.gz -C /app
 RUN echo "$MAXWELL_VERSION" > /REVISION
 
 WORKDIR /app/maxwell-"$MAXWELL_VERSION"
-CMD ./bin/maxwell --user=root --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD --host=$MYSQL_PORT_3306_TCP_ADDR --producer=httpPost
+CMD ./bin/maxwell --user=root --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD --host=$MYSQL_PORT_3306_TCP_ADDR --producer=httppost --httppost_endpoint="$ENDPOINT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM java:openjdk-7-jre
 ENV MAXWELL_VERSION 1.5.2
-ENV ENDPOINT http://requestb.in/xr9aegxr
+
+RUN apt-get update && apt-get -y upgrade
 
 RUN mkdir /app
+WORKDIR /app
 
-COPY target/maxwell-"$MAXWELL_VERSION".tar.gz .
-RUN tar -zxf maxwell-"$MAXWELL_VERSION".tar.gz -C /app
+RUN curl -sLo - https://github.com/zendesk/maxwell/releases/download/v"$MAXWELL_VERSION"/maxwell-"$MAXWELL_VERSION".tar.gz \
+  | tar --strip-components=1 -zxvf -
 
 RUN echo "$MAXWELL_VERSION" > /REVISION
-
-WORKDIR /app/maxwell-"$MAXWELL_VERSION"
-CMD ./bin/maxwell --user=root --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD --host=$MYSQL_PORT_3306_TCP_ADDR --producer=httppost --httppost_endpoint="$ENDPOINT"
+CMD bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT $MAXWELL_OPTIONS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM java:openjdk-7-jre
 ENV MAXWELL_VERSION 1.5.2
 
-RUN apt-get update && apt-get -y upgrade
-
 RUN mkdir /app
-WORKDIR /app
 
-RUN curl -sLo - https://github.com/zendesk/maxwell/releases/download/v"$MAXWELL_VERSION"/maxwell-"$MAXWELL_VERSION".tar.gz \
-  | tar --strip-components=1 -zxvf -
+COPY target/maxwell-"$MAXWELL_VERSION".tar.gz .
+RUN tar -zxf maxwell-"$MAXWELL_VERSION".tar.gz -C /app
 
 RUN echo "$MAXWELL_VERSION" > /REVISION
-CMD bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT $MAXWELL_OPTIONS
+
+WORKDIR /app/maxwell-"$MAXWELL_VERSION"
+CMD ./bin/maxwell --user=root --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD --host=$MYSQL_PORT_3306_TCP_ADDR --producer=httpPost

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
       <version>3.4</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
       <version>3.4</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.5</version>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -86,7 +86,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "__separator_3" );
 
-		parser.accepts( "producer", "producer type: stdout|file|kafka" ).withRequiredArg();
+		parser.accepts( "producer", "producer type: stdout|file|kafka|httpPost" ).withRequiredArg();
 		parser.accepts( "output_file", "output file for 'file' producer" ).withRequiredArg();
 		parser.accepts( "kafka.bootstrap.servers", "at least one kafka server, formatted as HOST:PORT[,HOST:PORT]" ).withRequiredArg();
 		parser.accepts( "kafka_partition_by", "database|table|primary_key|column, kafka producer assigns partition by hashing the specified parameter").withRequiredArg();

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -41,6 +41,8 @@ public class MaxwellConfig extends AbstractConfig {
 	public MaxwellOutputConfig outputConfig;
 	public String log_level;
 
+    public String httpPostEndPoint;
+
 	public String clientID;
 	public Long replicaServerID;
 
@@ -86,7 +88,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "__separator_3" );
 
-		parser.accepts( "producer", "producer type: stdout|file|kafka|httpPost" ).withRequiredArg();
+		parser.accepts( "producer", "producer type: stdout|file|kafka|httppost" ).withRequiredArg();
 		parser.accepts( "output_file", "output file for 'file' producer" ).withRequiredArg();
 		parser.accepts( "kafka.bootstrap.servers", "at least one kafka server, formatted as HOST:PORT[,HOST:PORT]" ).withRequiredArg();
 		parser.accepts( "kafka_partition_by", "database|table|primary_key|column, kafka producer assigns partition by hashing the specified parameter").withRequiredArg();
@@ -100,6 +102,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "__separator_4" );
 
+		parser.accepts( "httppost_endpoint", "provide an endpoint to send data to using the httppost producer" ).withOptionalArg();
 		parser.accepts( "output_binlog_position", "produced records include binlog position; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_commit_info", "produced records include commit and xid; [true|false]. default: true" ).withOptionalArg();
 		parser.accepts( "output_nulls", "produced records include fields with NULL values [true|false]. default: true" ).withOptionalArg();
@@ -261,6 +264,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.outputFile         = fetchOption("output_file", options, properties, null);
 
+        this.httpPostEndPoint   = fetchOption("httppost_endpoint", options, properties, null);
+
 		this.includeDatabases   = fetchOption("include_dbs", options, properties, null);
 		this.excludeDatabases   = fetchOption("exclude_dbs", options, properties, null);
 		this.includeTables      = fetchOption("include_tables", options, properties, null);
@@ -349,7 +354,10 @@ public class MaxwellConfig extends AbstractConfig {
 		} else if ( this.producerType.equals("file")
 				&& this.outputFile == null) {
 			usageForOptions("please specify --output_file=FILE to use the file producer", "--producer", "--output_file");
-		}
+		} else if ( this.producerType.equals("httppost")
+                && this.httpPostEndPoint == null)
+			usageForOptions("please specify --httppost_endpoint=URI to use the httppost producer", "--producer", "--httppost_endpoint");
+
 
 		if ( !this.bootstrapperType.equals("async")
 				&& !this.bootstrapperType.equals("sync")

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -42,6 +42,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public String log_level;
 
     public String httpPostEndPoint;
+	public String httpPostHmacSecret;
 
 	public String clientID;
 	public Long replicaServerID;
@@ -102,7 +103,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "__separator_4" );
 
-		parser.accepts( "httppost_endpoint", "provide an endpoint to send data to using the httppost producer" ).withOptionalArg();
+		parser.accepts( "httppost_endpoint", "provide an endpoint to send data to using the httppost producer" ).withRequiredArg();
+		parser.accepts( "httppost_hmacsecret", "secret key for calculating HMAC digest for httppost producer" ).withRequiredArg();
 		parser.accepts( "output_binlog_position", "produced records include binlog position; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_commit_info", "produced records include commit and xid; [true|false]. default: true" ).withOptionalArg();
 		parser.accepts( "output_nulls", "produced records include fields with NULL values [true|false]. default: true" ).withOptionalArg();
@@ -265,6 +267,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.outputFile         = fetchOption("output_file", options, properties, null);
 
         this.httpPostEndPoint   = fetchOption("httppost_endpoint", options, properties, null);
+		this.httpPostHmacSecret = fetchOption("httppost_hmacsecret", options, properties, null);
 
 		this.includeDatabases   = fetchOption("include_dbs", options, properties, null);
 		this.excludeDatabases   = fetchOption("exclude_dbs", options, properties, null);

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -229,7 +229,7 @@ public class MaxwellContext {
 		case "buffer":
 			this.producer = new BufferedProducer(this, this.config.bufferedProducerSize);
 			break;
-		case "httpPost":
+		case "httppost":
 			this.producer = new HttpPostProducer(this, this.config.httpPostEndPoint);
 			break;
 		case "none":

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -229,6 +229,9 @@ public class MaxwellContext {
 		case "buffer":
 			this.producer = new BufferedProducer(this, this.config.bufferedProducerSize);
 			break;
+		case "httpPost":
+			this.producer = new HttpPostProducer(this);
+			break;
 		case "none":
 			this.producer = null;
 			break;

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -230,7 +230,7 @@ public class MaxwellContext {
 			this.producer = new BufferedProducer(this, this.config.bufferedProducerSize);
 			break;
 		case "httppost":
-			this.producer = new HttpPostProducer(this, this.config.httpPostEndPoint);
+			this.producer = new HttpPostProducer(this, this.config.httpPostEndPoint, this.config.httpPostHmacSecret);
 			break;
 		case "none":
 			this.producer = null;

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -230,7 +230,7 @@ public class MaxwellContext {
 			this.producer = new BufferedProducer(this, this.config.bufferedProducerSize);
 			break;
 		case "httpPost":
-			this.producer = new HttpPostProducer(this);
+			this.producer = new HttpPostProducer(this, this.config.httpPostEndPoint);
 			break;
 		case "none":
 			this.producer = null;

--- a/src/main/java/com/zendesk/maxwell/producer/HttpPostProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/HttpPostProducer.java
@@ -1,0 +1,54 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.row.RowMap;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class HttpPostProducer extends AbstractProducer {
+	public HttpPostProducer(MaxwellContext context) {
+		super(context);
+	}
+
+	@Override
+	public void push(RowMap r) throws Exception {
+
+        Set<String> eventTypeWhilteList = new HashSet<String>(Arrays.asList("insert", "update", "delete"));
+
+        String rowType = r.getRowType();
+        if ( eventTypeWhilteList.contains(rowType)) {
+            String payload = r.toJSON(outputConfig);
+            String database = r.getDatabase();
+            String table = r.getTable();
+
+            CloseableHttpClient httpClient = HttpClients.createDefault();
+            HttpPost httpPost = new HttpPost("http://requestb.in/1k1i3n81");
+            httpPost.addHeader("Content-Type", "application/json");
+            StringEntity params = new StringEntity(payload);
+            httpPost.setEntity(params);
+            CloseableHttpResponse response = httpClient.execute(httpPost);
+            int status = response.getStatusLine().getStatusCode();
+
+            System.out.println(payload);
+            String statusMessage = String.format("Got status %s", status);
+            System.out.println(statusMessage);
+
+
+        } else {
+            String message = String.format("Event type %s ignoring ...", rowType);
+            System.out.println(message);
+        }
+
+		this.context.setPosition(r);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/producer/HttpPostProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/HttpPostProducer.java
@@ -16,8 +16,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class HttpPostProducer extends AbstractProducer {
-	public HttpPostProducer(MaxwellContext context) {
+    private final String httpPostEndPoint;
+
+	public HttpPostProducer(MaxwellContext context, String httpPostEndPoint) {
 		super(context);
+        this.httpPostEndPoint = httpPostEndPoint;
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/producer/StdoutProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/StdoutProducer.java
@@ -12,8 +12,11 @@ public class StdoutProducer extends AbstractProducer {
 	public void push(RowMap r) throws Exception {
 		String output = r.toJSON(outputConfig);
 
-		if ( output != null )
-			System.out.println(output);
+		if ( output != null ) {
+            String result = String.format("Table %s, database %s, event type is %s", r.getTable(), r.getDatabase(), r.getRowType());
+			System.out.println(result);
+
+        }
 
 		this.context.setPosition(r);
 	}

--- a/src/test/java/com/zendesk/maxwell/producer/HttpPostProducerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/HttpPostProducerTest.java
@@ -1,0 +1,51 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.MaxwellConfig;
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.MaxwellTestSupport;
+import com.zendesk.maxwell.MaxwellTestSupport;
+
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpTransport;
+
+import java.sql.SQLException;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class HttpPostProducerTest {
+    private String endPoint = "http://test.local";
+    private HttpPostProducer producer;
+
+	@Before
+	public void setupBefore() {
+        try {
+            MaxwellContext context = MaxwellTestSupport.buildContext(3306, null, null);
+            this.producer = new HttpPostProducer(context, this.endPoint);
+        } catch (SQLException e) {
+            System.err.println(e.getMessage());
+        }
+	}
+
+    @Test
+    public void TestSendSuccessfulPayload() {
+        String testUrl = "http://test.local";
+        HttpTransport transport = new MockHttpTransport();
+        HttpRequestFactory factory = transport.createRequestFactory();
+        GenericUrl url = new GenericUrl(testUrl);
+        String data = "{\"myKey\": \"myVal\"}";
+
+        try {
+            this.producer.sendPayload(factory, url, data);
+        } catch (IOException e) {
+            System.err.println(e.getMessage());
+        }
+
+        assert(true);
+    }
+
+}


### PR DESCRIPTION
This PR adds the ability to send Maxwell binlog events via HTTP POST requests to an arbitrary endpoint. Users can optionally sign the request with an HMAC secret for authentication and validation.