### PR TITLE
cleanup/unify datetime formatting

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ColumnWithDefinition.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ColumnWithDefinition.java
@@ -15,11 +15,7 @@ public class ColumnWithDefinition {
 	}
 
 	private Object valueForJSON() {
-		if (column instanceof DatetimeColumn)
-			return ((DatetimeColumn) column).getLongValue();
-
 		if (column instanceof AbstractDatetimeColumn) {
-			// time2, datetime2, timestamp2
 			return ((AbstractDatetimeColumn) column).getTimestampValue();
 		}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -1,8 +1,5 @@
 package com.zendesk.maxwell.schema.columndef;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import com.google.code.or.common.util.MySQLConstants;
 
 public class DateColumnDef extends ColumnDef {
@@ -10,35 +7,22 @@ public class DateColumnDef extends ColumnDef {
 		super(name, type, pos);
 	}
 
-	private static SimpleDateFormat dateFormatter;
-
-	private static SimpleDateFormat getDateFormatter() {
-		if ( dateFormatter == null ) {
-			dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
-		}
-		return dateFormatter;
-	}
-
-
 	@Override
 	public boolean matchesMysqlType(int type) {
 		return type == MySQLConstants.TYPE_DATE;
 	}
 
-	private String formatDate(Object value) {
-		/* protect against multithreaded access of static dateFormatter */
-		synchronized ( DateColumnDef.class ) {
-			return getDateFormatter().format((Date) value);
-		}
-	}
-
 	@Override
 	public String toSQL(Object value) {
-		return "'" + formatDate(value) + "'";
+		String formatted = DateFormatter.formatDate(value);
+		if ( formatted == null )
+			return null;
+		else
+			return "'" +  formatted + "'";
 	}
 
 	@Override
 	public Object asJSON(Object value) {
-		return formatDate(value);
+		return DateFormatter.formatDate(value);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateFormatter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateFormatter.java
@@ -1,0 +1,69 @@
+package com.zendesk.maxwell.schema.columndef;
+
+import java.text.SimpleDateFormat;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class DateFormatter {
+	private static SimpleDateFormat makeFormatter(String format, boolean utc) {
+		SimpleDateFormat dateFormatter = new SimpleDateFormat(format);
+		if ( utc )
+			dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		return dateFormatter;
+	}
+
+	private static SimpleDateFormat dateFormatter           = makeFormatter("yyyy-MM-dd", false);
+	private static SimpleDateFormat dateUTCFormatter        = makeFormatter("yyyy-MM-dd", true);
+	private static SimpleDateFormat dateTimeFormatter       = makeFormatter("yyyy-MM-dd HH:mm:ss", false);
+	private static SimpleDateFormat dateTimeUTCFormatter    = makeFormatter("yyyy-MM-dd HH:mm:ss", true);
+
+	public static Timestamp extractTimestamp(Object value) {
+		if (value instanceof Long) {
+			return new Timestamp((Long) value);
+		} else if (value instanceof Timestamp) {
+			return (Timestamp) value;
+		} else if ( value instanceof Date ) {
+			Long time = ((Date) value).getTime();
+			return new Timestamp(time);
+		} else
+			throw new RuntimeException("couldn't extract date/time out of " + value);
+
+	}
+
+	private static Long MIN_DATE = Timestamp.valueOf("1000-01-01 00:00:00").getTime();
+	private static String extractAndFormat(SimpleDateFormat formatter, Object value) {
+		synchronized(formatter) {
+			Timestamp t = extractTimestamp(value);
+			if ( t.getTime() < MIN_DATE )
+				return null;
+			else
+				return formatter.format(t);
+		}
+	}
+
+	public static String formatDate(Object value) {
+		SimpleDateFormat formatter;
+
+		// if value is a Long, this means it's coming back from shyko's binlog connector
+		// and we should treat it as a UTC timestamp.
+		if ( value instanceof Long )
+			formatter = dateUTCFormatter;
+		else
+			formatter = dateFormatter;
+
+		return extractAndFormat(formatter, value);
+	}
+
+	public static String formatDateTime(Object value) {
+		SimpleDateFormat formatter;
+
+		if ( value instanceof Long )
+			formatter = dateTimeUTCFormatter;
+		else
+			formatter = dateTimeFormatter;
+
+		return extractAndFormat(formatter, value);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -3,21 +3,14 @@ package com.zendesk.maxwell.schema.columndef;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import com.google.code.or.common.util.MySQLConstants;
+import com.zendesk.maxwell.MaxwellConfig;
 
 public class DateTimeColumnDef extends ColumnDefWithLength {
 	public DateTimeColumnDef(String name, String type, int pos, Long columnLength) {
 		super(name, type, pos, columnLength);
-	}
-
-	private static SimpleDateFormat dateTimeFormatter;
-
-	private static SimpleDateFormat getDateTimeFormatter() {
-		if ( dateTimeFormatter == null ) {
-			dateTimeFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		}
-		return dateTimeFormatter;
 	}
 
 	@Override
@@ -32,37 +25,11 @@ public class DateTimeColumnDef extends ColumnDefWithLength {
 	}
 
 	protected String formatValue(Object value) {
-		/* protect against multithreaded access of static dateTimeFormatter */
-		synchronized ( DateTimeColumnDef.class ) {
-			if ( value instanceof Long && getType().equals("datetime") ) {
-				return formatLong(( Long ) value);
-
-			} else if ( value instanceof Timestamp ) {
-				Timestamp ts = (Timestamp) value;
-				String datetimeAsStr = getDateTimeFormatter().format(ts);
-
-				return objectWithPrecisionToString(datetimeAsStr, ts, this.columnLength);
-
-			} else if ( value instanceof Date ) {
-				Timestamp ts = new Timestamp((( Date ) value).getTime());
-				String dateAsStr = getDateTimeFormatter().format(ts);
-
-				return objectWithPrecisionToString(dateAsStr, ts, this.columnLength);
-
-			} else {
-				return "";
-			}
-		}
-	}
-
-	private String formatLong(Long value) {
-		final int second = (int)(value % 100); value /= 100;
-		final int minute = (int)(value % 100); value /= 100;
-		final int hour = (int)(value % 100); value /= 100;
-		final int day = (int)(value % 100); value /= 100;
-		final int month = (int)(value % 100);
-		final int year = (int)(value / 100);
-
-		return String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
+		Timestamp ts = DateFormatter.extractTimestamp(value);
+		String dateString = DateFormatter.formatDateTime(value);
+		if ( dateString == null )
+			return null;
+		else
+			return objectWithPrecisionToString(dateString, ts, columnLength);
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
@@ -42,6 +42,7 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 		runJSON("json/bootstrap-null-values");
 	}
 
+	@Test
 	public void testBool() throws Exception {
 		testColumnType("bool", "0", 0);
 		testColumnType("bool", "1", 1);
@@ -98,6 +99,8 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testStringTypes( ) throws Exception {
 		String epoch = String.valueOf(new Timestamp(0)); // timezone dependent
+		testColumnType("datetime", "'1000-01-01 00:00:00'","1000-01-01 00:00:00", null);
+
 		testColumnType("tinytext", "'hello'", "hello");
 		testColumnType("text", "'hello'", "hello");
 		testColumnType("mediumtext","'hello'", "hello");
@@ -105,15 +108,22 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 		testColumnType("varchar(10)","'hello'", "hello");
 		testColumnType("char", "'h'", "h");
 		testColumnType("date", "'2015-11-07'","2015-11-07");
-		testColumnType("date", "'0000-00-00'","0002-11-30", null);
 		testColumnType("datetime", "'2015-11-07 01:02:03'","2015-11-07 01:02:03");
 
-		if ( server.getVersion().equals("5.5") )
-			testColumnType("datetime", "'0000-00-00 00:00:00'","0000-00-00 00:00:00", null);
+		testColumnType("date", "'0000-00-00'",null);
+		testColumnType("datetime", "'1000-01-01 00:00:00'","1000-01-01 00:00:00");
+		testColumnType("datetime", "'0000-00-00 00:00:00'", null);
 
 		testColumnType("timestamp", "'2015-11-07 01:02:03'","2015-11-07 01:02:03");
 		testColumnType("timestamp", "'0000-00-00 00:00:00'","" + epoch.substring(0, epoch.length() - 2) + "", null);
 
+		testColumnType("enum('a', 'b')","'a'", "a");
+		testColumnType("bit(8)","b'01010101'", 85);
+		testColumnType("bit(8)","b'1'", 1);
+	}
+
+	@Test
+	public void testSubsecondTypes() throws Exception {
 		if ( server.getVersion().equals("5.6") ) {
 			testColumnType("timestamp(6)", "'2015-11-07 01:02:03.333444'","2015-11-07 01:02:03.333444");
 			testColumnType("timestamp(6)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123000");
@@ -131,10 +141,6 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 			testColumnType("time(3)", "'01:02:03.123456'","01:02:03.123");
 			testColumnType("time(3)", "'01:02:03.123'","01:02:03.123");
 		}
-
-		testColumnType("enum('a', 'b')","'a'", "a");
-		testColumnType("bit(8)","b'01010101'", 85);
-		testColumnType("bit(8)","b'1'", 1);
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -11,6 +11,9 @@ import org.junit.*;
 
 public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 	protected static MysqlIsolatedServer server;
+	static {
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+	}
 
 	@BeforeClass
 	public static void setupTest() throws Exception {

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -45,6 +45,7 @@ public class MysqlIsolatedServer {
 				"--innodb_flush_log_at_trx_commit=1",
 				serverID,
 				"--character-set-server=utf8",
+				"--default-time-zone=+00:00",
 				"--verbose",
 				xtraParams
 		);

--- a/src/test/resources/sql/json/test_zero_created_at
+++ b/src/test/resources/sql/json/test_zero_created_at
@@ -1,7 +1,7 @@
 CREATE DATABASE `cdb`
 create table `cdb`.`ca` ( id int(11) auto_increment not null primary key, datecol datetime NOT NULL default 0, ch varchar(255));
 insert into cdb.ca set ch='a';
--> {"database":"cdb", "table": "ca", "type": "insert", "data":  {"id": 1, "ch": "a", "datecol": "0000-00-00 00:00:00"}  }
+-> {"database":"cdb", "table": "ca", "type": "insert", "data":  {"id": 1, "ch": "a", "datecol": null}  }
 insert into cdb.ca set ch='a', datecol = '0003-00-00 00:00:01';
--> {"database":"cdb", "table": "ca", "type": "insert", "data":  {"id": 2, "ch": "a", "datecol": "0003-00-00 00:00:01"}  }
+-> {"database":"cdb", "table": "ca", "type": "insert", "data":  {"id": 2, "ch": "a", "datecol": null}  }
 


### PR DESCRIPTION
In prep for a port to shyko's binlog-connector, we'll unify the formatting of dates and datetimes into one code path.

The only non-refactoring change here deals with how we deal with "invalid" dates; those before '1000-01-01'.  Mysql's documentation seems to indicate that dates like '0000-00-00' should be considered invalid, although it accepts the damn things anyway.  Maxwell has had highly
differing policies on the data in the past; invalid dates coming from the bootstrap code paths were null, dates from 5.5 were reproduced faithfully, and dates from 5.6 were off by a few years.
binlog-connector makes 'em null, and that's good enough for me.

@zendesk/rules