### PR TITLE
improve enum values extraction

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -15,6 +15,7 @@ import com.zendesk.maxwell.schema.columndef.*;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrTokenizer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +30,7 @@ import snaq.db.ConnectionPool;
 
 
 public class MysqlSavedSchema {
-	static int SchemaStoreVersion = 3;
+	static int SchemaStoreVersion = 4;
 
 	private Schema schema;
 	private BinlogPosition position;
@@ -213,7 +214,13 @@ public class MysqlSavedSchema {
 
 					if ( c instanceof EnumeratedColumnDef ) {
 						EnumeratedColumnDef enumColumn = (EnumeratedColumnDef) c;
-						enumValuesSQL = StringUtils.join(enumColumn.getEnumValues(), ",");
+						if (enumColumn.getEnumValues() != null) {
+							try {
+								enumValuesSQL = mapper.writeValueAsString(enumColumn.getEnumValues());
+							} catch (JsonProcessingException e) {
+								throw new SQLException(e);
+							}
+						}
 					}
 
 					columnData.add(schemaId);
@@ -500,7 +507,15 @@ public class MysqlSavedSchema {
 
 			String[] enumValues = null;
 			if (columnEnumValues != null) {
-				enumValues = StringUtils.splitByWholeSeparatorPreserveAllTokens(columnEnumValues, ",");
+				if (this.schemaVersion >= 4) {
+					try {
+						enumValues = mapper.readValue(columnEnumValues, String[].class);
+					} catch (IOException e) {
+						throw new SQLException(e);
+					}
+				} else {
+					enumValues = StringUtils.splitByWholeSeparatorPreserveAllTokens(columnEnumValues, ",");
+				}
 			}
 
 			ColumnDef c = ColumnDef.build(

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -2,7 +2,7 @@ package com.zendesk.maxwell.schema;
 
 import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrTokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -217,14 +217,9 @@ public class SchemaCapturer {
 	}
 
 	private static String[] extractEnumValues(String expandedType) {
-		String[] enumValues;
 		Matcher matcher = Pattern.compile("(enum|set)\\((.*)\\)").matcher(expandedType);
 		matcher.matches(); // why do you tease me so.
 
-		enumValues = StringUtils.split(matcher.group(2), ",");
-		for (int j = 0; j < enumValues.length; j++) {
-			enumValues[j] = enumValues[j].substring(1, enumValues[j].length() - 1);
-		}
-		return enumValues;
+		return new StrTokenizer(matcher.group(2), ',', '\'').getTokenArray();
 	}
 }

--- a/src/test/resources/sql/schema/enum.sql
+++ b/src/test/resources/sql/schema/enum.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS `test`.`enum_test` (
+  `language` ENUM('en-US', 'de-DE'),
+  `decimal_separator` ENUM(',', '.'),
+  PRIMARY KEY (`language`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Currently enum values containing commas will lead to a StringIndexOutOfBoundsException