### PR TITLE
ProfilerProducer - Prevent NullPointerException on rows without JSON

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/ProfilerProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/ProfilerProducer.java
@@ -26,8 +26,11 @@ public class ProfilerProducer extends AbstractProducer {
 		if ( this.startTime == 0)
 			this.startTime = System.currentTimeMillis();
 
+		String value = r.toJSON();
 
-		nullOutputStream.write(r.toJSON().getBytes());
+		if (value != null) {
+			nullOutputStream.write(value.getBytes());
+		}
 
 		this.count++;
 		if ( this.count % 10000 == 0 ) {


### PR DESCRIPTION
I get a NullPointException when running the ProfilerProducer when receiving DDL changes.  This PR adds a null check in order to prevent exceptions.
```
19:35:05,209 INFO  AbstractSchemaStore - storing schema @BinlogPosition[qdbs2275.000074:127216780] after applying "DROP TABLE IF EXISTS xxxxxx"
java.lang.NullPointerException
	at com.zendesk.maxwell.producer.ProfilerProducer.push(ProfilerProducer.java:30)
	at com.zendesk.maxwell.replication.AbstractReplicator.processQueryEvent(AbstractReplicator.java:74)
	at com.zendesk.maxwell.replication.MaxwellReplicator.processQueryEvent(MaxwellReplicator.java:376)
	at com.zendesk.maxwell.replication.MaxwellReplicator.getRow(MaxwellReplicator.java:350)
	at com.zendesk.maxwell.replication.AbstractReplicator.work(AbstractReplicator.java:127)
	at com.zendesk.maxwell.util.RunLoopProcess.runLoop(RunLoopProcess.java:35)
	at com.zendesk.maxwell.Maxwell.start(Maxwell.java:178)
	at com.zendesk.maxwell.Maxwell.main(Maxwell.java:199)
```
