### PR TITLE
ignore kafka/kinesis producer errors based on new configuration ignore_producer_error

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -138,7 +138,7 @@ client_id                      | STRING                              | unique te
 replica_server_id              | LONG                                | unique numeric identifier for this maxwell instance | 6379 (see notes)
 master_recovery                | BOOLEAN                             | enable experimental master recovery code            | false
 gtid_mode                      | BOOLEAN                             | enable GTID-based replication                       | false
-ignore_producer_error          | BOOLEAN                             | Maxwell will be terminated on kafka/kinesis errors when set it to false. Otherwise, those producer errors are only logged. | true
+ignore_producer_error          | BOOLEAN                             | Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. | true
 &nbsp;
 replication_host               | STRING                              | mysql host to replicate from.  Only specify if different from `host` (see notes) | *schema-store host*
 replication_password           | STRING                              | password on replication server | (none)

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -138,6 +138,7 @@ client_id                      | STRING                              | unique te
 replica_server_id              | LONG                                | unique numeric identifier for this maxwell instance | 6379 (see notes)
 master_recovery                | BOOLEAN                             | enable experimental master recovery code            | false
 gtid_mode                      | BOOLEAN                             | enable GTID-based replication                       | false
+ignore_producer_error          | BOOLEAN                             | terminate Maxwell on Kafka/Kinesis errors if false  | true
 &nbsp;
 replication_host               | STRING                              | mysql host to replicate from.  Only specify if different from `host` (see notes) | *schema-store host*
 replication_password           | STRING                              | password on replication server | (none)

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -138,7 +138,7 @@ client_id                      | STRING                              | unique te
 replica_server_id              | LONG                                | unique numeric identifier for this maxwell instance | 6379 (see notes)
 master_recovery                | BOOLEAN                             | enable experimental master recovery code            | false
 gtid_mode                      | BOOLEAN                             | enable GTID-based replication                       | false
-ignore_producer_error          | BOOLEAN                             | terminate Maxwell on Kafka/Kinesis errors if false  | true
+ignore_producer_error          | BOOLEAN                             | Maxwell will be terminated on kafka/kinesis errors when set it to false. Otherwise, those producer errors are only logged. | true
 &nbsp;
 replication_host               | STRING                              | mysql host to replicate from.  Only specify if different from `host` (see notes) | *schema-store host*
 replication_password           | STRING                              | password on replication server | (none)

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.7.22</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>2.8.2</version>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -166,7 +166,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "replay", "replay mode, don't store any information to the server").withOptionalArg();
 		parser.accepts( "master_recovery", "(experimental) enable master position recovery code").withOptionalArg();
 		parser.accepts( "gtid_mode", "(experimental) enable gtid mode").withOptionalArg();
-		parser.accepts( "ignore_producer_error", "Maxwell will be terminated on kafka/kinesis errors when set it to false. Otherwise, those producer errors are only logged. Default to true").withOptionalArg();
+		parser.accepts( "ignore_producer_error", "Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. Default to true").withOptionalArg();
 
 		parser.accepts( "__separator_7" );
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -71,6 +71,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public BinlogPosition initPosition;
 	public boolean replayMode;
 	public boolean masterRecovery;
+	public boolean ignoreProducerError;
 
 	public MaxwellConfig() { // argv is only null in tests
 		this.kafkaProperties = new Properties();
@@ -165,6 +166,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "replay", "replay mode, don't store any information to the server").withOptionalArg();
 		parser.accepts( "master_recovery", "(experimental) enable master position recovery code").withOptionalArg();
 		parser.accepts( "gtid_mode", "(experimental) enable gtid mode").withOptionalArg();
+		parser.accepts( "ignore_producer_error", "maxwell is terminated on Kafka/Kinesis errors when set it to false, default to true").withOptionalArg();
 
 		parser.accepts( "__separator_7" );
 
@@ -385,6 +387,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.replayMode =     fetchBooleanOption("replay", options, null, false);
 		this.masterRecovery = fetchBooleanOption("master_recovery", options, properties, false);
