### PR TITLE
#538: pom.xml add missing <version> element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+	<version>3.6.0</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>


### PR DESCRIPTION
after the change, you don't see the [WARNING] anymore.


svaddi:maxwell svaddi$ mvn install
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building maxwell 1.7.0
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- jacoco-maven-plugin:0.7.5.201505241946:prepare-agent (default) @ maxwell ---
[INFO] argLine set to -javaagent:/Users/svaddi/.m2/repository/org/jacoco/org.jacoco.agent/0.7.5.201505241946/org.jacoco.agent-0.7.5.201505241946-runtime.jar=destfile=/Users/svaddi/SreeVaddi/sources/github/maxwell/target/jacoco.exec