### PR TITLE
Adding default constructor to RowMap pertaining to issue #604

### DIFF
--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -66,6 +66,8 @@ public class RowMap implements Serializable {
 				}
 			};
 
+	public RowMap() {}
+
 	public RowMap(String type, String database, String table, Long timestamp, List<String> pkColumns,
 			BinlogPosition nextPosition) {
 		this.rowType = type;


### PR DESCRIPTION
I am trying to use Dozer for auto transforming objects, and the absence of default constructor is throwing exception as specified in #604 . Please let me know if this solution works for everyone.