### PR TITLE
update binlog position on rds heartbeat inserts

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -159,10 +159,6 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 	public void writePosition(BinlogPosition p) throws SQLException {
 		// ensure that we don't prematurely advance the binlog pointer.
 		inflightMessages.addMessage(p);
-		BinlogPosition newPosition = inflightMessages.completeMessage(p);
-
-		if (newPosition != null) {
-			super.writePosition(newPosition);
-		}
+		inflightMessages.completeMessage(p);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -159,6 +159,10 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 	public void writePosition(BinlogPosition p) throws SQLException {
 		// ensure that we don't prematurely advance the binlog pointer.
 		inflightMessages.addMessage(p);
-		inflightMessages.completeMessage(p);
+		BinlogPosition newPosition = inflightMessages.completeMessage(p);
+
+		if (newPosition != null) {
+			super.writePosition(newPosition);
+		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -80,9 +80,9 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 			this.producer.writePosition(position);
 	}
 
-	protected void processRDSHeartbeatEvent(BinlogPosition position) throws Exception {
-		if ( this.producer != null )
-			this.producer.writePosition(position);
+	protected void processRDSHeartbeatInsertEvent(String database, BinlogPosition position) throws Exception {
+		HeartbeatRowMap hbr = new HeartbeatRowMap(database, position);
+		this.producer.push(hbr);
 	}
 
 	/**

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -65,7 +65,7 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 	 * @param sql The DDL SQL to be processed
 	 * @param schemaStore A SchemaStore object to which we delegate the parsing of the sql
 	 * @param position The position that the SQL happened at
-	 * @param timestmap The timestamp of the SQL binlog event
+	 * @param timestamp The timestamp of the SQL binlog event
 	 */
 	protected void processQueryEvent(String dbName, String sql, SchemaStore schemaStore, BinlogPosition position, Long timestamp) throws Exception {
 		List<ResolvedSchemaChange> changes =  schemaStore.processSQL(sql, dbName, position);
@@ -76,6 +76,11 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 
 		tableCache.clear();
 
+		if ( this.producer != null )
+			this.producer.writePosition(position);
+	}
+
+	protected void processRDSHeartbeatEvent(BinlogPosition position) throws Exception {
 		if ( this.producer != null )
 			this.producer.writePosition(position);
 	}

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -383,8 +383,8 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 
 	private void processRDSHeartbeatInsertEvent(QueryEvent event) throws Exception {
 		processRDSHeartbeatInsertEvent(
-				event.getDatabaseName().toString(),
-				eventBinlogPosition(event)
+			event.getDatabaseName().toString(),
+			eventBinlogPosition(event)
 		);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -1,6 +1,8 @@
 package com.zendesk.maxwell.replication;
 
 import java.sql.SQLException;
+import java.util.Objects;
+import java.util.List
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -8,9 +10,13 @@ import java.util.regex.Pattern;
 import com.google.code.or.binlog.impl.event.*;
 import com.google.code.or.net.TransportException;
 import com.zendesk.maxwell.*;
+import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMapBuffer;
 import com.zendesk.maxwell.schema.*;
+import com.zendesk.maxwell.schema.ddl.DDLMap;
+import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
+import com.zendesk.maxwell.util.RunLoopProcess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -1,8 +1,6 @@
 package com.zendesk.maxwell.replication;
 
 import java.sql.SQLException;
-import java.util.Objects;
-import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -10,13 +8,9 @@ import java.util.regex.Pattern;
 import com.google.code.or.binlog.impl.event.*;
 import com.google.code.or.net.TransportException;
 import com.zendesk.maxwell.*;
-import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMapBuffer;
 import com.zendesk.maxwell.schema.*;
-import com.zendesk.maxwell.schema.ddl.DDLMap;
-import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
-import com.zendesk.maxwell.util.RunLoopProcess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -273,7 +267,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 						// INSERT INTO mysql.rds_heartbeat2(id, value) values (1,1483041015005) ON DUPLICATE KEY UPDATE value = 1483041015005
 						// As a result they are processed as query events.
 						// When these occur we need to update to update our position.
-						processRDSHeartbeatEvent(qe);
+						processRDSHeartbeatInsertEvent(qe);
 					} else {
 						LOGGER.warn("Unhandled QueryEvent inside transaction: " + qe);
 					}
@@ -381,8 +375,9 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 		);
 	}
 
-	private void processRDSHeartbeatEvent(QueryEvent event) throws Exception {
-		processRDSHeartbeatEvent(
+	private void processRDSHeartbeatInsertEvent(QueryEvent event) throws Exception {
+		processRDSHeartbeatInsertEvent(
+				event.getDatabaseName().toString(),
 				eventBinlogPosition(event)
 		);
 	}

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -2,7 +2,7 @@ package com.zendesk.maxwell.replication;
 
 import java.sql.SQLException;
 import java.util.Objects;
-import java.util.List
+import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -268,6 +268,12 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 						// to us starting on a WRITE_ROWS event -- we sync the schema position somewhere
 						// kinda unsafe.
 						processQueryEvent(qe);
+					} else if (sql.toUpperCase().startsWith("INSERT INTO MYSQL.RDS_HEARTBEAT")) {
+						// RDS heartbeat events take the following form:
+						// INSERT INTO mysql.rds_heartbeat2(id, value) values (1,1483041015005) ON DUPLICATE KEY UPDATE value = 1483041015005
+						// As a result they are processed as query events.
+						// When these occur we need to update to update our position.
+						processRDSHeartbeatEvent(qe);
 					} else {
 						LOGGER.warn("Unhandled QueryEvent inside transaction: " + qe);
 					}
@@ -372,6 +378,12 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 			this.schemaStore,
 			eventBinlogPosition(event),
 			event.getHeader().getTimestamp()
+		);
+	}
+
+	private void processRDSHeartbeatEvent(QueryEvent event) throws Exception {
+		processRDSHeartbeatEvent(
+				eventBinlogPosition(event)
 		);
 	}
 


### PR DESCRIPTION
it looks to me like maxwell doesn't update its position on rds heartbeats - on very low-throughput services i never see binlog updates corresponding with anything other than actual data changes, and the heartbeat events that come through aren't processed.
hopefully this corrects that, though i'm not overly fond of what appears to be a delay in the flushing of the position to the db.