### PR TITLE
Improve kinesis producer

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -140,6 +140,22 @@ kinesis_stream=maxwell
 # Default: false
 #kinesis_md5_keys=true
 
+# AWS KPL tries to send each event up to a maximum TTL (defined in kinesis.producer-library.properties).
+# However in some cases you must guarantee that each event is sent to the stream.
+# With this parameter you can configure that maxwell tries to send the event to the KPL
+# a number of times
+# Values: integer value
+# Default: 0
+kinesis_max_attempts=3
+
+# AWS KPL buffers sent records before passing them to a kinesis stream. This consumes
+# system resources, and if you don't control it, you can exhauste them
+# This parameter establishes the maximum of buffered records Maxwell will allow in order
+# to avoid backpressure
+# Values: integer value
+# Default: 1000
+kinesis_max_buffered_records=1000
+
 ######### filter stuff ###############
 
 # filter rows out of Maxwell's output.

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -44,6 +44,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public String kinesisStream;
 	public boolean kinesisMd5Keys;
+	public int kinesisMaxAttempts;
 
 	public String outputFile;
 	public MaxwellOutputConfig outputConfig;
@@ -301,6 +302,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.kinesisStream  = fetchOption("kinesis_stream", options, properties, null);
 		this.kinesisMd5Keys = fetchBooleanOption("kinesis_md5_keys", options, properties, false);
+		this.kinesisMaxAttempts = fetchLongOption("kinesis_max_attempts", options, properties, 0L).intValue();
 
 		this.outputFile         = fetchOption("output_file", options, properties, null);
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -45,6 +45,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public String kinesisStream;
 	public boolean kinesisMd5Keys;
 	public int kinesisMaxAttempts;
+	public int kinesisMaxBufferedRecords;
 
 	public String outputFile;
 	public MaxwellOutputConfig outputConfig;
@@ -303,6 +304,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.kinesisStream  = fetchOption("kinesis_stream", options, properties, null);
 		this.kinesisMd5Keys = fetchBooleanOption("kinesis_md5_keys", options, properties, false);
 		this.kinesisMaxAttempts = fetchLongOption("kinesis_max_attempts", options, properties, 0L).intValue();
+		this.kinesisMaxBufferedRecords = fetchLongOption("kinesis_max_buffered_records", options, properties, 1000L).intValue();
 
 		this.outputFile         = fetchOption("output_file", options, properties, null);
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -102,6 +102,7 @@ public class MaxwellContext {
 		this.replicationConnectionPool.release();
 		this.maxwellConnectionPool.release();
 		this.rawMaxwellConnectionPool.release();
+		this.producer.release();
 	}
 
 	public PositionStoreThread getPositionStoreThread() {

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
@@ -14,4 +14,6 @@ public abstract class AbstractProducer {
 	}
 
 	abstract public void push(RowMap r) throws Exception;
+
+	public void release() {};
 }

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -172,11 +172,17 @@ public class MaxwellKinesisProducer extends AbstractAsyncProducer {
 		String key = this.partitioner.getKinesisKey(r);
 		String value = r.toJSON(outputConfig);
 
-		ByteBuffer encodedValue = ByteBuffer.wrap(value.getBytes("UTF-8"));
+        ByteBuffer encodedValue = ByteBuffer.wrap(value.getBytes("UTF-8"));
 		ListenableFuture<UserRecordResult> future = kinesisProducer.addUserRecord(kinesisStream, key, encodedValue);
 
 		FutureCallback<UserRecordResult> callback = new KinesisCallback(cc, r.getPosition(), key, value, successRecords, errorRecords, kinesisProducer, kinesisStream, 0, maxAttempts, lastInfoLog);
 
 		Futures.addCallback(future, callback);
 	}
+
+	@Override
+    public void release() {
+	    kinesisProducer.flushSync();
+	    kinesisProducer.destroy();
+    }
 }


### PR DESCRIPTION
Hi,

As I commented on the original PR when Kinesis producer was created (see: [https://github.com/zendesk/maxwell/pull/505#issuecomment-270169122](url), I had some improvements:

- Add a backpressure control to avoid exhausting system resources
- Add a mechanism to stop kinesis producer
- Add a retry mechanism for kinesis producer
- Improve kinesis producer logging

Many of these ideas have been taken from this AWS blog post: https://aws.amazon.com/es/blogs/big-data/implementing-efficient-and-reliable-producers-with-the-amazon-kinesis-producer-library/