### PR TITLE
separate KafkaProducer#push from the main thread

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ArrayBlockingQueue;
 
 
 class KafkaCallback implements Callback {
@@ -57,14 +57,14 @@ class KafkaCallback implements Callback {
 
 
 public class MaxwellKafkaProducer extends AbstractProducer {
-	private final LinkedBlockingQueue<RowMap> queue;
+	private final ArrayBlockingQueue<RowMap> queue;
 	private final MaxwellKafkaProducerWorker worker;
 
 	public MaxwellKafkaProducer(MaxwellContext context, Properties kafkaProperties, String kafkaTopic) {
 		super(context);
-		this.queue = new LinkedBlockingQueue<>(100);
+		this.queue = new ArrayBlockingQueue<>(100);
 		this.worker = new MaxwellKafkaProducerWorker(context, kafkaProperties, kafkaTopic, this.queue);
-		new Thread(this.worker, "maxwell-kafka-producer").start();
+		new Thread(this.worker, "maxwell-kafka-worker").start();
 
 	}
 
@@ -84,9 +84,9 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	private final MaxwellKafkaPartitioner ddlPartitioner;
 	private final KeyFormat keyFormat;
 	private final boolean interpolateTopic;
-	private final LinkedBlockingQueue<RowMap> queue;
+	private final ArrayBlockingQueue<RowMap> queue;
 
-	public MaxwellKafkaProducerWorker(MaxwellContext context, Properties kafkaProperties, String kafkaTopic, LinkedBlockingQueue<RowMap> queue) {
+	public MaxwellKafkaProducerWorker(MaxwellContext context, Properties kafkaProperties, String kafkaTopic, ArrayBlockingQueue<RowMap> queue) {
 		super(context);
 
 		this.topic = kafkaTopic;

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.concurrent.LinkedBlockingQueue;
+
 
 class KafkaCallback implements Callback {
 	public static final Logger LOGGER = LoggerFactory.getLogger(MaxwellKafkaProducer.class);
@@ -53,7 +55,26 @@ class KafkaCallback implements Callback {
 	}
 }
 
-public class MaxwellKafkaProducer extends AbstractAsyncProducer {
+
+public class MaxwellKafkaProducer extends AbstractProducer {
+	private final LinkedBlockingQueue<RowMap> queue;
+	private final MaxwellKafkaProducerWorker worker;
+
+	public MaxwellKafkaProducer(MaxwellContext context, Properties kafkaProperties, String kafkaTopic) {
+		super(context);
+		this.queue = new LinkedBlockingQueue<>(100);
+		this.worker = new MaxwellKafkaProducerWorker(context, kafkaProperties, kafkaTopic, this.queue);
+		new Thread(this.worker, "maxwell-kafka-producer").start();
+
+	}
+
+	@Override
+	public void push(RowMap r) throws Exception {
+		this.queue.put(r);
+	}
+}
+
+class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnable {
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellKafkaProducer.class);
 
 	private final KafkaProducer<String, String> kafka;
@@ -63,8 +84,9 @@ public class MaxwellKafkaProducer extends AbstractAsyncProducer {
 	private final MaxwellKafkaPartitioner ddlPartitioner;
 	private final KeyFormat keyFormat;
 	private final boolean interpolateTopic;
+	private final LinkedBlockingQueue<RowMap> queue;
 
-	public MaxwellKafkaProducer(MaxwellContext context, Properties kafkaProperties, String kafkaTopic) {
+	public MaxwellKafkaProducerWorker(MaxwellContext context, Properties kafkaProperties, String kafkaTopic, LinkedBlockingQueue<RowMap> queue) {
 		super(context);
 
 		this.topic = kafkaTopic;
@@ -87,6 +109,20 @@ public class MaxwellKafkaProducer extends AbstractAsyncProducer {
 			keyFormat = KeyFormat.HASH;
 		else
 			keyFormat = KeyFormat.ARRAY;
+
+		this.queue = queue;
+	}
+
+	@Override
+	public void run() {
+		while ( true ) {
+			try {
+				RowMap row = queue.take();
+				this.push(row);
+			} catch ( Exception e ) {
+				throw new RuntimeException(e);
+			}
+		}
 	}
 
 	private Integer getNumPartitions(String topic) {


### PR DESCRIPTION
This should be worth roughly 25% of cpu-concurrency, by running
binlog-event-to-RowMap code on a different thread than the
json-marshalling and kafka-data-compression/batching.  We could go
deeper than this by also parceling out the json-marshal calls into a
separate thread, but at that point I think I'd adopt rx-java or some
kind of pipeline framework.

Also note that we're doing fairly dumb stuff with any exceptions that the guts of `#push` might throw, but I *think* they're ok as runtime exceptions.  I should probably validate that they still crash the process in the same way.

@zendesk/rules @gabetax @prudhvi 