### PR TITLE
PositionStoreThread: only store final position if it has changed

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/PositionStoreThread.java
+++ b/src/main/java/com/zendesk/maxwell/schema/PositionStoreThread.java
@@ -50,12 +50,18 @@ public class PositionStoreThread extends RunLoopProcess implements Runnable {
 	@Override
 	protected void beforeStop() {
 		if ( exception == null ) {
-			LOGGER.info("Storing final position: " + position);
 			try {
-				store.set(position);
+				storeFinalPosition();
 			} catch ( Exception e ) {
 				LOGGER.error("error storing final position: " + e);
 			}
+		}
+	}
+
+	void storeFinalPosition() throws SQLException {
+		if ( position != null && !position.equals(storedPosition) ) {
+			LOGGER.info("Storing final position: " + position);
+			store.set(position);
 		}
 	}
 
@@ -94,8 +100,12 @@ public class PositionStoreThread extends RunLoopProcess implements Runnable {
 	}
 
 	public synchronized void setPosition(BinlogPosition p) {
-		if ( position == null || p.newerThan(position) )
+		if ( position == null || p.newerThan(position) ) {
 			position = p;
+			if (storedPosition == null) {
+				storedPosition = p;
+			}
+		}
 	}
 
 	public synchronized BinlogPosition getPosition() throws SQLException {

--- a/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
+++ b/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
@@ -312,7 +312,7 @@ public class RecoveryTest extends TestWithNameLogging {
 		BinlogPosition oldlogPosition = MaxwellTestSupport.capture(server.getConnection());
 		LOGGER.info("Initial pos: " + oldlogPosition);
 		MaxwellContext context = getContext(server.getPort(), false);
-		context.setPosition(oldlogPosition);
+		context.getPositionStore().set(oldlogPosition);
 		MysqlSavedSchema savedSchema = MysqlSavedSchema.restore(context, oldlogPosition);
 		if (savedSchema == null) {
 			Connection c = context.getMaxwellConnection();

--- a/src/test/java/com/zendesk/maxwell/schema/PositionStoreThreadTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/PositionStoreThreadTest.java
@@ -1,0 +1,45 @@
+package com.zendesk.maxwell.schema;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.MaxwellTestSupport;
+import com.zendesk.maxwell.MaxwellTestWithIsolatedServer;
+import com.zendesk.maxwell.replication.BinlogPosition;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class PositionStoreThreadTest extends MaxwellTestWithIsolatedServer {
+	private MysqlPositionStore buildStore(MaxwellContext context) throws Exception {
+		return new MysqlPositionStore(context.getMaxwellConnectionPool(), context.getServerID(), "maxwell", MaxwellTestSupport.inGtidMode());
+	}
+
+	@Test
+	public void testStoresFinalPosition() throws Exception {
+		MaxwellContext context = buildContext();
+		MysqlPositionStore store = buildStore(context);
+		BinlogPosition initialPosition = new BinlogPosition(4L, "file");
+		BinlogPosition finalPosition = new BinlogPosition(88L, "file");
+		PositionStoreThread thread = new PositionStoreThread(store, context);
+
+		thread.setPosition(initialPosition);
+		thread.setPosition(finalPosition);
+		thread.storeFinalPosition();
+
+		assertThat(store.get(), is(finalPosition));
+	}
+
+	@Test
+	public void testDoesNotStoreUnchangedPosition() throws Exception {
+		MaxwellContext context = buildContext();
+		MysqlPositionStore store = buildStore(context);
+		BinlogPosition initialPosition = new BinlogPosition(4L, "file");
+		PositionStoreThread thread = new PositionStoreThread(store, context);
+
+		thread.setPosition(initialPosition);
+		thread.storeFinalPosition();
+
+		assertThat(store.get(), nullValue());
+	}
+}


### PR DESCRIPTION
When maxwell gets in a crash loop, it keeps storing its final position which is inconvenient if your remediation includes altering or removing that position. Now we only store the position if it's changed, and additionally store a derived initial position as soon as we know it (in `getInitialPosition()`)

/cc @zendesk/goanna 