### PR TITLE
bump log4j 2.1 -> 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.1</version>
+      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.1</version>
+      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Allows concise JSON logging (i.e. one log per line)

/cc @zendesk/goanna 