### PR TITLE
clean restart open replicator on missing heartbeats

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -35,7 +35,10 @@ public class InflightMessageList {
 	/* returns the position that stuff is complete up to, or null if there were no changes */
 	public synchronized BinlogPosition completeMessage(BinlogPosition p) {
 		InflightMessage m = this.linkedMap.get(p.toString());
-		assert(m != null);
+
+		if (m == null) {
+			return null;
+		}
 
 		m.isComplete = true;
 


### PR DESCRIPTION
When we restart open replicator due to missing heartbeats, maxwell could end up with a bad state:
the queue used by `MaxwellReplicator` contains messages with positions later than restarting position of the replicator, so the messages in the queue are out of order, so we cannot group them into clean mysql transactions anymore.

The fix here is to only mark replicator position at the end of transaction so we can restart at the start of the transaction. Also add a parser listener to the replicator so we can clear the queue on restart.

/cc @timbertson @osheroff 