### PR TITLE
MaxwellReplicator: log more details on unexpected DML

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -244,7 +244,8 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 				case EXT_UPDATE_ROWS:
 				case DELETE_ROWS:
 				case EXT_DELETE_ROWS:
-					LOGGER.warn("Started replication stream outside of transaction.  This shouldn't normally happen.");
+					LOGGER.warn("Started replication stream inside a transaction.  This shouldn't normally happen.");
+					LOGGER.warn("Assuming new transaction at unexpected event:" + event);
 
 					queue.offerFirst(event);
 					rowBuffer = getTransactionRows();

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -321,7 +321,8 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 				case MySQLConstants.UPDATE_ROWS_EVENT_V2:
 				case MySQLConstants.DELETE_ROWS_EVENT:
 				case MySQLConstants.DELETE_ROWS_EVENT_V2:
-					LOGGER.warn("Started replication stream outside of transaction.  This shouldn't normally happen.");
+					LOGGER.warn("Started replication stream inside a transaction.  This shouldn't normally happen.");
+					LOGGER.warn("Assuming new transaction at unexpected event:" + v4Event);
 
 					queue.offerFirst(v4Event);
 					rowBuffer = getTransactionRows();


### PR DESCRIPTION
We've seen this log occur multiple times in a row when replication gets restarted (doe to a lost heartbeat), it'd be good to see the event which is triggering this branch.

@osheroff am I misunderstanding the old log message here? I've updated the message to mean what I think the code means, but I thought I'd check...

/cc @zendesk/goanna 