### PR TITLE
add RowMap getters for `data` and `oldData` maps

### DIFF
--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -377,4 +377,14 @@ public class RowMap implements Serializable {
 	public boolean shouldOutput(MaxwellOutputConfig outputConfig) {
 		return true;
 	}
+
+	public LinkedHashMap<String, Object> getData()
+	{
+		return new LinkedHashMap<>(data);
+	}
+
+	public LinkedHashMap<String, Object> getOldData()
+	{
+		return new LinkedHashMap<>(oldData);
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -1,0 +1,37 @@
+package com.zendesk.maxwell.row;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+
+public class RowMapTest {
+  @Test
+  public void testGetDataMaps() throws Exception {
+    RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", 1234567890L, null, null);
+    rowMap.putData("foo", "bar");
+    rowMap.putOldData("fiz", "buz");
+
+    // Sanity check.
+    Assert.assertEquals("bar", rowMap.getData("foo"));
+    Assert.assertEquals("buz", rowMap.getOldData("fiz"));
+
+    // Get data maps.
+    LinkedHashMap<String, Object> data = rowMap.getData();
+    LinkedHashMap<String, Object> oldData = rowMap.getOldData();
+    Assert.assertEquals("bar", data.get("foo"));
+    Assert.assertEquals("buz", oldData.get("fiz"));
+
+    // Manipulate data maps extracted from RowMap.
+    data.put("foo", "BAR");
+    oldData.put("fiz", "BUZ");
+
+    // Another sanity check.
+    Assert.assertEquals("BAR", data.get("foo"));
+    Assert.assertEquals("BUZ", oldData.get("fiz"));
+
+    // Assert original RowMap data was not changed.
+    Assert.assertEquals("bar", rowMap.getData("foo"));
+    Assert.assertEquals("buz", rowMap.getOldData("fiz"));
+  }
+}


### PR DESCRIPTION
add getters for `data` and `oldData` maps. this increases usability of the data model in Java consumer apps. returned maps are copies, protecting the source maps from manipulations on the fetched maps.