### PR TITLE
Fix boolean cli args not using false

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -150,9 +150,9 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "schema_database", "database name for maxwell state (schema and binlog position)").withRequiredArg();
 		parser.accepts( "max_schemas", "deprecated.").withOptionalArg();
 		parser.accepts( "init_position", "initial binlog position, given as BINLOG_FILE:POSITION").withRequiredArg();
-		parser.accepts( "replay", "replay mode, don't store any information to the server");
-		parser.accepts( "master_recovery", "(experimental) enable master position recovery code");
-		parser.accepts( "gtid_mode", "(experimental) enable gtid mode");
+		parser.accepts( "replay", "replay mode, don't store any information to the server").withOptionalArg();
+		parser.accepts( "master_recovery", "(experimental) enable master position recovery code").withOptionalArg();
+		parser.accepts( "gtid_mode", "(experimental) enable gtid mode").withOptionalArg();
 
 		parser.accepts( "__separator_7" );
 


### PR DESCRIPTION
Currently, if you pass a flag that takes a Boolean argument, the argument is ignored and the flag is always set to true. This fixes that.

For instance:
`--gtid_mode=false` would being ignored and gtid_mode would be set to ON anyway.