### PR TITLE
findSchema: determine newest schema based on binlog position, not insertion order

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogPosition.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogPosition.java
@@ -114,8 +114,11 @@ public class BinlogPosition implements Serializable {
 			return false;
 		BinlogPosition otherPosition = (BinlogPosition) other;
 
-		return this.file.equals(otherPosition.file) && this.offset == otherPosition.offset
-			&& (gtidSetStr == null) ? otherPosition.gtidSetStr == null
-				: gtidSetStr.equals(otherPosition.gtidSetStr);
+		return this.file.equals(otherPosition.file)
+			&& this.offset == otherPosition.offset
+			&& (gtidSetStr == null
+					? otherPosition.gtidSetStr == null
+					: gtidSetStr.equals(otherPosition.gtidSetStr)
+				);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -543,11 +543,13 @@ public class MysqlSavedSchema {
 			}
 			return null;
 		} else {
+			// Only consider binlog positions before the target position on the current server.
+			// Within those, sort for the latest binlog file, then the latest binlog position.
 			PreparedStatement s = connection.prepareStatement(
 				"SELECT id from `schemas` "
 				+ "WHERE deleted = 0 "
 				+ "AND ((binlog_file < ?) OR (binlog_file = ? and binlog_position <= ?)) AND server_id = ? "
-				+ "ORDER BY id desc limit 1");
+				+ "ORDER BY binlog_file DESC, binlog_position DESC limit 1");
 
 			s.setString(1, targetPosition.getFile());
 			s.setString(2, targetPosition.getFile());

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.sql.Connection;
 import java.util.List;
@@ -27,6 +28,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 	private Schema schema;
 	private BinlogPosition binlogPosition;
 	private MysqlSavedSchema savedSchema;
+	private CaseSensitivity caseSensitivity = CaseSensitivity.CASE_SENSITIVE;
 
 	String ary[] = {
 			"delete from `maxwell`.`positions`",
@@ -181,5 +183,114 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 		DateTimeColumnDef cd = (DateTimeColumnDef) restored.getSchema().findDatabase("shard_1").findTable("without_col_length").findColumn("badcol");
 
 		assertEquals((Long) 3L, (Long) cd.getColumnLength());
+	}
+
+	private Schema buildSchema() {
+		String charset = Charset.defaultCharset().toString();
+		List<Database> databases = new ArrayList<>();
+		return new Schema(databases, charset, caseSensitivity);
+	}
+
+	private void populateSchemasSurroundingTarget(
+			Connection c,
+			Long serverId,
+			BinlogPosition targetPosition,
+			String previousFile,
+			String newerFile
+	) throws SQLException {
+
+		// newer binlog file
+		new MysqlSavedSchema(
+			serverId, caseSensitivity,
+			buildSchema(),
+			new BinlogPosition(targetPosition.getOffset() - 100L, newerFile)
+		).saveSchema(c);
+
+		// newer binlog position
+		new MysqlSavedSchema(
+			serverId, caseSensitivity,
+			buildSchema(),
+			new BinlogPosition(targetPosition.getOffset() + 100L, targetPosition.getFile())
+		).saveSchema(c);
+
+		// different server ID
+		new MysqlSavedSchema(
+			serverId + 1L, caseSensitivity,
+			buildSchema(),
+			targetPosition
+		).saveSchema(c);
+
+		// older binlog file
+		new MysqlSavedSchema(
+			serverId, caseSensitivity,
+			buildSchema(),
+			new BinlogPosition(targetPosition.getOffset(), previousFile)
+		).saveSchema(c);
+	}
+
+	@Test
+	public void testFindSchemaReturnsTheLatestSchemaForTheCurrentBinlog() throws Exception {
+		if (context.getConfig().gtidMode) {
+			return;
+		}
+
+		Connection c = context.getMaxwellConnection();
+
+		long serverId = 100;
+		long targetPosition = 500;
+		String targetFile = "binlog08";
+		String previousFile = "binlog07";
+		String newerFile = "binlog09";
+		BinlogPosition targetBinlogPosition = new BinlogPosition(targetPosition, targetFile);
+
+		MysqlSavedSchema expectedSchema = new MysqlSavedSchema(serverId, caseSensitivity,
+			buildSchema(),
+			new BinlogPosition(targetPosition - 50L, targetFile)
+		);
+		expectedSchema.save(c);
+
+		// older binlog position
+		new MysqlSavedSchema(
+			serverId, caseSensitivity,
+			buildSchema(),
+			new BinlogPosition(targetPosition - 200L, targetFile)
+		).saveSchema(c);
+
+		populateSchemasSurroundingTarget(c, serverId, targetBinlogPosition,
+			previousFile, newerFile);
+
+		MysqlSavedSchema foundSchema = MysqlSavedSchema.restore(context.getMaxwellConnectionPool(), serverId, caseSensitivity, targetBinlogPosition);
+		assertThat(foundSchema.getBinlogPosition(), equalTo(expectedSchema.getBinlogPosition()));
+		assertThat(foundSchema.getSchemaID(), equalTo(expectedSchema.getSchemaID()));
+	}
+
+	@Test
+	public void testFindSchemaReturnsTheLatestSchemaForPreviousBinlog() throws Exception {
+		if (context.getConfig().gtidMode) {
+			return;
+		}
+
+		Connection c = context.getMaxwellConnection();
+		long serverId = 100;
+		long targetPosition = 500;
+		String targetFile = "binlog08";
+		String previousFile = "binlog07";
+		String newerFile = "binlog09";
+		BinlogPosition targetBinlogPosition = new BinlogPosition(targetPosition, targetFile);
+
+		// the newest schema:
+		MysqlSavedSchema expectedSchema = new MysqlSavedSchema(serverId, caseSensitivity,
+				buildSchema(),
+				new BinlogPosition(targetPosition + 50L, previousFile)
+		);
+		expectedSchema.save(c);
+
+		populateSchemasSurroundingTarget(c, serverId, targetBinlogPosition,
+			previousFile, newerFile);
+
+		MysqlSavedSchema foundSchema = MysqlSavedSchema.restore(context.getMaxwellConnectionPool(),
+			serverId, caseSensitivity, targetBinlogPosition);
+		assertThat(foundSchema.getBinlogPosition(), equalTo(expectedSchema.getBinlogPosition()));
+		assertThat(foundSchema.getSchemaID(), equalTo(expectedSchema.getSchemaID()));
 	}
 }


