### PR TITLE
implement backpressure support for bootstraping (all async producers)

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -26,8 +26,8 @@ public class InflightMessageList {
 		}
 	}
 
-	private final HashSet<String> nonTXMessages;
-	private final LinkedHashMap<String, InflightTXMessage> txMessages;
+	private final HashSet<Integer> nonTXMessages;
+	private final LinkedHashMap<Integer, InflightTXMessage> txMessages;
 
 	private final Lock txLock = new ReentrantLock();
 	private final Lock nonTXLock = new ReentrantLock();
@@ -36,11 +36,11 @@ public class InflightMessageList {
 	private final int MAX_INFLIGHT_NON_TX_MESSAGES = 10000;
 
 	public InflightMessageList() {
-		this.nonTXMessages = new HashSet<>();
-		this.txMessages = new LinkedHashMap<>();
+		this.nonTXMessages = new HashSet<Integer>();
+		this.txMessages = new LinkedHashMap<Integer, InflightTXMessage>();
 	}
 
-	public void addTXMessage(String rowId, BinlogPosition position) {
+	public void addTXMessage(int rowId, BinlogPosition position) {
 		txLock.lock();
 
 		try {
@@ -53,7 +53,7 @@ public class InflightMessageList {
 		return;
 	}
 
-	public void addNonTXMessage(String rowId) throws InterruptedException {
+	public void addNonTXMessage(int rowId) throws InterruptedException {
 		nonTXLock.lock();
 
 		try {
@@ -68,7 +68,7 @@ public class InflightMessageList {
 	}
 
 	/* returns the position that stuff is complete up to, or null if there were no changes */
-	public BinlogPosition completeTXMessage(String rowId) {
+	public BinlogPosition completeTXMessage(int rowId) {
 		BinlogPosition completeUntil = null;
 
 		txLock.lock();
@@ -96,7 +96,7 @@ public class InflightMessageList {
 		return completeUntil;
 	}
 
-	public void completeNonTXMessage(String rowId) {
+	public void completeNonTXMessage(int rowId) {
 		nonTXLock.lock();
 
 		try {

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -1,60 +1,111 @@
 package com.zendesk.maxwell.producer;
 /* respresents a list of inflight messages -- stuff being sent over the
-   network, that may complete in any order.  Allows for only bumping
-   the binlog position upon completion of the oldest outstanding item.
+	 network, that may complete in any order.  Allows for only bumping
+	 the binlog position upon completion of the oldest outstanding item.
 
-   Assumes .addInflight(position) will be call monotonically.
-   */
+	 Assumes .addInflight(position) will be call monotonically.
+	 */
 
 import com.zendesk.maxwell.replication.BinlogPosition;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.Condition;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Iterator;
 
 public class InflightMessageList {
-	class InflightMessage {
+	class InflightTXMessage {
 		public final BinlogPosition position;
 		public boolean isComplete;
-		InflightMessage(BinlogPosition position) {
+
+		public InflightTXMessage(BinlogPosition position) {
 			this.position = position;
 			this.isComplete = false;
 		}
 	}
 
-	private LinkedHashMap<String, InflightMessage> linkedMap;
+	private final HashSet<String> nonTXMessages;
+	private final LinkedHashMap<String, InflightTXMessage> txMessages;
+
+	private final Lock txLock = new ReentrantLock();
+	private final Lock nonTXLock = new ReentrantLock();
+	private final Condition nonTXMessagesNotFull = nonTXLock.newCondition(); 
+
+	private final int MAX_INFLIGHT_NON_TX_MESSAGES = 10000;
 
 	public InflightMessageList() {
-		this.linkedMap = new LinkedHashMap<>();
+		this.nonTXMessages = new HashSet<>();
+		this.txMessages = new LinkedHashMap<>();
 	}
 
-	public synchronized void addMessage(BinlogPosition p) {
-		InflightMessage m = new InflightMessage(p);
-		this.linkedMap.put(p.toString(), m);
+	public void addTXMessage(String rowId, BinlogPosition position) {
+		txLock.lock();
+
+		try {
+			InflightTXMessage m = new InflightTXMessage(position);
+			txMessages.put(rowId, m);
+		} finally {
+			txLock.unlock();
+		}
+
+		return;
+	}
+
+	public void addNonTXMessage(String rowId) throws InterruptedException {
+		nonTXLock.lock();
+
+		try {
+			while(nonTXMessages.size() > MAX_INFLIGHT_NON_TX_MESSAGES) {
+				nonTXMessagesNotFull.await();
+			}
+
+			this.nonTXMessages.add(rowId);
+		} finally {
+			nonTXLock.unlock();
+		}
 	}
 
 	/* returns the position that stuff is complete up to, or null if there were no changes */
-	public synchronized BinlogPosition completeMessage(BinlogPosition p) {
-		InflightMessage m = this.linkedMap.get(p.toString());
-		assert(m != null);
-
-		m.isComplete = true;
-
+	public BinlogPosition completeTXMessage(String rowId) {
 		BinlogPosition completeUntil = null;
-		Iterator<InflightMessage> iterator = this.linkedMap.values().iterator();
 
-		while ( iterator.hasNext() ) {
-			InflightMessage msg = iterator.next();
-			if ( !msg.isComplete )
-				break;
+		txLock.lock();
 
-			completeUntil = msg.position;
-			iterator.remove();
+		try {
+			InflightTXMessage m = txMessages.get(rowId);
+			assert(m != null);
+
+			m.isComplete = true;
+			Iterator<InflightTXMessage> iterator = txMessages.values().iterator();
+
+			while ( iterator.hasNext() ) {
+				InflightTXMessage msg = iterator.next();
+				if ( !msg.isComplete )
+					break;
+
+				completeUntil = msg.position;
+				iterator.remove();
+			}
+
+		} finally {
+			txLock.unlock();
 		}
 
 		return completeUntil;
 	}
 
-	public int size() {
-		return linkedMap.size();
+	public void completeNonTXMessage(String rowId) {
+		nonTXLock.lock();
+
+		try {
+			nonTXMessages.remove(rowId);
+			nonTXMessagesNotFull.signal();
+		} finally {
+			nonTXLock.unlock();
+		}
+
+		return;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -1,10 +1,11 @@
 package com.zendesk.maxwell.producer;
-/* respresents a list of inflight messages -- stuff being sent over the
-	 network, that may complete in any order.  Allows for only bumping
-	 the binlog position upon completion of the oldest outstanding item.
+/*
+    respresents a list of inflight messages -- stuff being sent over the
+    network, that may complete in any order.  Allows for only bumping
+    the binlog position upon completion of the oldest outstanding item.
 
-	 Assumes .addInflight(position) will be call monotonically.
-	 */
+    Assumes .addInflight(position) will be call monotonically.
+*/
 
 import com.zendesk.maxwell.replication.BinlogPosition;
 
@@ -31,7 +32,7 @@ public class InflightMessageList {
 
 	private final Lock txLock = new ReentrantLock();
 	private final Lock nonTXLock = new ReentrantLock();
-	private final Condition nonTXMessagesNotFull = nonTXLock.newCondition(); 
+	private final Condition nonTXMessagesNotFull = nonTXLock.newCondition();
 
 	private final int MAX_INFLIGHT_NON_TX_MESSAGES = 10000;
 

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -108,4 +108,8 @@ public class InflightMessageList {
 
 		return;
 	}
+
+	public int size() {
+		return txMessages.size() + nonTXMessages.size();
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -45,28 +45,28 @@ public class RowMap implements Serializable {
 	private long approximateSize;
 
 	private static final ThreadLocal<ByteArrayOutputStream> byteArrayThreadLocal =
-		new ThreadLocal<ByteArrayOutputStream>() {
-			@Override
-			protected ByteArrayOutputStream initialValue() {
-				return new ByteArrayOutputStream();
-			}
-		};
+			new ThreadLocal<ByteArrayOutputStream>() {
+				@Override
+				protected ByteArrayOutputStream initialValue() {
+					return new ByteArrayOutputStream();
+				}
+			};
 
 	private static final ThreadLocal<JsonGenerator> jsonGeneratorThreadLocal =
-		new ThreadLocal<JsonGenerator>() {
-			@Override
-			protected JsonGenerator initialValue() {
-				JsonGenerator g = null;
-				try {
-					g = jsonFactory.createGenerator(byteArrayThreadLocal.get());
-				} catch (IOException e) {
-					LOGGER.error("error initializing jsonGenerator", e);
-					return null;
+			new ThreadLocal<JsonGenerator>() {
+				@Override
+				protected JsonGenerator initialValue() {
+					JsonGenerator g = null;
+					try {
+						g = jsonFactory.createGenerator(byteArrayThreadLocal.get());
+					} catch (IOException e) {
+						LOGGER.error("error initializing jsonGenerator", e);
+						return null;
+					}
+					g.setRootValueSeparator(null);
+					return g;
 				}
-				g.setRootValueSeparator(null);
-				return g;
-			}
-		};
+			};
 
 	public RowMap(String type, String database, String table, Long timestamp, List<String> pkColumns,
 				  BinlogPosition nextPosition) {

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -39,7 +39,7 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 	private final LinkedHashMap<String, Object> oldData;
 	private final List<String> pkColumns;
 
-	private static final AtomicInteger rowIdCounter = new AtomicInteger();
+	private static final AtomicInteger rowIdCounter = new AtomicInteger(1);
 	private static final JsonFactory jsonFactory = new JsonFactory();
 
 	private long approximateSize;
@@ -70,7 +70,8 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 
 	public RowMap(String type, String database, String table, Long timestamp, List<String> pkColumns,
 			BinlogPosition nextPosition) {
-		this.rowId = Math.abs(rowIdCounter.incrementAndGet());
+		rowIdCounter.compareAndSet(Integer.MAX_VALUE, 1);
+		this.rowId = rowIdCounter.getAndIncrement();
 		this.rowType = type;
 		this.database = database;
 		this.table = table;

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RowMap implements Serializable {
 
 	public enum KeyFormat { HASH, ARRAY }
-static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
+	static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 
 	private final int rowId;
 	private final String rowType;
@@ -45,7 +45,7 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 	private long approximateSize;
 
 	private static final ThreadLocal<ByteArrayOutputStream> byteArrayThreadLocal =
-		new ThreadLocal<ByteArrayOutputStream>(){
+		new ThreadLocal<ByteArrayOutputStream>() {
 			@Override
 			protected ByteArrayOutputStream initialValue() {
 				return new ByteArrayOutputStream();
@@ -69,7 +69,7 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 		};
 
 	public RowMap(String type, String database, String table, Long timestamp, List<String> pkColumns,
-			BinlogPosition nextPosition) {
+				  BinlogPosition nextPosition) {
 		rowIdCounter.compareAndSet(Integer.MAX_VALUE, 1);
 		this.rowId = rowIdCounter.getAndIncrement();
 		this.rowType = type;
@@ -117,7 +117,7 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 		g.writeEndObject(); // end of 'data: { }'
 		g.flush();
 		return jsonFromStream();
-		}
+	}
 
 	private String pkToJsonArray() throws IOException {
 		JsonGenerator g = jsonGeneratorThreadLocal.get();
@@ -213,7 +213,7 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 		}
 
 		generator.writeEndObject(); // end of 'jsonMapName: { }'
-		}
+	}
 
 	public String toJSON() throws IOException {
 		return toJSON(new MaxwellOutputConfig());
@@ -275,7 +275,7 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 		g.flush();
 
 		return jsonFromStream();
-		}
+	}
 
 	private String jsonFromStream() {
 		ByteArrayOutputStream b = byteArrayThreadLocal.get();
@@ -395,4 +395,4 @@ static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 	{
 		return new LinkedHashMap<>(oldData);
 	}
-	}
+}

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -18,9 +18,9 @@ public class InflightMessageListTest {
 	@Before
 	public void setupBefore() {
 		list = new InflightMessageList();
-		list.addTXMessage("1", p1);
-		list.addTXMessage("2", p2);
-		list.addTXMessage("3", p3);
+		list.addTXMessage(1, p1);
+		list.addTXMessage(2, p2);
+		list.addTXMessage(3, p3);
 	}
 
 	@Test
@@ -28,13 +28,13 @@ public class InflightMessageListTest {
 		BinlogPosition ret;
 
 
-		ret = list.completeTXMessage("1");
+		ret = list.completeTXMessage(1);
 		assert(ret.equals(p1));
 
-		ret = list.completeTXMessage("2");
+		ret = list.completeTXMessage(2);
 		assert(ret.equals(p2));
 
-		ret = list.completeTXMessage("3");
+		ret = list.completeTXMessage(3);
 		assert(ret.equals(p3));
 
 		assert(list.size() == 0);
@@ -44,13 +44,13 @@ public class InflightMessageListTest {
 	public void testOutOfOrderComplete() {
 		BinlogPosition ret;
 
-		ret = list.completeTXMessage("3");
+		ret = list.completeTXMessage(3);
 		assert(ret == null);
 
-		ret = list.completeTXMessage("2");
+		ret = list.completeTXMessage(2);
 		assert(ret == null);
 
-		ret = list.completeTXMessage("1");
+		ret = list.completeTXMessage(1);
 		assertEquals(p3, ret);
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -18,9 +18,9 @@ public class InflightMessageListTest {
 	@Before
 	public void setupBefore() {
 		list = new InflightMessageList();
-		list.addMessage(p1);
-		list.addMessage(p2);
-		list.addMessage(p3);
+		list.addTXMessage("1", p1);
+		list.addTXMessage("2", p2);
+		list.addTXMessage("3", p3);
 	}
 
 	@Test
@@ -28,13 +28,13 @@ public class InflightMessageListTest {
 		BinlogPosition ret;
 
 
-		ret = list.completeMessage(p1);
+		ret = list.completeTXMessage("1");
 		assert(ret.equals(p1));
 
-		ret = list.completeMessage(p2);
+		ret = list.completeTXMessage("2");
 		assert(ret.equals(p2));
 
-		ret = list.completeMessage(p3);
+		ret = list.completeTXMessage("3");
 		assert(ret.equals(p3));
 
 		assert(list.size() == 0);
@@ -44,13 +44,13 @@ public class InflightMessageListTest {
 	public void testOutOfOrderComplete() {
 		BinlogPosition ret;
 
-		ret = list.completeMessage(p3);
+		ret = list.completeTXMessage("3");
 		assert(ret == null);
 
-		ret = list.completeMessage(p2);
+		ret = list.completeTXMessage("2");
 		assert(ret == null);
 
-		ret = list.completeMessage(p1);
+		ret = list.completeTXMessage("1");
 		assertEquals(p3, ret);
 	}
 }


### PR DESCRIPTION
This is an alternative to the backpressure implementation in #548.

I'm using Maxwell with Kinesis and bootstrapping will push records to KPL faster than it can send them to AWS, resulting in memory consumption issues, slowdown of KPL, the the bootstrap utility giving inaccurate estimates since the synchronous bootstraper reports the rows as inserted before the callbacks complete.

Kinesis only allows 1MB/s per shard ingest and the streaming query during bootstrapping can pull data from mysql at a much faster rate which fills KPL's buffer very quickly.  Kafka most likely can match the throughput of the mysql data link, so I'm guessing that's why something like this PR hasn't been needed yet.  I haven't done any testing with Kafka though, so I'm uncertain the affects this PR will have there (if any).

This PR modifies the `InflightMessageList` to keep track of TXCommit and NonTXCommit (the bootstrap records) separately, and enforces a limit on the number of NonTXCommit messages using lock conditions.  ~~Also, RowMap now has a UUID generated I use for hash keys since bootstrap records don't have binlog positions.~~  I don't think changing the hash key for TXCommits affects behavior.

Edit: I now use an atomicinteger value for the rowid to avoid the overhead of uuid generate and size of the string.  The atomicinteger should be fine since we will never have more than `Integer.MAX_VALUE` rows inflight at one time and it will roll over once it reaches the max value.  Could also use AtomicLong here if we want the rowId's to be unique for a longer period of time.

I avoided using the `kinesisProducer.getOutstandingRecordCount()` because it's producer specific and it's getting the size of a concurrentHashMap underneath which feels like something that shouldn't be called every message (see http://stackoverflow.com/questions/10754675/concurrent-hashmap-size-method-complexity).

TXCommit and NonTXCommit messages have their own locks and do not contend with each other, and I decided to not implement back pressure for TXCommit messages, though it's an easy addition from here . Maybe should be added to improve robustness of maxwell generally?  I figured for normal usage when not bootstraping, the number of kinesis shards should be scaled so it's not as much of an issue.  Also, the current setup should give TXCommit some priority over a bootstrap flood since it will still allow TXCommit messages to pass through on the bootstrap replication thread when we block NonTXCommit's on the async bootstrap thread.

I chose a limit of 10000 inflight messages in order to make sure KPL has enough messages to aggregate properly, though the ideal number may be based off the average record size and number of shards.   Maybe `numberOfInflightMessage = (numberOfShards * 1000000 / averageMessageSizeInBytes)` which would allow KPL to have around 1 second worth of messages in memory to figure out its aggregation stuff.  Maybe be worth exposing as a configuration option?

Thanks for this awesome library and wanted to get this here in front of eyes.  I still need to update/add more unit tests for my additions.