### PR TITLE
Make Maxwell compatible with MariaDB MaxScale

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -89,6 +89,7 @@ public class Maxwell implements Runnable {
 				MysqlSchemaStore oldServerSchemaStore = new MysqlSchemaStore(
 					context.getMaxwellConnectionPool(),
 					context.getReplicationConnectionPool(),
+					context.getSchemaConnectionPool(),
 					recoveryInfo.serverID,
 					recoveryInfo.position,
 					context.getCaseSensitivity(),

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -29,6 +29,7 @@ public class MaxwellContext {
 	private final ConnectionPool replicationConnectionPool;
 	private final ConnectionPool maxwellConnectionPool;
 	private final ConnectionPool rawMaxwellConnectionPool;
+	private final ConnectionPool schemaConnectionPool;
 	private final MaxwellConfig config;
 	private MysqlPositionStore positionStore;
 	private PositionStoreThread positionStoreThread;
@@ -45,6 +46,19 @@ public class MaxwellContext {
 
 		this.replicationConnectionPool = new ConnectionPool("ReplicationConnectionPool", 10, 0, 10,
 				config.replicationMysql.getConnectionURI(false), config.replicationMysql.user, config.replicationMysql.password);
+
+		if (config.schemaMysql.host == null) {
+			this.schemaConnectionPool = null;
+		} else {
+			this.schemaConnectionPool = new ConnectionPool(
+					"SchemaConnectionPool",
+					10,
+					0,
+					10,
+					config.schemaMysql.getConnectionURI(false),
+					config.schemaMysql.user,
+					config.schemaMysql.password);
+		}
 
 		this.rawMaxwellConnectionPool = new ConnectionPool("RawMaxwellConnectionPool", 1, 2, 100,
 			config.maxwellMysql.getConnectionURI(false), config.maxwellMysql.user, config.maxwellMysql.password);
@@ -73,6 +87,13 @@ public class MaxwellContext {
 
 	public ConnectionPool getReplicationConnectionPool() { return replicationConnectionPool; }
 	public ConnectionPool getMaxwellConnectionPool() { return maxwellConnectionPool; }
+
+	public ConnectionPool getSchemaConnectionPool() {
+	    if (this.schemaConnectionPool != null) {
+		return schemaConnectionPool;
+	    }
+	    return replicationConnectionPool;
+	}
 
 	public Connection getMaxwellConnection() throws SQLException {
 		return this.maxwellConnectionPool.getConnection();

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -77,7 +77,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 
 		this.shouldHeartbeat = shouldHeartbeat;
 		if ( shouldHeartbeat )
-			this.replicator.setHeartbeatPeriod(0.5f);
+			this.replicator.setHeartbeatPeriod(1f);
 
 		this.stopOnEOF = stopOnEOF;
 

--- a/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
@@ -19,24 +19,26 @@ import snaq.db.ConnectionPool;
 public abstract class AbstractSchemaStore {
 	static final Logger LOGGER = LoggerFactory.getLogger(AbstractSchemaStore.class);
 	protected final ConnectionPool replicationConnectionPool;
+	protected final ConnectionPool schemaConnectionPool;
 	protected final CaseSensitivity caseSensitivity;
 	private final MaxwellFilter filter;
 
 	protected AbstractSchemaStore(ConnectionPool replicationConnectionPool,
+								  ConnectionPool schemaConnectionPool,
 								  CaseSensitivity caseSensitivity,
 								  MaxwellFilter filter) {
 		this.replicationConnectionPool = replicationConnectionPool;
+		this.schemaConnectionPool = schemaConnectionPool;
 		this.caseSensitivity = caseSensitivity;
 		this.filter = filter;
-
-
 	}
+
 	protected AbstractSchemaStore(MaxwellContext context) throws SQLException {
-		this(context.getReplicationConnectionPool(), context.getCaseSensitivity(), context.getFilter());
+		this(context.getReplicationConnectionPool(), context.getSchemaConnectionPool(), context.getCaseSensitivity(), context.getFilter());
 	}
 
 	protected Schema captureSchema() throws SQLException {
-		try(Connection connection = replicationConnectionPool.getConnection()) {
+		try(Connection connection = schemaConnectionPool.getConnection()) {
 			LOGGER.info("Maxwell is capturing initial schema");
 			SchemaCapturer capturer = new SchemaCapturer(connection, caseSensitivity);
 			return capturer.capture();

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -26,12 +26,13 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 
 	public MysqlSchemaStore(ConnectionPool maxwellConnectionPool,
 							ConnectionPool replicationConnectionPool,
+							ConnectionPool schemaConnectionPool,
 							Long serverID,
 							BinlogPosition initialPosition,
 							CaseSensitivity caseSensitivity,
 							MaxwellFilter filter,
 							boolean readOnly) {
-		super(replicationConnectionPool, caseSensitivity, filter);
+		super(replicationConnectionPool, schemaConnectionPool, caseSensitivity, filter);
 		this.serverID = serverID;
 		this.filter = filter;
 		this.maxwellConnectionPool = maxwellConnectionPool;
@@ -43,6 +44,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 		this(
 			context.getMaxwellConnectionPool(),
 			context.getReplicationConnectionPool(),
+			context.getSchemaConnectionPool(),
 			context.getServerID(),
 			initialPosition,
 			context.getCaseSensitivity(),

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -465,4 +465,27 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	}
 
+	@Test
+	public void testSchemaServerDifferentThanReplicationServer() throws Exception {
+		String[] opts = {
+			"--replication_host=replhost",
+			"--replication_port=1001",
+			"--replication_user=repluser",
+			"--replication_password=replpass",
+			"--schema_host=schemahost",
+			"--schema_port=2002",
+			"--schema_user=schemauser",
+			"--schema_password=schemapass"
+		};
+		MaxwellConfig config = new MaxwellConfig(opts);
+		assertEquals(config.replicationMysql.host, "replhost");
+		assertThat(config.replicationMysql.port, is(1001));
+		assertEquals(config.replicationMysql.user, "repluser");
+		assertEquals(config.replicationMysql.password, "replpass");
+		assertEquals(config.schemaMysql.host, "schemahost");
+		assertThat(config.schemaMysql.port, is(2002));
+		assertEquals(config.schemaMysql.user, "schemauser");
+		assertEquals(config.schemaMysql.password, "schemapass");
+	}
+
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -488,4 +488,21 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertEquals(config.schemaMysql.password, "schemapass");
 	}
 
+	@Test
+	public void testSchemaServerNotSet() throws Exception {
+		String[] opts = {
+			"--replication_host=replhost",
+			"--replication_port=1001",
+			"--replication_user=repluser",
+			"--replication_password=replpass",
+		};
+		MaxwellConfig config = new MaxwellConfig(opts);
+		assertEquals(config.replicationMysql.host, "replhost");
+		assertThat(config.replicationMysql.port, is(1001));
+		assertEquals(config.replicationMysql.user, "repluser");
+		assertEquals(config.replicationMysql.password, "replpass");
+		assertNull(config.schemaMysql.host);
+		assertNull(config.schemaMysql.user);
+		assertNull(config.schemaMysql.password);
+	}
 }


### PR DESCRIPTION
There are 2 logical changes in the PR, each in its own commit:

 * Add separate, dedicated connection for retrieving database schema during Maxwell startup

This is required when `replication_host` option is set to MaxScale.  MaxScale does not keep a copy of database schema.  The commit introduces a new `schema_{host,port,user,password}` options that are to be configured with a location of a MySQL/MariaDB's node holding the schema.

 * Change default heartbeat interval from 0.5s to 1s

MaxScale is not capable of handling sub-second heartbeat intervals and requesting one, results (due to integer truncation) in heartbeat interval set to 0, which disables heartbeats altogether.