### PR TITLE
add a fix for table-id re-use

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -256,6 +256,7 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 					}
 					break;
 				case ROTATE:
+					tableCache.clear();
 					if ( stopOnEOF && event.getPosition().getOffset() > 0 ) {
 						this.binlogEventListener.mustStop.set(true);
 						this.client.disconnect();

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -352,6 +352,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 					}
 					break;
 				case MySQLConstants.ROTATE_EVENT:
+					tableCache.clear();
 					if ( stopOnEOF ) {
 						this.replicator.stopQuietly(100, TimeUnit.MILLISECONDS);
 						setReplicatorPosition((AbstractBinlogEventV4) v4Event);


### PR DESCRIPTION
if maxwell survives a server restart, or the table_id wraps (unlikely), or is itself down at the time of server-restart, we may get duplicate entries for a particular table_id and totally fail hilariously.  See
https://github.com/zendesk/maxwell/issue

@zendesk/rules cc @nmaquet 