### PR TITLE
add RowMap constructor that accepts JSON.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
       <artifactId>lz4</artifactId>
       <version>1.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20160810</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -1,11 +1,18 @@
 package com.zendesk.maxwell.row;
 
+import com.google.common.io.ByteStreams;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.LinkedHashMap;
 
+import static org.junit.Assert.assertEquals;
+
 public class RowMapTest {
+  private JSONObject json = new JSONObject();
+
   @Test
   public void testGetDataMaps() throws Exception {
     RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", 1234567890L, null, null);
@@ -33,5 +40,111 @@ public class RowMapTest {
     // Assert original RowMap data was not changed.
     Assert.assertEquals("bar", rowMap.getData("foo"));
     Assert.assertEquals("buz", rowMap.getOldData("fiz"));
+  }
+
+  @Test
+  public void testGetType() throws JSONException {
+    json.put("type", "patch");
+
+    RowMap result = new RowMap(json);
+    assertEquals("patch", result.getRowType());
+  }
+
+  @Test
+  public void testGetDatabase() throws JSONException {
+    json.put("database", "MyDatabase");
+
+    RowMap result = new RowMap(json);
+    assertEquals("MyDatabase", result.getDatabase());
+  }
+
+  @Test
+  public void testGetTable() throws JSONException {
+    json.put("table", "MyTable");
+
+    RowMap result = new RowMap(json);
+    assertEquals("MyTable", result.getTable());
+  }
+
+  @Test
+  public void testGetTimestamp() throws JSONException {
+    json.put("ts", 1234567890L);
+
+    RowMap result = new RowMap(json);
+    assertEquals(String.valueOf(1234567890L), String.valueOf(result.getTimestamp()));
+  }
+
+  @Test
+  public void testGetXID() throws JSONException {
+    json.put("xid", 1234567890L);
+
+    RowMap result = new RowMap(json);
+    assertEquals(String.valueOf(1234567890L), String.valueOf(result.getXid()));
+  }
+
+  @Test
+  public void testGetData() throws JSONException {
+    JSONObject data = new JSONObject();
+    data.put("FirstName", "Fiz");
+    data.put("LastName", "Buz");
+    json.put("data", data);
+
+    RowMap result = new RowMap(json);
+    assertEquals("Fiz", result.getData("FirstName"));
+    assertEquals("Buz", result.getData("LastName"));
+  }
+
+  @Test
+  public void testGetOldData() throws JSONException {
+    JSONObject oldData = new JSONObject();
+    oldData.put("FirstName", "Foo");
+    oldData.put("LastName", "Bar");
+    json.put("old", oldData);
+
+    RowMap result = new RowMap(json);
+    assertEquals("Foo", result.getOldData("FirstName"));
+    assertEquals("Bar", result.getOldData("LastName"));
+  }
+
+  @Test
+  public void testInsertIntegrationTest() throws Exception {
+    byte[] bytes = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/json/user-insert.json"));
+    Assert.assertNotNull(bytes);
+
+    RowMap rowMap = new RowMap(new JSONObject(new String(bytes)));
+    Assert.assertNotNull(rowMap);
+
+    Assert.assertEquals("MyDatabase", rowMap.getDatabase());
+    Assert.assertEquals("User", rowMap.getTable());
+    Assert.assertEquals("insert", rowMap.getRowType());
+    Assert.assertEquals("1486439516", rowMap.getTimestamp().toString());
+    Assert.assertEquals("5694", rowMap.getXid().toString());
+    Assert.assertEquals(20, rowMap.getData("UserID"));
+    Assert.assertEquals("Fiz", rowMap.getData("FirstName"));
+    Assert.assertNull(rowMap.getData("MiddleName"));
+    Assert.assertEquals("Buz", rowMap.getData("LastName"));
+    Assert.assertEquals(1486703131000L, rowMap.getData("Version"));
+  }
+
+  @Test
+  public void testUpdateIntegrationTest() throws Exception {
+    byte[] bytes = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/json/user-update.json"));
+    Assert.assertNotNull(bytes);
+
+    RowMap rowMap = new RowMap(new JSONObject(new String(bytes)));
+    Assert.assertNotNull(rowMap);
+
+    Assert.assertEquals("MyDatabase", rowMap.getDatabase());
+    Assert.assertEquals("User", rowMap.getTable());
+    Assert.assertEquals("update", rowMap.getRowType());
+    Assert.assertEquals("1486439516", rowMap.getTimestamp().toString());
+    Assert.assertEquals("5694", rowMap.getXid().toString());
+    Assert.assertEquals(20, rowMap.getData("UserID"));
+    Assert.assertEquals("Fiz", rowMap.getData("FirstName"));
+    Assert.assertNull(rowMap.getData("MiddleName"));
+    Assert.assertEquals("Buz", rowMap.getData("LastName"));
+    Assert.assertEquals(1486703131000L, rowMap.getData("Version"));
+    Assert.assertEquals("Foo", rowMap.getOldData("FirstName"));
+    Assert.assertEquals("Bar", rowMap.getOldData("LastName"));
   }
 }

--- a/src/test/resources/json/user-insert.json
+++ b/src/test/resources/json/user-insert.json
@@ -1,0 +1,1 @@
+{"database":"MyDatabase","table":"User","type":"insert","ts":1486439516,"xid":5694,"commit":true,"data":{"UserID":20,"FirstName":"Fiz","MiddleName":null,"LastName":"Buz","Version":1486703131000}}

--- a/src/test/resources/json/user-update.json
+++ b/src/test/resources/json/user-update.json
@@ -1,0 +1,1 @@
+{"database":"MyDatabase","table":"User","type":"update","ts":1486439516,"xid":5694,"commit":true,"data":{"UserID":20,"FirstName":"Fiz","MiddleName":null,"LastName":"Buz","Version":1486703131000},"old":{"backup_date":"2017-02-08 02:00:05","FirstName":"Foo","LastName":"Bar"}}


### PR DESCRIPTION
adds a RowMap constructor that accepts JSONObject. constructor params, xid, data, and old data are set into the model.

i couldn't come up with a sane default for BinlogPosition, so i left it null and i feel awful about that. any suggestions?

i'm also not too keen on the added dependency, but JSONObject is what i was working with in my consumer app. i'd be happy to take a crack at using Jackson's object-mapper but i think i need to learn about mix-ins with their creator feature if i want to avoid adding annotations to the model. again, up for suggestions : )

~~i chose to use a version range for the JSONObject dependency in case you were ok with that addition. the src and tests work with the earliest and latest stable versions of the dependency so i thought there was no reason to be forceful.~~

the integration tests read JSON from a file because i ran into a little issue with JSONObject where null was wrapped in an object.