### PR DESCRIPTION
OK, this is a bit of a hairy one (with a conveniently simple fix). This is how we think it went down:

(/cc @zendesk/goanna @osheroff @hawknewton @vanchi-zendesk )

### A tale of two maxwells

Two (or more) maxwells are replicating the same DB to different kafka clusters. call them MAXWELL_A and MAXWELL_B.

MAXWELL_A (spuriously?) detects a master failover:
 - gets new position on the new master (and stores it in schemas)
 - immediately afterwards it falls over because that binlog file doesn't exist:

```
WARN  Recovery - attempting to recover from master-change: old-server-id: 175113239, file: account1-bin-log.002480, position: 711569117, heartbeat: 1490725038684
INFO  OpenReplicator - starting replication at account4-bin-log.001571:4
WARN  Recovery - recovered new master position: BinlogPosition[account4-bin-log.001571:684320609]
( ... )
INFO  OpenReplicator - starting replication at account4-bin-log.001571:684320609
ERROR MaxwellReplicator - Missing binlog 'account4-bin-log.001571' on account-master
ERROR MaxwellReplicator - Transport exception #1236
com.google.code.or.net.TransportException: Could not find first log file name in binary log index file
 at com.google.code.or.OpenReplicator.dumpBinlog(OpenReplicator.java:343)
 at com.google.code.or.OpenReplicator.start(OpenReplicator.java:115)
 at com.zendesk.maxwell.replication.MaxwellReplicator.startReplicator(MaxwellReplicator.java:127)
 at com.zendesk.maxwell.replication.MaxwellReplicator.beforeStart(MaxwellReplicator.java:142)
 at com.zendesk.maxwell.util.RunLoopProcess.runLoop(RunLoopProcess.java:29)
 at com.zendesk.maxwell.Maxwell.start(Maxwell.java:178)
 at com.zendesk.maxwell.Maxwell.main(Maxwell.java:199)

# ( note that this still happens on shutdown, which possibly poisons the well for future restarts: )

INFO  PositionStoreThread - Storing final position: BinlogPosition[account4-bin-log.001571:684320609]
 ```

**Question: How did it recover this binlog position if it doesn't exist?**
If it the heartbeat was the last entry of that particular binlog, maybe there's an edge case where we start at the "next position", which doesn't exist (what we actually want is the beginning of the next binlog file)?

Whatever the reason, MAXWELL_A is out of action for a bit after this - it keeps trying to resume from this faulty binlog position.

Meanwhile, node MAXWELL_B has been following the DB just fine. It still sees `account1` as the master (never saw a failover to `account4`). A migration occurs. MAXWELL_B sees this and dutifully writes the schema diff into the `schemas` table. That occurred at account1-bin-log.002486, which is a position after MAXWELL_A dropped off.

MAXWELL_A comes back - it sees `account1` as the master, and recovers from its last known binlog position (account4-bin-log.001571:684320609). Since this is associated with a valid heartbeat, it doesn't matter that the binlog position isn't valid - it finds the new position on `account1` and actually recovers successfully. It writes its recovered schema to `schemas`, at binlog position `account1-bin-log.002480:711569117`.

This is correct behaviour, until MAXWELL_B gets restarted. It finds the latest schema which was _written_ for the active server (by sorting by ID), which is MAXWELL_A's recovery. MAXWELL_B now thinks that this schema (for an earlier binlog position than the schema change it recorded) is the latest schema, and proceeds to fall over when data comes for the modified table.