### PR TITLE
Adding encryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
       <artifactId>lz4</artifactId>
       <version>1.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20160212</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -138,6 +138,9 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "output_thread_id", "produced records include thread_id; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_ddl", "produce DDL records to ddl_kafka_topic [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "ddl_kafka_topic", "optionally provide an alternate topic to push DDL records to. default: kafka_topic").withOptionalArg();
+		parser.accepts("encryption_key", "The 128 bit key used for encryption").withOptionalArg();
+		parser.accepts("secret_key", "The secret key for the AES encryption").withOptionalArg();
+		parser.accepts("use_encryption", "boolean flag to enable encryption").withOptionalArg();
 
 		parser.accepts( "__separator_5" );
 
@@ -359,6 +362,9 @@ public class MaxwellConfig extends AbstractConfig {
 		outputConfig.includesThreadId = fetchBooleanOption("output_thread_id", options, properties, false);
 		outputConfig.outputDDL	= fetchBooleanOption("output_ddl", options, properties, false);
 		this.excludeColumns     = fetchOption("exclude_columns", options, properties, null);
+		outputConfig.useEncryption = fetchBooleanOption("use_encryption", options, properties, false);
+		outputConfig.encryption_key = fetchOption("encryption_key", options, properties, null);
+		outputConfig.secret_key = fetchOption("secret_key", options, properties, null);
 
 		if ( this.excludeColumns != null ) {
 			for ( String s : this.excludeColumns.split(",") ) {

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
@@ -13,6 +13,9 @@ public class MaxwellOutputConfig {
 	public boolean includesThreadId;
 	public boolean outputDDL;
 	public List<Pattern> excludeColumns;
+	public boolean useEncryption;
+	public String encryption_key;
+	public String secret_key;
 
 	public MaxwellOutputConfig() {
 		this.includesBinlogPosition = false;
@@ -23,5 +26,8 @@ public class MaxwellOutputConfig {
 		this.includesThreadId = false;
 		this.outputDDL = false;
 		this.excludeColumns = new ArrayList<>();
+		this.useEncryption = false;
+		this.encryption_key = null;
+		this.secret_key = null;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/row/RowEncrypt.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowEncrypt.java
@@ -1,0 +1,32 @@
+package com.zendesk.maxwell.row;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RowEncrypt {
+
+	static final Logger LOGGER = LoggerFactory.getLogger(RowEncrypt.class);
+
+	public static String encrypt(String value, String key, String initVector) {
+		try {
+			IvParameterSpec iv = new IvParameterSpec(initVector.getBytes("UTF-8"));
+			SecretKeySpec skeySpec = new SecretKeySpec(key.getBytes("UTF-8"), "AES");
+
+			Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+			cipher.init(Cipher.ENCRYPT_MODE, skeySpec, iv);
+
+			byte[] encrypted = cipher.doFinal(value.getBytes());
+
+			return Base64.encodeBase64String(encrypted);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+
+		return null;
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
@@ -240,7 +240,7 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 		for ( RowMap r : rows ) {
 			String json = r.toJSON(outputConfig);
-			
+
 			Map<String, Object> data, output = MaxwellTestJSON.parseJSON(r.toJSON(outputConfig));
 			if ( output.get("table").equals("column_test") && output.get("type").equals("insert") ) {
 				IvParameterSpec ivSpec = new IvParameterSpec(outputConfig.secret_key.getBytes("UTF-8"));

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -5,14 +5,21 @@ import static org.junit.Assert.*;
 
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.row.RowMap;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.nio.charset.Charset;
 import java.sql.ResultSet;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.*;
 
 import com.zendesk.maxwell.schema.SchemaStoreSchema;
 import org.junit.Test;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
@@ -25,13 +32,23 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		String input[] = {"insert into minimal set account_id =1, text_field='hello'"};
 		list = getRowsForSQL(input);
 		String json = list.get(0).toJSON(outputConfig);
-		assertTrue(Pattern.matches(".*\"ts\":\\d+.*",json));
-		assertTrue(Pattern.matches(".*\"database\":\"shard_1\".*",json));
-		assertTrue(Pattern.matches(".*\"xid\":\\d+.*", json));
-		assertTrue(Pattern.matches(".*\"commit\":true.*",json));
-		assertTrue(Pattern.matches(".*\"data\":\"1ub4DX5FGXqLnDWK6nhrZAY6sbwNvItFnTPzpByMNX4BuIRIgNq7rybo\\+hztXCdD\".*",json));
-		assertTrue(Pattern.matches(".*\"type\":\"insert\".*",json));
-		assertTrue(Pattern.matches(".*\"table\":\"minimal\".*",json));
+
+		Map<String,Object> output = MaxwellTestJSON.parseJSON(json);
+
+		IvParameterSpec ivSpec = new IvParameterSpec(outputConfig.secret_key.getBytes("UTF-8"));
+		SecretKeySpec skeySpec = new SecretKeySpec(outputConfig.encryption_key.getBytes("UTF-8"), "AES");
+		Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+		cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivSpec);
+
+		output.put("data",MaxwellTestJSON.parseJSON(new String(cipher.doFinal(Base64.decodeBase64(output.get("data").toString().getBytes())), Charset.forName("UTF-8"))));
+		assertTrue(output.get("database").equals("shard_1"));
+		assertTrue(output.get("table").equals("minimal"));
+		assertTrue(Pattern.matches("\\d+", output.get("xid").toString()));
+		assertTrue(output.get("type").equals("insert"));
+		assertTrue(Pattern.matches("\\d+",output.get("ts").toString()));
+		assertTrue(output.get("commit").equals(true));
+		assertTrue(((Map) output.get("data")).get("account_id").equals(1));
+		assertTrue(((Map) output.get("data")).get("text_field").equals("hello"));
 	}
 	@Test
 	public void testGetEvent() throws Exception {

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -16,6 +16,24 @@ import org.junit.Test;
 
 public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
+	public void testEncryptedValues() throws Exception{
+		MaxwellOutputConfig outputConfig = new MaxwellOutputConfig();
+		outputConfig.useEncryption = true;
+		outputConfig.encryption_key = "aaaaaaaaaaaaaaaa";
+		outputConfig.secret_key = "RandomInitVector";
+		List<RowMap> list;
+		String input[] = {"insert into minimal set account_id =1, text_field='hello'"};
+		list = getRowsForSQL(input);
+		String json = list.get(0).toJSON(outputConfig);
+		assertTrue(Pattern.matches(".*\"ts\":\\d+.*",json));
+		assertTrue(Pattern.matches(".*\"database\":\"shard_1\".*",json));
+		assertTrue(Pattern.matches(".*\"xid\":\\d+.*", json));
+		assertTrue(Pattern.matches(".*\"commit\":true.*",json));
+		assertTrue(Pattern.matches(".*\"data\":\"1ub4DX5FGXqLnDWK6nhrZAY6sbwNvItFnTPzpByMNX4BuIRIgNq7rybo\\+hztXCdD\".*",json));
+		assertTrue(Pattern.matches(".*\"type\":\"insert\".*",json));
+		assertTrue(Pattern.matches(".*\"table\":\"minimal\".*",json));
+	}
+	@Test
 	public void testGetEvent() throws Exception {
 		List<RowMap> list;
 		String input[] = {"insert into minimal set account_id = 1, text_field='hello'"};


### PR DESCRIPTION
Not including the trimString and removeNonAscii features that Dave and I had for Vertica purposes in this branch so a lot less needed changing. Also improved the testing efforts for encryption. This is just 1.8.1 with our encryption and the requirements are off from that they wanted still because they wanted the whole payload encrypted with an option to prefix that encrypted data with the kafka key so I wouldn't submit this still. 