### PR TITLE
Add task manager class to terminate all background tasks on exit / exception

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -5,7 +5,6 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.concurrent.TimeoutException;
 
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
@@ -19,6 +18,8 @@ import com.zendesk.maxwell.schema.ReadOnlyMysqlPositionStore;
 import com.zendesk.maxwell.schema.MysqlPositionStore;
 import com.zendesk.maxwell.schema.PositionStoreThread;
 
+import com.zendesk.maxwell.util.StoppableTask;
+import com.zendesk.maxwell.util.TaskManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import snaq.db.ConnectionPool;
@@ -37,12 +38,15 @@ public class MaxwellContext {
 	private BinlogPosition initialPosition;
 	private CaseSensitivity caseSensitivity;
 	private AbstractProducer producer;
+	private TaskManager taskManager;
+	private volatile Exception error;
 
 	private Integer mysqlMajorVersion;
 	private Integer mysqlMinorVersion;
 
 	public MaxwellContext(MaxwellConfig config) throws SQLException {
 		this.config = config;
+		this.taskManager = new TaskManager();
 
 		this.replicationConnectionPool = new ConnectionPool("ReplicationConnectionPool", 10, 0, 10,
 				config.replicationMysql.getConnectionURI(false), config.replicationMysql.user, config.replicationMysql.password);
@@ -111,24 +115,34 @@ public class MaxwellContext {
 		this.positionStore.heartbeat();
 	}
 
+	public void addTask(StoppableTask task) {
+		this.taskManager.add(task);
+	}
+
 	public void terminate() {
-		if ( this.positionStoreThread != null ) {
-			try {
-				this.positionStoreThread.stopLoop();
-				this.positionStoreThread = null;
-			} catch (TimeoutException e) {
-				LOGGER.error("got timeout trying to shutdown positionStore thread.");
-			}
+		terminate(null);
+	}
+
+	public void terminate(Exception error) {
+		if (this.error == null) {
+			this.error = error;
 		}
-		this.replicationConnectionPool.release();
-		this.maxwellConnectionPool.release();
-		this.rawMaxwellConnectionPool.release();
+		if (taskManager.stop(error)) {
+			this.replicationConnectionPool.release();
+			this.maxwellConnectionPool.release();
+			this.rawMaxwellConnectionPool.release();
+		}
+	}
+
+	public Exception getError() {
+		return error;
 	}
 
 	public PositionStoreThread getPositionStoreThread() {
 		if ( this.positionStoreThread == null ) {
-			this.positionStoreThread = new PositionStoreThread(this.positionStore);
+			this.positionStoreThread = new PositionStoreThread(this.positionStore, this);
 			this.positionStoreThread.start();
+			addTask(positionStoreThread);
 		}
 		return this.positionStoreThread;
 	}
@@ -161,16 +175,6 @@ public class MaxwellContext {
 
 	public MysqlPositionStore getPositionStore() {
 		return this.positionStore;
-	}
-
-	public void ensurePositionThread() throws Exception {
-		if ( this.positionStoreThread == null )
-			return;
-
-		Exception e = this.getPositionStoreThread().getException();
-		if ( e != null ) {
-			throw (e);
-		}
 	}
 
 	public Long getServerID() throws SQLException {
@@ -260,6 +264,13 @@ public class MaxwellContext {
 			throw new RuntimeException("Unknown producer type: " + this.config.producerType);
 		}
 
+		StoppableTask task = null;
+		if (producer != null) {
+			task = producer.getStoppableTask();
+		}
+		if (task != null) {
+			addTask(task);
+		}
 		return this.producer;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
@@ -1,8 +1,8 @@
 package com.zendesk.maxwell.producer;
 
-import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.util.StoppableTask;
 
 public abstract class AbstractProducer {
 	protected final MaxwellContext context;
@@ -14,4 +14,8 @@ public abstract class AbstractProducer {
 	}
 
 	abstract public void push(RowMap r) throws Exception;
+
+	public StoppableTask getStoppableTask() {
+		return null;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -92,7 +92,9 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 		super(context);
 		this.queue = new ArrayBlockingQueue<>(100);
 		this.worker = new MaxwellKafkaProducerWorker(context, kafkaProperties, kafkaTopic, this.queue);
-		new Thread(this.worker, "maxwell-kafka-worker").start();
+		Thread thread = new Thread(this.worker, "maxwell-kafka-worker");
+		thread.setDaemon(true);
+		thread.start();
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -163,7 +163,7 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 		while ( true ) {
 			try {
 				RowMap row = queue.take();
-				if (!taskState.keepGoing()) {
+				if (!taskState.isRunning()) {
 					taskState.stopped();
 					return;
 				}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -11,6 +11,8 @@ import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMap.KeyFormat;
 import com.zendesk.maxwell.schema.ddl.DDLMap;
+import com.zendesk.maxwell.util.StoppableTask;
+import com.zendesk.maxwell.util.StoppableTaskState;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -24,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 
 class KafkaCallback implements Callback {
@@ -90,16 +93,20 @@ public class MaxwellKafkaProducer extends AbstractProducer {
 		this.queue = new ArrayBlockingQueue<>(100);
 		this.worker = new MaxwellKafkaProducerWorker(context, kafkaProperties, kafkaTopic, this.queue);
 		new Thread(this.worker, "maxwell-kafka-worker").start();
-
 	}
 
 	@Override
 	public void push(RowMap r) throws Exception {
 		this.queue.put(r);
 	}
+
+	@Override
+	public StoppableTask getStoppableTask() {
+		return this.worker;
+	}
 }
 
-class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnable {
+class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnable, StoppableTask {
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellKafkaProducer.class);
 
 	private final KafkaProducer<String, String> kafka;
@@ -111,6 +118,8 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	private final boolean interpolateTopic;
 	private final Timer metricsTimer;
 	private final ArrayBlockingQueue<RowMap> queue;
+	private Thread thread;
+	private StoppableTaskState taskState;
 
 	private final Counter succeededMessageCount = MaxwellMetrics.metricRegistry.counter(succeededMessageCountName);
 	private final Meter succeededMessageMeter = MaxwellMetrics.metricRegistry.meter(succeededMessageMeterName);
@@ -143,16 +152,24 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 
 		this.metricsTimer = MaxwellMetrics.metricRegistry.timer(MetricRegistry.name(MaxwellMetrics.getMetricsPrefix(), "time", "overall"));
 		this.queue = queue;
+		this.taskState = new StoppableTaskState("MaxwellKafkaProducerWorker");
 	}
 
 	@Override
 	public void run() {
+		this.thread = Thread.currentThread();
 		while ( true ) {
 			try {
 				RowMap row = queue.take();
+				if (!taskState.keepGoing()) {
+					taskState.stopped();
+					return;
+				}
 				this.push(row);
 			} catch ( Exception e ) {
-				throw new RuntimeException(e);
+				taskState.stopped();
+				context.terminate(e);
+				return;
 			}
 		}
 	}
@@ -194,5 +211,21 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 				this.succeededMessageCount, this.failedMessageCount, this.succeededMessageMeter, this.failedMessageMeter);
 
 		kafka.send(record, callback);
+	}
+
+	@Override
+	public void requestStop() {
+		taskState.requestStop();
+		kafka.close();
+	}
+
+	@Override
+	public void awaitStop(Long timeout) throws TimeoutException {
+		taskState.awaitStop(thread, timeout);
+	}
+
+	@Override
+	public StoppableTask getStoppableTask() {
+		return this;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -65,8 +65,7 @@ public class Recovery {
 						null,
 						null,
 						replicationConfig,
-						0L, // server-id of 0 activatives "mysqlbinlog" behavior where the server will stop after each binlog
-						null,
+						0L, // server-id of 0 activates "mysqlbinlog" behavior where the server will stop after each binlog
 						maxwellDatabaseName,
 						position,
 						true,
@@ -78,9 +77,8 @@ public class Recovery {
 						null,
 						null,
 						replicationConfig,
-						0L, // server-id of 0 activatives "mysqlbinlog" behavior where the server will stop after each binlog
+						0L, // server-id of 0 activates "mysqlbinlog" behavior where the server will stop after each binlog
 						false,
-						null,
 						maxwellDatabaseName,
 						position,
 						true,

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -9,7 +9,6 @@ import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
-import com.zendesk.maxwell.schema.PositionStoreThread;
 import com.zendesk.maxwell.schema.SchemaStore;
 import com.zendesk.maxwell.schema.ddl.DDLMap;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
@@ -24,7 +23,6 @@ import java.util.Objects;
 public abstract class AbstractReplicator extends RunLoopProcess implements Replicator {
 	private static Logger LOGGER = LoggerFactory.getLogger(AbstractReplicator.class);
 	protected final String clientID;
-	protected final PositionStoreThread positionStoreThread;
 	protected final AbstractProducer producer;
 	protected final AbstractBootstrapper bootstrapper;
 	protected final String maxwellSchemaDatabaseName;
@@ -42,10 +40,9 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 
 	protected Long replicationLag = 0L;
 
-	public AbstractReplicator(String clientID, AbstractBootstrapper bootstrapper, PositionStoreThread positionStoreThread, String maxwellSchemaDatabaseName, AbstractProducer producer) {
+	public AbstractReplicator(String clientID, AbstractBootstrapper bootstrapper, String maxwellSchemaDatabaseName, AbstractProducer producer) {
 		this.clientID = clientID;
 		this.bootstrapper = bootstrapper;
-		this.positionStoreThread = positionStoreThread;
 		this.maxwellSchemaDatabaseName = maxwellSchemaDatabaseName;
 		this.producer = producer;
 	}
@@ -143,12 +140,6 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 
 		rowCounter.inc();
 		rowMeter.mark();
-
-		// todo: this is inelegant.  Ideally the outer code would monitor the
-		// position thread and stop us if it was dead.
-
-		if ( positionStoreThread.getException() != null )
-			throw positionStoreThread.getException();
 
 		if ( row == null )
 			return;

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -39,13 +39,12 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 		AbstractBootstrapper bootstrapper,
 		MaxwellMysqlConfig mysqlConfig,
 		Long replicaServerID,
-		PositionStoreThread positionStoreThread,
 		String maxwellSchemaDatabaseName,
 		BinlogPosition start,
 		boolean stopOnEOF,
 		String clientID
 	) {
-		super(clientID, bootstrapper, positionStoreThread, maxwellSchemaDatabaseName, producer);
+		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer);
 		this.schemaStore = schemaStore;
 
 		this.client = new BinaryLogClient(mysqlConfig.host, mysqlConfig.port, mysqlConfig.user, mysqlConfig.password);
@@ -79,7 +78,6 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 			bootstrapper,
 			ctx.getConfig().replicationMysql,
 			ctx.getConfig().replicaServerID,
-			ctx.getPositionStoreThread(),
 			ctx.getConfig().databaseName,
 			start,
 			false,
@@ -91,7 +89,8 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 		if ( !client.isConnected() && !stopOnEOF ) {
 			String gtidStr = client.getGtidSet();
 			String binlogPos = client.getBinlogFilename() + ":" + client.getBinlogPosition();
-			LOGGER.warn("replicator stopped at position: " + gtidStr == null ? binlogPos : gtidStr + " -- restarting");
+			String position = gtidStr == null ? binlogPos : gtidStr;
+			LOGGER.warn("replicator stopped at position: " + position + " -- restarting");
 			client.connect(5000);
 		}
 	}

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -44,13 +44,12 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 		MaxwellMysqlConfig mysqlConfig,
 		Long replicaServerID,
 		boolean shouldHeartbeat,
-		PositionStoreThread positionStoreThread,
 		String maxwellSchemaDatabaseName,
 		BinlogPosition start,
 		boolean stopOnEOF,
 		String clientID
 	) {
-		super(clientID, bootstrapper, positionStoreThread, maxwellSchemaDatabaseName, producer);
+		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer);
 		this.schemaStore = schemaStore;
 		this.binlogEventListener = new BinlogEventListener(queue);
 
@@ -84,7 +83,6 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 			ctx.getConfig().replicationMysql,
 			ctx.getConfig().replicaServerID,
 			ctx.shouldHeartbeat(),
-			ctx.getPositionStoreThread(),
 			ctx.getConfig().databaseName,
 			start,
 			false,

--- a/src/main/java/com/zendesk/maxwell/replication/Replicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/Replicator.java
@@ -1,15 +1,15 @@
 package com.zendesk.maxwell.replication;
 
-import java.util.concurrent.TimeoutException;
 import com.zendesk.maxwell.MaxwellFilter;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.SchemaStoreException;
 import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.util.StoppableTask;
 
 /**
  * Created by ben on 10/23/16.
  */
-public interface Replicator {
+public interface Replicator extends StoppableTask {
 	void setFilter(MaxwellFilter filter);
 	void startReplicator() throws Exception;
 	RowMap getRow() throws Exception;
@@ -18,5 +18,4 @@ public interface Replicator {
 	Long getReplicationLag();
 
 	boolean runLoop() throws Exception;
-	void stopLoop() throws TimeoutException;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/PositionStoreThread.java
+++ b/src/main/java/com/zendesk/maxwell/schema/PositionStoreThread.java
@@ -25,6 +25,7 @@ public class PositionStoreThread extends RunLoopProcess implements Runnable {
 
 	public void start() {
 		this.thread = new Thread(this, "Position Flush Thread");
+		this.thread.setDaemon(true);
 		thread.start();
 	}
 

--- a/src/main/java/com/zendesk/maxwell/util/RunLoopProcess.java
+++ b/src/main/java/com/zendesk/maxwell/util/RunLoopProcess.java
@@ -2,41 +2,36 @@ package com.zendesk.maxwell.util;
 
 import java.util.concurrent.TimeoutException;
 
-abstract public class RunLoopProcess {
-	private enum RunState { STOPPED, RUNNING, REQUEST_STOP };
-	private volatile RunState runState;
+abstract public class RunLoopProcess implements StoppableTask {
+	protected volatile StoppableTaskState taskState;
 	private Thread thread;
 
 	public RunLoopProcess() {
-		this.runState = RunState.STOPPED;
 	}
 
-	protected void requestStop() {
-		if ( this.runState != RunState.STOPPED )
-			this.runState = RunState.REQUEST_STOP;
-
+	public void requestStop() {
+		this.taskState.requestStop();
 	}
 
-	protected boolean isStopRequested() {
-		return this.runState == RunState.REQUEST_STOP;
+	public void awaitStop(Long timeout) throws TimeoutException {
+		this.taskState.awaitStop(thread, timeout);
 	}
 
 	public boolean runLoop() throws Exception {
-		if ( this.runState != RunState.STOPPED )
+		if ( this.taskState != null )
 			return false;
 
+		this.taskState = new StoppableTaskState(this.getClass().getName());
 		this.thread = Thread.currentThread();
 		this.beforeStart();
 
-		this.runState = RunState.RUNNING;
-
 		try {
-			while (this.runState == RunState.RUNNING)
+			while (this.taskState.keepGoing()) {
 				work();
-
+			}
 		} finally {
 			this.beforeStop();
-			this.runState = RunState.STOPPED;
+			this.taskState.stopped();
 		}
 
 		return true;
@@ -45,28 +40,4 @@ abstract public class RunLoopProcess {
 	protected abstract void work() throws Exception;
 	protected void beforeStart() throws Exception { }
 	protected void beforeStop() throws Exception { }
-
-	public void stopLoop() throws TimeoutException {
-		stopLoop(5000);
-	}
-
-	public void stopLoop(long timeoutMS) throws TimeoutException {
-		if ( this.runState == RunState.STOPPED )
-			return;
-
-		/* gentle request */
-		this.requestStop();
-
-		/* foot tapping */
-		for (long left = timeoutMS; left > 0 && this.runState == RunState.REQUEST_STOP; left -= 10)
-			try { Thread.sleep(10); } catch (InterruptedException e) { }
-
-		/* very impatient throat clear */
-		thread.interrupt();
-
-		try { Thread.sleep(100); } catch (InterruptedException e) { }
-
-		if( this.runState != RunState.STOPPED )
-			throw new TimeoutException("Timed out trying to stop processed after " + timeoutMS + "ms.");
-	}
 }

--- a/src/main/java/com/zendesk/maxwell/util/RunLoopProcess.java
+++ b/src/main/java/com/zendesk/maxwell/util/RunLoopProcess.java
@@ -26,7 +26,7 @@ abstract public class RunLoopProcess implements StoppableTask {
 		this.beforeStart();
 
 		try {
-			while (this.taskState.keepGoing()) {
+			while (this.taskState.isRunning()) {
 				work();
 			}
 		} finally {

--- a/src/main/java/com/zendesk/maxwell/util/RunState.java
+++ b/src/main/java/com/zendesk/maxwell/util/RunState.java
@@ -1,0 +1,3 @@
+package com.zendesk.maxwell.util;
+
+public enum RunState { STOPPED, RUNNING, REQUEST_STOP }

--- a/src/main/java/com/zendesk/maxwell/util/StoppableTask.java
+++ b/src/main/java/com/zendesk/maxwell/util/StoppableTask.java
@@ -1,0 +1,8 @@
+package com.zendesk.maxwell.util;
+
+import java.util.concurrent.TimeoutException;
+
+public interface StoppableTask {
+	void requestStop();
+	void awaitStop(Long timeout) throws TimeoutException;
+}

--- a/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
+++ b/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
@@ -1,0 +1,51 @@
+package com.zendesk.maxwell.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeoutException;
+
+public class StoppableTaskState {
+	private static Logger LOGGER = LoggerFactory.getLogger(StoppableTaskState.class);
+	private volatile RunState state;
+	private final String description;
+
+	public StoppableTaskState(String description) {
+		state = RunState.RUNNING;
+		this.description = description;
+	}
+
+	public boolean keepGoing() {
+		return state == RunState.RUNNING;
+	}
+
+	public synchronized void requestStop() {
+		LOGGER.info(description + " requestStop() called (in state: " + state + ")");
+		if (state == RunState.RUNNING) {
+			this.state = RunState.REQUEST_STOP;
+		}
+	}
+
+	public void stopped() {
+		this.state = RunState.STOPPED;
+	}
+
+	public synchronized void awaitStop(Thread t, long timeoutMS) throws TimeoutException {
+		/* foot tapping */
+		for (long left = timeoutMS; left > 0 && this.state == RunState.REQUEST_STOP; left -= 10)
+			try { Thread.sleep(10); } catch (InterruptedException e) { }
+
+		/* very impatient throat clear */
+		if (t != null) {
+			t.interrupt();
+		}
+
+		try { Thread.sleep(100); } catch (InterruptedException e) { }
+
+		if( this.state != RunState.STOPPED ) {
+			throw new TimeoutException(
+				"Timed out trying waiting for " + description + " process to stop after " + timeoutMS + "ms."
+			);
+		}
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
+++ b/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
@@ -48,4 +48,8 @@ public class StoppableTaskState {
 			);
 		}
 	}
+
+	public RunState getState() {
+		return state;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
+++ b/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
@@ -15,13 +15,13 @@ public class StoppableTaskState {
 		this.description = description;
 	}
 
-	public boolean keepGoing() {
+	public boolean isRunning() {
 		return state == RunState.RUNNING;
 	}
 
 	public synchronized void requestStop() {
 		LOGGER.info(description + " requestStop() called (in state: " + state + ")");
-		if (state == RunState.RUNNING) {
+		if (isRunning()) {
 			this.state = RunState.REQUEST_STOP;
 		}
 	}

--- a/src/main/java/com/zendesk/maxwell/util/TaskManager.java
+++ b/src/main/java/com/zendesk/maxwell/util/TaskManager.java
@@ -1,0 +1,60 @@
+package com.zendesk.maxwell.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeoutException;
+
+public class TaskManager {
+	private static final Logger LOGGER = LoggerFactory.getLogger(TaskManager.class);
+
+	private final ArrayList<StoppableTask> tasks;
+	private volatile RunState state;
+
+	public TaskManager() {
+		this.tasks = new ArrayList<>();
+		this.state = RunState.RUNNING;
+	}
+
+	// Can be invoked multiple times, will only return `true`
+	// for the first invocation.
+	public synchronized boolean stop(Exception error) {
+		if (this.state != RunState.RUNNING) {
+			LOGGER.debug("stop() called multiple times");
+			return false;
+		}
+		this.state = RunState.REQUEST_STOP;
+
+		LOGGER.info("stopping " + tasks.size() + " tasks");
+
+		if (error != null) {
+			LOGGER.error("cause: ", error);
+		}
+
+		// tell everything to stop
+		for (StoppableTask task: this.tasks) {
+			task.requestStop();
+		}
+
+		// then wait for everything to stop
+		Long timeout = 500L;
+		for (StoppableTask task: this.tasks) {
+			try {
+				task.awaitStop(timeout);
+			} catch (TimeoutException e) {
+				LOGGER.error(e.getMessage());
+			}
+		}
+
+		this.state = RunState.STOPPED;
+		LOGGER.info("stopped all tasks");
+		return true;
+	}
+
+	public synchronized void add(StoppableTask task) {
+		synchronized (tasks) {
+			tasks.add(task);
+		}
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -226,6 +226,10 @@ public class MaxwellTestSupport {
 
 		callback.beforeTerminate(mysql);
 		maxwell.terminate();
+		Exception maxwellError = maxwell.context.getError();
+		if (maxwellError != null) {
+			throw maxwellError;
+		}
 
 		return list;
 	}

--- a/src/test/java/com/zendesk/maxwell/util/StoppableTaskStateTest.java
+++ b/src/test/java/com/zendesk/maxwell/util/StoppableTaskStateTest.java
@@ -1,0 +1,60 @@
+package com.zendesk.maxwell.util;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.junit.Test;
+
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class StoppableTaskStateTest {
+
+	@Test
+	public void testStateTransition() {
+		StoppableTaskState state = new StoppableTaskState("task");
+		assertThat(state.getState(), equalTo(RunState.RUNNING));
+		assertThat(state.keepGoing(), equalTo(true));
+
+		state.requestStop();
+		assertThat(state.getState(), equalTo(RunState.REQUEST_STOP));
+		assertThat(state.keepGoing(), equalTo(false));
+
+		state.stopped();
+		assertThat(state.getState(), equalTo(RunState.STOPPED));
+		assertThat(state.keepGoing(), equalTo(false));
+	}
+
+	@Test
+	public void requestStopIsIgnoredIfAlreadyStopped() {
+		StoppableTaskState state = new StoppableTaskState("task");
+		state.stopped();
+
+		state.requestStop();
+		assertThat(state.getState(), equalTo(RunState.STOPPED));
+	}
+
+	@Test
+	public void awaitSucceedsWhenAlreadyStopped() throws TimeoutException {
+		StoppableTaskState state = new StoppableTaskState("task");
+		state.stopped();
+
+		state.awaitStop(null, 0L);
+	}
+
+	@Test
+	public void awaitThrowsWhenNotStopped() {
+		StoppableTaskState state = new StoppableTaskState("task");
+
+		TimeoutException e = null;
+		try {
+			state.awaitStop(null, 0L);
+		} catch (TimeoutException _e) {
+			e = _e;
+		}
+
+		assertThat(e, notNullValue());
+		assertThat(state.getState(), equalTo(RunState.RUNNING));
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/util/StoppableTaskStateTest.java
+++ b/src/test/java/com/zendesk/maxwell/util/StoppableTaskStateTest.java
@@ -1,6 +1,5 @@
 package com.zendesk.maxwell.util;
 
-import org.apache.commons.lang3.time.StopWatch;
 import org.junit.Test;
 
 import java.util.concurrent.TimeoutException;
@@ -15,15 +14,15 @@ public class StoppableTaskStateTest {
 	public void testStateTransition() {
 		StoppableTaskState state = new StoppableTaskState("task");
 		assertThat(state.getState(), equalTo(RunState.RUNNING));
-		assertThat(state.keepGoing(), equalTo(true));
+		assertThat(state.isRunning(), equalTo(true));
 
 		state.requestStop();
 		assertThat(state.getState(), equalTo(RunState.REQUEST_STOP));
-		assertThat(state.keepGoing(), equalTo(false));
+		assertThat(state.isRunning(), equalTo(false));
 
 		state.stopped();
 		assertThat(state.getState(), equalTo(RunState.STOPPED));
-		assertThat(state.keepGoing(), equalTo(false));
+		assertThat(state.isRunning(), equalTo(false));
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/util/TaskManagerTest.java
+++ b/src/test/java/com/zendesk/maxwell/util/TaskManagerTest.java
@@ -1,0 +1,110 @@
+package com.zendesk.maxwell.util;
+
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class TaskManagerTest {
+	class SampleTask implements StoppableTask {
+		private final List<Event> log;
+		public String name;
+
+		SampleTask(List<Event> eventLog, String name) {
+			this.log = eventLog;
+			this.name = name;
+		}
+
+		@Override
+		public void requestStop() {
+			log.add(new Event(EventType.REQUEST_STOP, this.name));
+		}
+
+		@Override
+		public void awaitStop(Long timeout) throws TimeoutException {
+			log.add(new Event(EventType.AWAIT_STOP, this.name));
+		}
+	}
+	enum EventType { REQUEST_STOP, AWAIT_STOP };
+
+	class UnstoppableTask implements StoppableTask {
+		UnstoppableTask() {
+		}
+
+		@Override
+		public void requestStop() {
+		}
+
+		@Override
+		public void awaitStop(Long timeout) throws TimeoutException {
+			throw new TimeoutException("can't stop this");
+		}
+	}
+
+	class Event extends MutablePair<EventType, String> {
+		Event(EventType left, String right) {
+			super(left, right);
+		}
+	}
+
+	@Test
+	public void shutsDownAllTasksAndWaitsForCompletion() {
+		List<Event> log = new ArrayList<>();
+		StoppableTask task1 = new SampleTask(log, "task1");
+		StoppableTask task2 = new SampleTask(log, "task2");
+
+		TaskManager manager = new TaskManager();
+		manager.add(task1);
+		manager.add(task2);
+
+		manager.stop(null);
+		assertThat(log, equalTo(Arrays.asList(
+			// stop tasks first
+			new Event(EventType.REQUEST_STOP, "task1"),
+			new Event(EventType.REQUEST_STOP, "task2"),
+			// ... then wait
+			new Event(EventType.AWAIT_STOP, "task1"),
+			new Event(EventType.AWAIT_STOP, "task2")
+		)));
+	}
+
+	@Test
+	public void continuesOnAwaitTimeout() {
+		List<Event> log = new ArrayList<>();
+		StoppableTask task1 = new UnstoppableTask();
+		StoppableTask task2 = new SampleTask(log, "task2");
+
+		TaskManager manager = new TaskManager();
+		manager.add(task1);
+		manager.add(task2);
+
+		manager.stop(null); // does not throw
+
+		assertThat(log, hasItem(
+			new Event(EventType.AWAIT_STOP, "task2")
+		));
+	}
+
+	@Test
+	public void onlyStopsTasksOnce() {
+		List<Event> log = new ArrayList<>();
+		StoppableTask task = new SampleTask(log, "task");
+		TaskManager manager = new TaskManager();
+		manager.add(task);
+
+		assertThat(manager.stop(null), equalTo(true));
+		assertThat(manager.stop(null), equalTo(false));
+
+		assertThat(log, equalTo(Arrays.asList(
+			new Event(EventType.REQUEST_STOP, "task"),
+			new Event(EventType.AWAIT_STOP, "task")
+		)));
+	}
+}


### PR DESCRIPTION
I'd appreciate review @osheroff if you've got some time. (also @zendesk/goanna )

Key points:

 - new TaskManager class attached to MaxwellConfig which collects tasks (and eventually stops them). Tasks are:
   - replicator
   - positionStoreThread
   - (possibly) producer, for async Kafka producer
 - MaxwellContext.terminate tracks whether termination was clean or due to an exception
 - Replicator no longer checks for PositionStoreThread exceptions; the parent (RunLoopProcess takes care of being stopped by the task manager)

~A failed kafka publish callback now terminates the associated maxwell context (issue #614)~, as does exception in the MaxwellKafkaProducerWorker's run() thread. This should cause maxwell to actually terminate on error, instead of skipping messages or bravely forging ahead without a producer thread.

TODO:

- [x] add tests
- [x] mark all non-main threads as daemons so they can't accidentally prevent shutdown