### PR TITLE
blacklist aurora heartbeat table

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -137,7 +137,7 @@ public class MaxwellFilter {
 	}
 
 	public static boolean isSystemBlacklisted(String databaseName, String tableName) {
-		return "mysql".equals(databaseName) && "ha_health_check".equals(tableName);
+		return "mysql".equals(databaseName) && ("ha_health_check".equals(tableName) || "rds_heartbeat2".equals(tableName));
 	}
 
 	public static boolean matches(MaxwellFilter filter, String database, String table) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -1,10 +1,11 @@
 package com.zendesk.maxwell;
 
-import java.util.*;
-import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
 
-import com.google.code.or.common.glossary.Column;
-import com.google.code.or.common.glossary.Row;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /*
 	filters compile down to:
@@ -137,7 +138,8 @@ public class MaxwellFilter {
 	}
 
 	public static boolean isSystemBlacklisted(String databaseName, String tableName) {
-		return "mysql".equals(databaseName) && ("ha_health_check".equals(tableName) || "rds_heartbeat2".equals(tableName));
+		return "mysql".equals(databaseName) &&
+			("ha_health_check".equals(tableName) || StringUtils.startsWith(tableName, "rds_heartbeat"));
 	}
 
 	public static boolean matches(MaxwellFilter filter, String database, String table) {

--- a/src/main/java/com/zendesk/maxwell/replication/TableCache.java
+++ b/src/main/java/com/zendesk/maxwell/replication/TableCache.java
@@ -26,7 +26,7 @@ public class TableCache {
 				Table tbl = db.findTable(tblName);
 
 				if (tbl == null)
-					throw new RuntimeException("Couldn't find table " + tblName);
+					throw new RuntimeException("Couldn't find table " + tblName + " in database " + dbName);
 				else
 					tableMapCache.put(tableId, tbl);
 			}

--- a/src/main/java/com/zendesk/maxwell/schema/Database.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Database.java
@@ -52,7 +52,7 @@ public class Database {
 	public Table findTableOrThrow(String table) throws InvalidSchemaError {
 		Table t = findTable(table);
 		if ( t == null )
-			throw new InvalidSchemaError("Couldn't find table '" + table + "'" + " in database '" + this.name);
+			throw new InvalidSchemaError("Couldn't find table '" + table + "'" + " in database " + this.name);
 
 		return t;
 	}

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -279,7 +279,9 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	public void testSystemBlacklist() throws Exception  {
 		String sql[] = {
 			"create table mysql.ha_health_check ( id int )",
-			"insert into mysql.ha_health_check set id = 1"
+			"create table mysql.rds_heartbeat2 ( id int )",
+			"insert into mysql.ha_health_check set id = 1",
+			"insert into mysql.rds_heartbeat2 set id = 1"
 		};
 
 		List<RowMap> list = getRowsForSQL(sql);


### PR DESCRIPTION
AWS Aurora db recently emitted some events for table `mysql.rds_heartbeat2` even this table is not listed under database `mysql`, possibly a bug in Aurora?

This is to fix the following runtime exception by blacklist this table:

```
java.lang.RuntimeException: Couldn't find table rds_heartbeat2
 at com.zendesk.maxwell.replication.TableCache.processEvent(TableCache.java:29)
 at com.zendesk.maxwell.replication.BinlogConnectorReplicator.getTransactionRows(BinlogConnectorReplicator.java:158)
 at com.zendesk.maxwell.replication.BinlogConnectorReplicator.getRow(BinlogConnectorReplicator.java:261)
 at com.zendesk.maxwell.replication.AbstractReplicator.work(AbstractReplicator.java:141)
 at com.zendesk.maxwell.util.RunLoopProcess.runLoop(RunLoopProcess.java:30)
 at com.zendesk.maxwell.Maxwell.startInner(Maxwell.java:212)
 at com.zendesk.maxwell.Maxwell.start(Maxwell.java:151)
 at com.zendesk.maxwell.Maxwell.main(Maxwell.java:236)

```
/cc @zendesk/goanna 