+		this.ignoreProducerError = fetchBooleanOption("ignore_producer_error", options, properties, true);
 
 		this.outputConfig = new MaxwellOutputConfig();
 		outputConfig.includesBinlogPosition = fetchBooleanOption("output_binlog_position", options, properties, false);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -166,7 +166,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "replay", "replay mode, don't store any information to the server").withOptionalArg();
 		parser.accepts( "master_recovery", "(experimental) enable master position recovery code").withOptionalArg();
 		parser.accepts( "gtid_mode", "(experimental) enable gtid mode").withOptionalArg();
-		parser.accepts( "ignore_producer_error", "maxwell is terminated on Kafka/Kinesis errors when set it to false, default to true").withOptionalArg();
+		parser.accepts( "ignore_producer_error", "Maxwell will be terminated on kafka/kinesis errors when set it to false. Otherwise, those producer errors are only logged. Default to true").withOptionalArg();
 
 		parser.accepts( "__separator_7" );
 

--- a/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
@@ -1,0 +1,49 @@
+package com.zendesk.maxwell.producer;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
+import com.zendesk.maxwell.MaxwellConfig;
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.replication.BinlogPosition;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.NotEnoughReplicasException;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class KafkaCallbackTest {
+
+	@Test
+	public void shouldIgnoreProducerErrorByDefault() {
+		MaxwellContext context = mock(MaxwellContext.class);
+		MaxwellConfig config = new MaxwellConfig();
+		when(context.getConfig()).thenReturn(config);
+		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
+		KafkaCallback callback = new KafkaCallback(cc,
+			new BinlogPosition(1, "binlog-1"), "key", "value",
+			new Timer(), new Counter(), new Counter(), new Meter(), new Meter(),
+			context);
+		NotEnoughReplicasException error = new NotEnoughReplicasException("blah");
+		callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 1), 1, 1), error);
+		verify(cc).markCompleted();
+	}
+
+	@Test
+	public void shouldTerminateWhenNotIgnoreProuderError() {
+		MaxwellContext context = mock(MaxwellContext.class);
+		MaxwellConfig config = new MaxwellConfig();
+		config.ignoreProducerError = false;
+		when(context.getConfig()).thenReturn(config);
+		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
+		KafkaCallback callback = new KafkaCallback(cc,
+			new BinlogPosition(1, "binlog-1"), "key", "value",
+			new Timer(), new Counter(), new Counter(), new Meter(), new Meter(),
+			context);
+		NotEnoughReplicasException error = new NotEnoughReplicasException("blah");
+		callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 1), 1, 1), error);
+		verify(context).terminate(error);
+		verifyZeroInteractions(cc);
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
@@ -31,7 +31,7 @@ public class KafkaCallbackTest {
 	}
 
 	@Test
-	public void shouldTerminateWhenNotIgnoreProuderError() {
+	public void shouldTerminateWhenNotIgnoreProducerError() {
 		MaxwellContext context = mock(MaxwellContext.class);
 		MaxwellConfig config = new MaxwellConfig();
 		config.ignoreProducerError = false;

--- a/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
@@ -25,7 +25,7 @@ public class KinesisCallbackTest {
 	}
 
 	@Test
-	public void shouldTerminateWhenNotIgnoreProuderError() {
+	public void shouldTerminateWhenNotIgnoreProducerError() {
 		MaxwellContext context = mock(MaxwellContext.class);
 		MaxwellConfig config = new MaxwellConfig();
 		config.ignoreProducerError = false;

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
@@ -1,0 +1,25 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.MaxwellConfig;
+import com.zendesk.maxwell.MaxwellContext;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MaxwellKafkaProducerWorkerTest {
+
+	@Test
+	public void constructNewWorkerWithNullTopic() {
+		MaxwellContext context = mock(MaxwellContext.class);
+		MaxwellConfig config = new MaxwellConfig();
+		when(context.getConfig()).thenReturn(config);
+		Properties kafkaProperties = new Properties();
+		kafkaProperties.put("bootstrap.servers", "localhost:9092");
+		String kafkaTopic = null;
+		//shouldn't throw NPE
+		new MaxwellKafkaProducerWorker(context, kafkaProperties, kafkaTopic, null);
+	}
+}


### PR DESCRIPTION
We Kafka/Kinesis fails to publish the message, we only log the error currently. When setting the new config `ignore_producer_error` to false, it will enable us to shutdown Maxwell and reprocess the message again when Maxwell is running again (hopefully Kafka/Kinesis can publish the message by then).

/cc @timbertson @osheroff 