### PR TITLE
Minor improvements to Maxwell#start() method

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -130,6 +130,7 @@ public class Maxwell implements Runnable {
 	}
 
 	protected void onReplicatorStart() {}
+
 	private void start() throws Exception {
 		try ( Connection connection = this.context.getReplicationConnection();
 			  Connection rawConnection = this.context.getRawMaxwellConnection() ) {
@@ -141,11 +142,6 @@ public class Maxwell implements Runnable {
 			try ( Connection schemaConnection = this.context.getMaxwellConnection() ) {
 				SchemaStoreSchema.upgradeSchemaStoreSchema(schemaConnection);
 			}
-
-		} catch ( SQLException e ) {
-			LOGGER.error("SQLException: " + e.getLocalizedMessage());
-			LOGGER.error(e.getLocalizedMessage());
-			return;
 		}
 
 		AbstractProducer producer = this.context.getProducer();


### PR DESCRIPTION
By design, `Maxwell#start()` method is meant to throw any sort of exceptions that may occur up to the caller. Indeed, both `Maxwell#run()` and `Maxwell#main()` surround calls to the `start()` method with try-catch block where the actual logging takes place. With this in mind, I took the liberty of removing `catch (SQLException) {...}` clause (lines 145-148).