### PR TITLE
add documentation referencing official container on docker hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,23 @@ advanced features:
     jQuery("pre").addClass("home-code");
   });
 </script>
+
+# Docker
+```
+docker pull osheroff/maxwell
+```
+
+## Kafka Producer
+```
+docker run -it --rm osheroff/maxwell bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT
+```
+
+## STDOUT Producer
+```
+docker run -it --rm osheroff/maxwell bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=stdout
+```
+
+## AWS Kinesis Producer
+```
+docker run -it --rm --name maxwell -v `cd && pwd`/.aws:/root/.aws maxwell sh -c 'cp /app/kinesis-producer-library.properties.example /app/kinesis-producer-library.properties && echo "Region=$AWS_DEFAULT_REGION" >> /app/kinesis-producer-library.properties && bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kinesis --kinesis_stream=$KINESIS_STREAM'
+```


### PR DESCRIPTION
hi Team, awesome project!

i had a hard time finding the official image on docker hub until i went hunting in this project for pull requests and issues. that's when i came across this guy:
https://github.com/zendesk/maxwell/issues/389

i thought it might be useful to reference the official image in this project. i added some `run` commands to demo the various producers. let me know if you want more info, less info, or if you think this isn't useful at all. thanks!