### PR TITLE
Added note for when using docker to start maxwell on macOSX

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -67,7 +67,7 @@ docker run -it --rm osheroff/maxwell bin/maxwell --user=$MYSQL_USERNAME --passwo
 ```
 
 *note*: If you are installing on local machine using `docker` on `macOSX` then make sure that,
-- Even if the `mysql` server is *local*, you will have to use the local ip address (use `ifconfig` to find it) & pass that as `$MYSQL_HOST` instead of localhost. This is because in macOSX docker doesnt run as localhost.
+- Even if the `mysql` server is *local*, you will have to use the local ip address (use `ifconfig` to find it) & pass that as `$MYSQL_HOST` instead of localhost. This is because in macOSX docker doesnt run as localhost. 
 - You will have to use the non-localhost way of granting permissions to maxwell's mysql user.
 - If you are specifying any files either for `config` location or for output of `file` producer then make sure you are explicitly sharing volumes/files present on the host. E.g. the above docker command then becomes,
 ```

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -52,7 +52,6 @@ mysql> GRANT ALL on maxwell.* to 'maxwell'@'localhost';
 
 ```
 
-
 ### STDOUT producer
 ***
 Useful for smoke-testing the thing.
@@ -67,6 +66,9 @@ bin/maxwell --user='maxwell' --password='XXXXXX' --host='1.7.2.0.1' --producer=s
 docker run -it --rm osheroff/maxwell bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=stdout
 ```
 
+*note*: If you are installing on local machine using `docker` on `macOSX` then make sure that,
+- Even if the `mysql` server is *local*, you will have to use the local ip address (use `ifconfig` to find it) & pass that as `$MYSQL_HOST` instead of localhost. This is because in macOSX docker doesnt run as localhost.
+- You will have to use the non-localhost way of granting permissions to maxwell's mysql user.
 
 If all goes well you'll see maxwell replaying your inserts:
 ```

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -69,6 +69,11 @@ docker run -it --rm osheroff/maxwell bin/maxwell --user=$MYSQL_USERNAME --passwo
 *note*: If you are installing on local machine using `docker` on `macOSX` then make sure that,
 - Even if the `mysql` server is *local*, you will have to use the local ip address (use `ifconfig` to find it) & pass that as `$MYSQL_HOST` instead of localhost. This is because in macOSX docker doesnt run as localhost.
 - You will have to use the non-localhost way of granting permissions to maxwell's mysql user.
+- If you are specifying any files either for `config` location or for output of `file` producer then make sure you are explicitly sharing volumes/files present on the host. E.g. the above docker command then becomes,
+```
+docker run -v /Users:/Users -it --rm osheroff/maxwell bin/maxwell --config=/Users/demo/maxwell/config/basic.properties
+```
+*make a note of the `-v` option.*
 
 If all goes well you'll see maxwell replaying your inserts:
 ```


### PR DESCRIPTION
As discussed in #555 creating this PR to update quick start docs, for starting maxwell using docker in macOSX platform.