### PR TITLE
Add detailed fix instructions when master recovery fails

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -69,7 +69,7 @@ public class Maxwell implements Runnable {
 	private BinlogPosition attemptMasterRecovery() throws Exception {
 		BinlogPosition recovered = null;
 		MysqlPositionStore positionStore = this.context.getPositionStore();
-		RecoveryInfo recoveryInfo = positionStore.getRecoveryInfo();
+		RecoveryInfo recoveryInfo = positionStore.getRecoveryInfo(config);
 
 		if ( recoveryInfo != null ) {
 			Recovery masterRecovery = new Recovery(

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -143,7 +143,7 @@ public class MaxwellContext {
 	}
 
 	public RecoveryInfo getRecoveryInfo() throws SQLException {
-		return this.positionStore.getRecoveryInfo();
+		return this.positionStore.getRecoveryInfo(config);
 	}
 
 	public void setPosition(RowMap r) throws SQLException {

--- a/src/main/java/com/zendesk/maxwell/recovery/RecoveryInfo.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/RecoveryInfo.java
@@ -14,4 +14,13 @@ public class RecoveryInfo {
 		this.serverID = serverID;
 		this.clientID = clientID;
 	}
+
+	public String toString() {
+		return "<RecoveryInfo" +
+				" position: " + position +
+				", heartbeat: " + heartbeat +
+				", serverId: " + serverID +
+				", clientId: " + clientID +
+				">";
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
@@ -1,20 +1,31 @@
 package com.zendesk.maxwell.schema;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.*;
 import com.zendesk.maxwell.*;
 import java.sql.ResultSet;
+import java.util.List;
 
+import com.zendesk.maxwell.recovery.RecoveryInfo;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.errors.DuplicateProcessException;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
 public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 	private MysqlPositionStore buildStore() throws Exception {
-		MaxwellContext context = buildContext();
-		return new MysqlPositionStore(context.getMaxwellConnectionPool(), context.getServerID(), "maxwell", MaxwellTestSupport.inGtidMode());
+		return buildStore(buildContext());
+	}
+
+	private MysqlPositionStore buildStore(MaxwellContext context) throws Exception {
+		return buildStore(context, context.getServerID());
+	}
+
+	private MysqlPositionStore buildStore(MaxwellContext context, Long serverID) throws Exception {
+		return new MysqlPositionStore(context.getMaxwellConnectionPool(), serverID, "maxwell", MaxwellTestSupport.inGtidMode());
 	}
 
 	@Test
@@ -63,5 +74,56 @@ public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 		}
 
 		assertThat(exception, is(not(nullValue())));
+	}
+
+	@Test
+	public void testEmptyPositionRecovery() throws Exception {
+		MaxwellContext context = buildContext();
+		MysqlPositionStore store = buildStore(context);
+		List<RecoveryInfo> recoveries = store.getAllRecoveryInfos();
+
+		assertThat(recoveries.size(), is(0));
+
+		String errorMessage = StringUtils.join(store.formatRecoveryFailure(context.getConfig(), recoveries), "\n");
+		assertThat(errorMessage, is("Unable to find any binlog positions in `positions` table"));
+		assertThat(store.getRecoveryInfo(context.getConfig()), is(nullValue()));
+	}
+
+	@Test
+	public void testMultiplePositionRecovery() throws Exception {
+		MaxwellContext context = buildContext();
+		Long activeServerID = context.getServerID();
+
+		Long newestServerID = activeServerID + 1;
+		Long intermediateServerID = activeServerID + 2;
+		Long oldestServerID = activeServerID + 3;
+
+		Long newestHeartbeat = 123L;
+		Long intermediateHeartbeat = newestHeartbeat - 10;
+		Long oldestHeartbeat = newestHeartbeat - 20;
+		String binlogFile = "bin.log";
+
+		buildStore(context, oldestServerID).set(new BinlogPosition(0L, binlogFile, oldestHeartbeat));
+		buildStore(context, intermediateServerID).set(new BinlogPosition(0L, binlogFile, intermediateHeartbeat));
+		buildStore(context, newestServerID).set(new BinlogPosition(0L, binlogFile, newestHeartbeat));
+		MysqlPositionStore store = buildStore(context);
+
+		List<RecoveryInfo> recoveries = store.getAllRecoveryInfos();
+
+		if (MaxwellTestSupport.inGtidMode()) {
+			assertThat(recoveries.size(), is(1));
+			// gtid mode can't get into a multiple recovery state
+			return;
+		}
+
+		assertThat(recoveries.size(), is(3));
+		assertThat(store.getRecoveryInfo(context.getConfig()), is(nullValue()));
+
+		String errorMessage = StringUtils.join(store.formatRecoveryFailure(context.getConfig(), recoveries), "\n");
+		assertThat(errorMessage, containsString("Found multiple binlog positions for cluster in `positions` table."));
+		for (RecoveryInfo recovery: recoveries) {
+			assertThat(errorMessage, containsString(" - " + recovery));
+		}
+		assertThat(errorMessage, containsString("execute: DELETE FROM maxwell.positions WHERE server_id <> " + newestServerID + ";"));
 	}
 }


### PR DESCRIPTION
It's hopefully paranoia since this _shouldn't_ happen any more, but can if you have bad data left in the `positions` table (or maybe something else goes horribly wrong at just the right moment).

Log the full details when we find multiple `RecoveryInfo`s, as well as manual remediation steps (delete all `positions` rows _except_ for the most recent master), assuming the one with the most recent heartbeat is The Right One:tm:

/cc @zendesk/goanna 