### PR TITLE
use seconds instead of milliseconds for DDL message timestamp

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -291,7 +291,7 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 			data.getSql(),
 			this.schemaStore,
 			event.getPosition(),
-			event.getEvent().getHeader().getTimestamp()
+			event.getEvent().getHeader().getTimestamp() / 1000
 		);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -378,7 +378,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 			event.getSql().toString(),
 			this.schemaStore,
 			eventBinlogPosition(event),
-			event.getHeader().getTimestamp()
+			event.getHeader().getTimestamp() / 1000
 		);
 	}
 


### PR DESCRIPTION
### Description

use seconds instead of milliseconds for DDL message timestamp

/cc @osheroff @timbertson 