### PR TITLE
MysqlSchemaStore: track last_heartbeat_read to protect against binlog number reuse

### DIFF
--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -114,7 +114,7 @@ public class Recovery {
 	}
 
 	/**
-	 * fetch a list of binlog postiions representing the start of each binlog file
+	 * fetch a list of binlog positions representing the start of each binlog file
 	 *
 	 * @return a list of binlog positions to attempt recovery at
 	 * */

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -44,7 +44,7 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 		boolean stopOnEOF,
 		String clientID
 	) {
-		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer);
+		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer, start);
 		this.schemaStore = schemaStore;
 
 		this.client = new BinaryLogClient(mysqlConfig.host, mysqlConfig.port, mysqlConfig.user, mysqlConfig.password);

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -49,7 +49,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 		boolean stopOnEOF,
 		String clientID
 	) {
-		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer);
+		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer, start);
 		this.schemaStore = schemaStore;
 		this.binlogEventListener = new BinlogEventListener(queue);
 

--- a/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
@@ -11,11 +11,18 @@ import java.util.ArrayList;
  */
 public class HeartbeatRowMap extends RowMap {
 	public HeartbeatRowMap(String database, BinlogPosition position) {
-		super("heartbeat", database, "heartbeats", position.getHeartbeat(), new ArrayList<String>(), position);
+		super("heartbeat", database, "heartbeats", position.getLastHeartbeat(), new ArrayList<String>(), position);
+		position.requireLastHeartbeat();
 	}
 
 	public static HeartbeatRowMap valueOf(String database, BinlogPosition position, long heartbeatValue) {
-		BinlogPosition p = new BinlogPosition(position.getGtidSetStr(), position.getGtid(), position.getOffset(), position.getFile(), heartbeatValue);
+		BinlogPosition p = new BinlogPosition(
+			position.getGtidSetStr(),
+			position.getGtid(),
+			position.getOffset(),
+			position.getFile(),
+			heartbeatValue
+			);
 		return new HeartbeatRowMap(database, p);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -44,7 +44,7 @@ public class MysqlPositionStore {
 		if ( newPosition == null )
 			return;
 
-		Long heartbeat = newPosition.getHeartbeat();
+		Long heartbeat = newPosition.getLastHeartbeat();
 		String lastHeartbeatSQL = heartbeat == null ? "" : "last_heartbeat_read = " + heartbeat + ", ";
 
 		String sql = "INSERT INTO `positions` set "
@@ -157,7 +157,10 @@ public class MysqlPositionStore {
 
 			String gtid = gtidMode ? rs.getString("gtid_set") : null;
 			return new BinlogPosition(gtid, null,
-				rs.getLong("binlog_position"), rs.getString("binlog_file"), null);
+				rs.getLong("binlog_position"),
+				rs.getString("binlog_file"),
+				rs.getLong("last_heartbeat_read")
+			);
 		}
 	}
 
@@ -200,7 +203,9 @@ public class MysqlPositionStore {
 			Long server_id = rs.getLong("server_id");
 			String gtid = gtidMode ? rs.getString("gtid_set") : null;
 			BinlogPosition position = BinlogPosition.at(gtid,
-				rs.getLong("binlog_position"), rs.getString("binlog_file"));
+				rs.getLong("binlog_position"), rs.getString("binlog_file"),
+				rs.getLong("last_heartbeat_read")
+			);
 			Long last_heartbeat_read = rs.getLong("last_heartbeat_read");
 
 			if ( rs.wasNull() ) {

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -146,6 +146,7 @@ public class SchemaStoreSchema {
 		}
 
 		if ( !getTableColumns("positions", c).containsKey("heartbeat_at") ) {
+			// Note: unused as of 64a6a30074e3509ed9ed102a149bf5ca844f5df5; will be removed in the future
 			performAlter(c, "alter table `positions` add column `heartbeat_at` bigint null default null");
 		}
 
@@ -166,6 +167,11 @@ public class SchemaStoreSchema {
 			LOGGER.info("adding heartbeats table to the maxwell schema.");
 			InputStream is = MysqlSavedSchema.class.getResourceAsStream("/sql/maxwell_schema_heartbeats.sql");
 			executeSQLInputStream(c, is, null);
+		}
+
+		if ( !schemaColumns.containsKey("last_heartbeat_read") ) {
+			// default 0 makes sorting easier (rows before this migration are older than those after)
+			performAlter(c, "alter table `schemas` add column `last_heartbeat_read` bigint null default 0");
 		}
 	}
 

--- a/src/main/resources/sql/maxwell_schema.sql
+++ b/src/main/resources/sql/maxwell_schema.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS `schemas` (
   id int unsigned auto_increment NOT NULL primary key,
   binlog_file varchar(255),
   binlog_position int unsigned,
+  last_heartbeat_read bigint null default 0,
   gtid_set varchar(4096),
   base_schema_id int unsigned NULL default NULL,
   deltas mediumtext charset 'utf8' NULL default NULL,

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -32,7 +32,9 @@ public class MaxwellTestSupport {
 		MysqlIsolatedServer server = new MysqlIsolatedServer();
 		server.boot(extraParams);
 
-		SchemaStoreSchema.ensureMaxwellSchema(server.getConnection(), "maxwell");
+		Connection conn = server.getConnection();
+		SchemaStoreSchema.ensureMaxwellSchema(conn, "maxwell");
+		SchemaStoreSchema.upgradeSchemaStoreSchema(conn);
 		return server;
 	}
 

--- a/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
@@ -33,11 +33,11 @@ public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 		MysqlPositionStore store = buildStore();
 		if (MaxwellTestSupport.inGtidMode()) {
 			String gtid = "123:1-100";
-			store.set(new BinlogPosition(gtid, null, 12345, "foo", null));
-			assertThat(buildStore().get(), is(new BinlogPosition(gtid, null, 12345, "foo", null)));
+			store.set(new BinlogPosition(gtid, null, 12345, "foo", 100L));
+			assertThat(buildStore().get(), is(new BinlogPosition(gtid, null, 12345, "foo", 100L)));
 		} else {
-			store.set(new BinlogPosition(12345, "foo"));
-			assertThat(buildStore().get(), is(new BinlogPosition(12345, "foo")));
+			store.set(new BinlogPosition(12345, "foo", 100L));
+			assertThat(buildStore().get(), is(new BinlogPosition(12345, "foo", 100L)));
 		}
 	}
 

--- a/src/test/java/com/zendesk/maxwell/schema/PositionStoreThreadTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/PositionStoreThreadTest.java
@@ -19,8 +19,8 @@ public class PositionStoreThreadTest extends MaxwellTestWithIsolatedServer {
 	public void testStoresFinalPosition() throws Exception {
 		MaxwellContext context = buildContext();
 		MysqlPositionStore store = buildStore(context);
-		BinlogPosition initialPosition = new BinlogPosition(4L, "file");
-		BinlogPosition finalPosition = new BinlogPosition(88L, "file");
+		BinlogPosition initialPosition = new BinlogPosition(4L, "file", 0L);
+		BinlogPosition finalPosition = new BinlogPosition(88L, "file", 1L);
 		PositionStoreThread thread = new PositionStoreThread(store, context);
 
 		thread.setPosition(initialPosition);
@@ -34,7 +34,7 @@ public class PositionStoreThreadTest extends MaxwellTestWithIsolatedServer {
 	public void testDoesNotStoreUnchangedPosition() throws Exception {
 		MaxwellContext context = buildContext();
 		MysqlPositionStore store = buildStore(context);
-		BinlogPosition initialPosition = new BinlogPosition(4L, "file");
+		BinlogPosition initialPosition = new BinlogPosition(4L, "file", 0L);
 		PositionStoreThread thread = new PositionStoreThread(store, context);
 
 		thread.setPosition(initialPosition);


### PR DESCRIPTION
With the changes in 7b50dfcc0a37081d5e1ebbef37ad7aed531d2e00 to order by binlog position instead of just insertion order, maxwell might treat old schema records as new if the mysql binlog numbering ever goes backwards. This can occur e.g. if a server is rebuilt from backups, keeping the same server_id but resetting its binlog numbering.

By storing the last heartbeat, we can accurately detect the "newest" schema for a given position by sorting by last_heartbeat_read. We still sort by position as a secondary ordering, both for backwards-compatibility step (all existing schemas have a `0` timestamp) and because there could be multiple schemas stored within a single heartbeat interval.

/cc @zendesk/goanna 

### Deployment note (for the changelog):

if you deploy this version and then rollback, future schemas created by an older version of maxwell will receive a default `0` value for `last_heartbeat_read`. Before rolling forward again, you should manually reset _all_ `maxwell.schema` rows to have a `0` `last_heartbeat_read` column so that the schemas created with this version are not considered newer than those created after the rollback.