### PR TITLE
move lastHeartbeat out of BinlogPosition and into an explicit Position class

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -195,7 +195,7 @@ metrics_datadog_port | INT | the port to publish metrics to when metrics_datadog
 &nbsp;
 **misc**
 bootstrapper                   | [async &#124; sync &#124; none]                   | bootstrapper type.  See bootstrapping docs.        | async
-init_position                  | FILE:POSITION                       | ignore the information in maxwell.positions and start at the given binlog position. Not available in config.properties. |
+init_position                  | FILE:POSITION:HEARTBEAT             | ignore the information in maxwell.positions and start at the given binlog position. Not available in config.properties. |
 replay                         | BOOLEAN                             | enable maxwell's read-only "replay" mode: don't store a binlog position or schema changes.  Not available in config.properties. |
 
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -13,6 +13,7 @@ import com.zendesk.maxwell.bootstrap.NoOpBootstrapper;
 import com.zendesk.maxwell.bootstrap.SynchronousBootstrapper;
 import com.zendesk.maxwell.producer.*;
 import com.zendesk.maxwell.recovery.RecoveryInfo;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.ReadOnlyMysqlPositionStore;
 import com.zendesk.maxwell.schema.MysqlPositionStore;
@@ -35,7 +36,7 @@ public class MaxwellContext {
 	private MysqlPositionStore positionStore;
 	private PositionStoreThread positionStoreThread;
 	private Long serverID;
-	private BinlogPosition initialPosition;
+	private Position initialPosition;
 	private CaseSensitivity caseSensitivity;
 	private AbstractProducer producer;
 	private TaskManager taskManager;
@@ -148,7 +149,7 @@ public class MaxwellContext {
 	}
 
 
-	public BinlogPosition getInitialPosition() throws SQLException {
+	public Position getInitialPosition() throws SQLException {
 		if ( this.initialPosition != null )
 			return this.initialPosition;
 
@@ -160,16 +161,16 @@ public class MaxwellContext {
 		return this.positionStore.getRecoveryInfo(config);
 	}
 
-	public void setPosition(RowMap r) throws SQLException {
+	public void setPosition(RowMap r) {
 		if ( r.isTXCommit() )
 			this.setPosition(r.getPosition());
 	}
 
-	public void setPosition(BinlogPosition position) {
+	public void setPosition(Position position) {
 		this.getPositionStoreThread().setPosition(position);
 	}
 
-	public BinlogPosition getPosition() throws SQLException {
+	public Position getPosition() throws SQLException {
 		return this.getPositionStoreThread().getPosition();
 	}
 
@@ -204,7 +205,8 @@ public class MaxwellContext {
 
 	public boolean shouldHeartbeat() throws SQLException {
 		fetchMysqlVersion();
-		return mysqlMajorVersion >= 5 && mysqlMinorVersion >= 5;
+		// 5.5 and above
+		return (mysqlMajorVersion >= 6) || (mysqlMajorVersion == 5 && mysqlMinorVersion >= 5);
 	}
 
 	public CaseSensitivity getCaseSensitivity() throws SQLException {

--- a/src/main/java/com/zendesk/maxwell/bootstrap/AsynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/AsynchronousBootstrapper.java
@@ -132,7 +132,7 @@ public class AsynchronousBootstrapper extends AbstractBootstrapper {
 		skippedRows.flushToDisk(databaseName, tableName);
 		while ( skippedRows.size(databaseName, tableName) > 0 ) {
 			RowMap row = skippedRows.removeFirst(databaseName, tableName);
-			if ( bootstrapStartBinlogPosition == null || row.getPosition().newerThan(bootstrapStartBinlogPosition) )
+			if ( bootstrapStartBinlogPosition == null || row.getPosition().getBinlogPosition().newerThan(bootstrapStartBinlogPosition) )
 				producer.push(row);
 		}
 		LOGGER.info("async bootstrapping: replay complete");

--- a/src/main/java/com/zendesk/maxwell/producer/BufferedProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/BufferedProducer.java
@@ -26,7 +26,7 @@ public class BufferedProducer extends AbstractProducer {
 	public RowMap poll(long timeout, TimeUnit unit) throws InterruptedException {
 		RowMap r = this.queue.poll(timeout, unit);
 		if (r != null) {
-			this.context.setPosition(r.getPosition());
+			this.context.setPosition(r);
 		}
 		return r;
 	}

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -7,39 +7,40 @@ package com.zendesk.maxwell.producer;
    */
 
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 
 import java.util.LinkedHashMap;
 import java.util.Iterator;
 
 public class InflightMessageList {
 	class InflightMessage {
-		public final BinlogPosition position;
+		public final Position position;
 		public boolean isComplete;
-		InflightMessage(BinlogPosition position) {
-			this.position = position;
+		InflightMessage(Position p) {
+			this.position = p;
 			this.isComplete = false;
 		}
 	}
 
-	private LinkedHashMap<String, InflightMessage> linkedMap;
+	private LinkedHashMap<Position, InflightMessage> linkedMap;
 
 	public InflightMessageList() {
 		this.linkedMap = new LinkedHashMap<>();
 	}
 
-	public synchronized void addMessage(BinlogPosition p) {
+	public synchronized void addMessage(Position p) {
 		InflightMessage m = new InflightMessage(p);
-		this.linkedMap.put(p.toString(), m);
+		this.linkedMap.put(p, m);
 	}
 
 	/* returns the position that stuff is complete up to, or null if there were no changes */
-	public synchronized BinlogPosition completeMessage(BinlogPosition p) {
-		InflightMessage m = this.linkedMap.get(p.toString());
+	public synchronized Position completeMessage(Position p) {
+		InflightMessage m = this.linkedMap.get(p);
 		assert(m != null);
 
 		m.isComplete = true;
 
-		BinlogPosition completeUntil = null;
+		Position completeUntil = null;
 		Iterator<InflightMessage> iterator = this.linkedMap.values().iterator();
 
 		while ( iterator.hasNext() ) {

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -8,6 +8,7 @@ import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.metrics.MaxwellMetrics;
 import com.zendesk.maxwell.producer.partitioners.MaxwellKafkaPartitioner;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMap.KeyFormat;
 import com.zendesk.maxwell.schema.ddl.DDLMap;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeoutException;
 class KafkaCallback implements Callback {
 	public static final Logger LOGGER = LoggerFactory.getLogger(MaxwellKafkaProducer.class);
 	private final AbstractAsyncProducer.CallbackCompleter cc;
-	private final BinlogPosition position;
+	private final Position position;
 	private final String json;
 	private final String key;
 	private final Timer timer;
@@ -43,9 +44,9 @@ class KafkaCallback implements Callback {
 	private Meter succeededMessageMeter;
 	private Meter failedMessageMeter;
 
-	public KafkaCallback(AbstractAsyncProducer.CallbackCompleter cc, BinlogPosition position, String key, String json,
-						 Timer timer, Counter producedMessageCount, Counter failedMessageCount, Meter producedMessageMeter,
-						Meter failedMessageMeter, MaxwellContext context) {
+	public KafkaCallback(AbstractAsyncProducer.CallbackCompleter cc, Position position, String key, String json,
+	                     Timer timer, Counter producedMessageCount, Counter failedMessageCount, Meter producedMessageMeter,
+	                     Meter failedMessageMeter, MaxwellContext context) {
 		this.cc = cc;
 		this.position = position;
 		this.key = key;

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -13,6 +13,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.partitioners.MaxwellKinesisPartitioner;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 
 import com.amazonaws.services.kinesis.producer.Attempt;
@@ -28,12 +29,12 @@ class KinesisCallback implements FutureCallback<UserRecordResult> {
 	public static final Logger logger = LoggerFactory.getLogger(KinesisCallback.class);
 
 	private final AbstractAsyncProducer.CallbackCompleter cc;
-	private final BinlogPosition position;
+	private final Position position;
 	private final String json;
 	private MaxwellContext context;
 	private final String key;
 
-	public KinesisCallback(AbstractAsyncProducer.CallbackCompleter cc, BinlogPosition position, String key, String json, MaxwellContext context) {
+	public KinesisCallback(AbstractAsyncProducer.CallbackCompleter cc, Position position, String key, String json, MaxwellContext context) {
 		this.cc = cc;
 		this.position = position;
 		this.key = key;

--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -4,7 +4,9 @@ import com.zendesk.maxwell.*;
 import com.zendesk.maxwell.replication.BinlogConnectorReplicator;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.MaxwellReplicator;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.replication.Replicator;
+import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +16,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import snaq.db.ConnectionPool;
 
@@ -42,22 +43,21 @@ public class Recovery {
 		this.shykoMode = shykoMode;
 	}
 
-	public BinlogPosition recover() throws Exception {
+	public Position recover() throws Exception {
 		String recoveryMsg = String.format(
-			"old-server-id: %d, file: %s, position: %d, heartbeat: %d",
+			"old-server-id: %d, position: %s",
 			recoveryInfo.serverID,
-			recoveryInfo.position.getFile(),
-			recoveryInfo.position.getOffset(),
-			recoveryInfo.heartbeat
+			recoveryInfo.position
 		);
 
 		LOGGER.warn("attempting to recover from master-change: " + recoveryMsg);
 
 		List<BinlogPosition> list = getBinlogInfo();
 		for ( int i = list.size() - 1; i >= 0 ; i-- ) {
-			BinlogPosition position = list.get(i);
+			BinlogPosition binlogPosition = list.get(i);
+			Position position = recoveryInfo.position.withBinlogPosition(binlogPosition);
 
-			LOGGER.debug("scanning binlog: " + position);
+			LOGGER.debug("scanning binlog: " + binlogPosition);
 			Replicator replicator;
 			if ( shykoMode ) {
 				replicator = new BinlogConnectorReplicator(
@@ -88,7 +88,7 @@ public class Recovery {
 
 			replicator.setFilter(new RecoveryFilter(this.maxwellDatabaseName));
 
-			BinlogPosition p = findHeartbeat(replicator);
+			Position p = findHeartbeat(replicator);
 			if ( p != null ) {
 				LOGGER.warn("recovered new master position: " + p);
 				return p;
@@ -103,12 +103,16 @@ public class Recovery {
 	 * try to find a given heartbeat value from the replicator.
 	 * @return A BinlogPosition where the heartbeat was found, or null if none was found.
 	 */
-	private BinlogPosition findHeartbeat(Replicator r) throws Exception {
+	private Position findHeartbeat(Replicator r) throws Exception {
 		r.startReplicator();
 		for (RowMap row = r.getRow(); row != null ; row = r.getRow()) {
-			if (Objects.equals(r.getLastHeartbeatRead(), recoveryInfo.heartbeat))
-				return row.getPosition();
-
+			if (!(row instanceof HeartbeatRowMap)) {
+				continue;
+			}
+			HeartbeatRowMap heartbeatRow = (HeartbeatRowMap) row;
+			Position heartbeatPosition = heartbeatRow.getPosition();
+			if (heartbeatPosition.getLastHeartbeatRead() == recoveryInfo.getHeartbeat())
+				return heartbeatPosition;
 		}
 		return null;
 	}

--- a/src/main/java/com/zendesk/maxwell/recovery/RecoveryInfo.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/RecoveryInfo.java
@@ -1,24 +1,25 @@
 package com.zendesk.maxwell.recovery;
 
-import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 
 public class RecoveryInfo {
-	public BinlogPosition position;
-	public Long heartbeat;
+	public Position position;
 	public Long serverID;
 	public String clientID;
 
-	public RecoveryInfo(BinlogPosition position, Long heartbeat, Long serverID, String clientID) {
+	public RecoveryInfo(Position position, Long serverID, String clientID) {
 		this.position = position;
-		this.heartbeat = heartbeat;
 		this.serverID = serverID;
 		this.clientID = clientID;
+	}
+
+	public long getHeartbeat() {
+		return position.getLastHeartbeatRead();
 	}
 
 	public String toString() {
 		return "<RecoveryInfo" +
 				" position: " + position +
-				", heartbeat: " + heartbeat +
 				", serverId: " + serverID +
 				", clientId: " + clientID +
 				">";

--- a/src/main/java/com/zendesk/maxwell/recovery/RecoverySchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/RecoverySchemaStore.java
@@ -1,7 +1,7 @@
 package com.zendesk.maxwell.recovery;
 
-import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.CaseSensitivity;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.schema.*;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
@@ -48,7 +48,7 @@ public class RecoverySchemaStore implements SchemaStore {
 	}
 
 	@Override
-	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
+	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Position position) throws SchemaStoreException, InvalidSchemaError {
 		return new ArrayList<>();
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractRowsEvent.java
@@ -1,7 +1,6 @@
 package com.zendesk.maxwell.replication;
 
 import java.util.*;
-import java.util.regex.Pattern;
 
 import com.google.code.or.binlog.BinlogEventV4Header;
 import com.google.code.or.binlog.impl.event.AbstractRowEvent;
@@ -25,20 +24,20 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractRowsEvent extends AbstractRowEvent {
 	static final Logger LOGGER = LoggerFactory.getLogger(AbstractRowsEvent.class);
 	private final AbstractRowEvent event;
-	private final Long heartbeat;
 
 	protected final Table table;
 	protected final String database;
 	protected final MaxwellFilter filter;
+	private final long lastHeartbeatRead;
 
-	public AbstractRowsEvent(AbstractRowEvent e, Table table, MaxwellFilter f, Long heartbeat) {
+	public AbstractRowsEvent(AbstractRowEvent e, Table table, MaxwellFilter f, long lastHeartbeat) {
 		this.tableId = e.getTableId();
 		this.event = e;
 		this.header = e.getHeader();
 		this.table = table;
 		this.database = table.getDatabase();
 		this.filter = f;
-		this.heartbeat = heartbeat;
+		this.lastHeartbeatRead = lastHeartbeat;
 	}
 
 	@Override
@@ -59,8 +58,8 @@ public abstract class AbstractRowsEvent extends AbstractRowEvent {
 		return event.getBinlogFilename();
 	}
 
-	public BinlogPosition getNextBinlogPosition() {
-		return new BinlogPosition(getHeader().getNextPosition(), getBinlogFilename(), heartbeat);
+	public Position getNextPosition() {
+		return new Position(new BinlogPosition(getHeader().getNextPosition(), getBinlogFilename()), lastHeartbeatRead);
 	}
 
 	@Override
@@ -154,7 +153,7 @@ public abstract class AbstractRowsEvent extends AbstractRowEvent {
 				getTable().getName(),
 				getHeader().getTimestamp() / 1000,
 				table.getPKList(),
-				this.getNextBinlogPosition());
+				this.getNextPosition());
 	}
 
 	public List<RowMap> jsonMaps() {

--- a/src/main/java/com/zendesk/maxwell/replication/DeleteRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/DeleteRowsEvent.java
@@ -12,13 +12,13 @@ import com.zendesk.maxwell.schema.Table;
 public class DeleteRowsEvent extends AbstractRowsEvent {
 	private final com.google.code.or.binlog.impl.event.DeleteRowsEvent event;
 
-	public DeleteRowsEvent(com.google.code.or.binlog.impl.event.DeleteRowsEvent e, Table table, MaxwellFilter f, Long heartbeat) {
-		super(e, table, f, heartbeat);
+	public DeleteRowsEvent(com.google.code.or.binlog.impl.event.DeleteRowsEvent e, Table table, MaxwellFilter f, long lastHeartbeat) {
+		super(e, table, f, lastHeartbeat);
 		this.event = e;
 	}
 
-	public DeleteRowsEvent(DeleteRowsEventV2 e2, Table table, MaxwellFilter filter, Long heartbeat) {
-		super(e2, table, filter, heartbeat);
+	public DeleteRowsEvent(DeleteRowsEventV2 e2, Table table, MaxwellFilter filter, long lastHeartbeat) {
+		super(e2, table, filter, lastHeartbeat);
 
 		com.google.code.or.binlog.impl.event.DeleteRowsEvent e =  new com.google.code.or.binlog.impl.event.DeleteRowsEvent(e2.getHeader());
 

--- a/src/main/java/com/zendesk/maxwell/replication/Position.java
+++ b/src/main/java/com/zendesk/maxwell/replication/Position.java
@@ -1,0 +1,64 @@
+package com.zendesk.maxwell.replication;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class Position implements Serializable {
+	// LastHeartbeat is the most recent heartbeat seen prior to this position.
+	// For a HeartbeatRow, it is the exact (new) heartbeat value for this position.
+	private final long lastHeartbeatRead;
+	private final BinlogPosition binlogPosition;
+
+	public Position(BinlogPosition binlogPosition, long lastHeartbeatRead) {
+		this.binlogPosition = binlogPosition;
+		this.lastHeartbeatRead = lastHeartbeatRead;
+	}
+
+	public Position withBinlogPosition(BinlogPosition position) {
+		return new Position(position, getLastHeartbeatRead());
+	}
+
+	public Position withHeartbeat(long lastHeartbeatRead) {
+		return new Position(getBinlogPosition(), lastHeartbeatRead);
+	}
+
+	public static Position capture(Connection c, boolean gtidMode) throws SQLException {
+		return new Position(BinlogPosition.capture(c, gtidMode), 0L);
+	}
+
+	public long getLastHeartbeatRead() {
+		return lastHeartbeatRead;
+	}
+
+	public BinlogPosition getBinlogPosition() {
+		return binlogPosition;
+	}
+
+	@Override
+	public String toString() {
+		return "Position[" + binlogPosition + ", lastHeartbeat=" + lastHeartbeatRead + "]";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( !(o instanceof Position) ) {
+			return false;
+		}
+		Position other = (Position) o;
+
+		return lastHeartbeatRead == other.lastHeartbeatRead
+			&& binlogPosition.equals(other.binlogPosition);
+	}
+
+	@Override
+	public int hashCode() {
+		return binlogPosition.hashCode();
+	}
+
+	public boolean newerThan(Position other) {
+		if ( other == null )
+			return true;
+		return this.getBinlogPosition().newerThan(other.getBinlogPosition());
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/replication/UpdateRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/UpdateRowsEvent.java
@@ -17,13 +17,13 @@ import java.util.Objects;
 public class UpdateRowsEvent extends AbstractRowsEvent {
 	private final com.google.code.or.binlog.impl.event.UpdateRowsEvent event;
 
-	public UpdateRowsEvent(com.google.code.or.binlog.impl.event.UpdateRowsEvent e, Table t, MaxwellFilter f, Long heartbeat) {
-		super(e, t, f, heartbeat);
+	public UpdateRowsEvent(com.google.code.or.binlog.impl.event.UpdateRowsEvent e, Table t, MaxwellFilter f, long lastHeartbeat) {
+		super(e, t, f, lastHeartbeat);
 		this.event = e;
 	}
 
-	public UpdateRowsEvent(UpdateRowsEventV2 e2, Table table, MaxwellFilter filter, Long heartbeat) {
-		super(e2, table, filter, heartbeat);
+	public UpdateRowsEvent(UpdateRowsEventV2 e2, Table table, MaxwellFilter filter, long lastHeartbeat) {
+		super(e2, table, filter, lastHeartbeat);
 		com.google.code.or.binlog.impl.event.UpdateRowsEvent e =  new com.google.code.or.binlog.impl.event.UpdateRowsEvent(e2.getHeader());
 
 		e.setBinlogFilename(e2.getBinlogFilename());

--- a/src/main/java/com/zendesk/maxwell/replication/WriteRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/WriteRowsEvent.java
@@ -17,13 +17,13 @@ public class WriteRowsEvent extends AbstractRowsEvent {
 		return event.getRows();
 	}
 
-	public WriteRowsEvent(com.google.code.or.binlog.impl.event.WriteRowsEvent e, Table t, MaxwellFilter f, Long heartbeat) {
-		super(e, t, f, heartbeat);
+	public WriteRowsEvent(com.google.code.or.binlog.impl.event.WriteRowsEvent e, Table t, MaxwellFilter f, long lastHeartbeat) {
+		super(e, t, f, lastHeartbeat);
 		this.event = e;
 	}
 
-	public WriteRowsEvent(WriteRowsEventV2 e2, Table table, MaxwellFilter filter, Long heartbeat) {
-		super(e2, table, filter, heartbeat);
+	public WriteRowsEvent(WriteRowsEventV2 e2, Table table, MaxwellFilter filter, long lastHeartbeat) {
+		super(e2, table, filter, lastHeartbeat);
 		com.google.code.or.binlog.impl.event.WriteRowsEvent e =  new com.google.code.or.binlog.impl.event.WriteRowsEvent(e2.getHeader());
 
 		e.setBinlogFilename(e2.getBinlogFilename());

--- a/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/HeartbeatRowMap.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell.row;
 
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -10,20 +11,12 @@ import java.util.ArrayList;
  * Created by ben on 9/7/16.
  */
 public class HeartbeatRowMap extends RowMap {
-	public HeartbeatRowMap(String database, BinlogPosition position) {
-		super("heartbeat", database, "heartbeats", position.getLastHeartbeat(), new ArrayList<String>(), position);
-		position.requireLastHeartbeat();
+	public HeartbeatRowMap(String database, Position position) {
+		super("heartbeat", database, "heartbeats", position.getLastHeartbeatRead(), new ArrayList<String>(), position);
 	}
 
-	public static HeartbeatRowMap valueOf(String database, BinlogPosition position, long heartbeatValue) {
-		BinlogPosition p = new BinlogPosition(
-			position.getGtidSetStr(),
-			position.getGtid(),
-			position.getOffset(),
-			position.getFile(),
-			heartbeatValue
-			);
-		return new HeartbeatRowMap(database, p);
+	public static HeartbeatRowMap valueOf(String database, Position position) {
+		return new HeartbeatRowMap(database, position);
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell.row;
 import com.fasterxml.jackson.core.*;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+import com.zendesk.maxwell.replication.Position;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +28,7 @@ public class RowMap implements Serializable {
 	private final String database;
 	private final String table;
 	private final Long timestamp;
-	private BinlogPosition nextPosition;
+	private Position nextPosition;
 
 	private Long xid;
 	private boolean txCommit;
@@ -67,7 +68,7 @@ public class RowMap implements Serializable {
 			};
 
 	public RowMap(String type, String database, String table, Long timestamp, List<String> pkColumns,
-			BinlogPosition nextPosition) {
+			Position nextPosition) {
 		this.rowType = type;
 		this.database = database;
 		this.table = table;
@@ -229,11 +230,12 @@ public class RowMap implements Serializable {
 				g.writeBooleanField("commit", true);
 		}
 
+		BinlogPosition binlogPosition = this.nextPosition.getBinlogPosition();
 		if ( outputConfig.includesBinlogPosition )
-			g.writeStringField("position", this.nextPosition.getFile() + ":" + this.nextPosition.getOffset());
+			g.writeStringField("position", binlogPosition.getFile() + ":" + binlogPosition.getOffset());
 
 		if ( outputConfig.includesGtidPosition)
-			g.writeStringField("gtid", this.nextPosition.getGtid());
+			g.writeStringField("gtid", binlogPosition.getGtid());
 
 		if ( outputConfig.includesServerId && this.serverId != null ) {
 			g.writeNumberField("server_id", this.serverId);
@@ -317,7 +319,7 @@ public class RowMap implements Serializable {
 		this.approximateSize += approximateKVSize(key, value);
 	}
 
-	public BinlogPosition getPosition() {
+	public Position getPosition() {
 		return nextPosition;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -4,6 +4,7 @@ import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.MaxwellFilter;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 import snaq.db.ConnectionPool;
@@ -17,7 +18,7 @@ import static com.zendesk.maxwell.schema.MysqlSavedSchema.restore;
 
 public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore {
 	private final ConnectionPool maxwellConnectionPool;
-	private final BinlogPosition initialPosition;
+	private final Position initialPosition;
 	private final boolean readOnly;
 	private final MaxwellFilter filter;
 	private Long serverID;
@@ -28,7 +29,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 							ConnectionPool replicationConnectionPool,
 							ConnectionPool schemaConnectionPool,
 							Long serverID,
-							BinlogPosition initialPosition,
+							Position initialPosition,
 							CaseSensitivity caseSensitivity,
 							MaxwellFilter filter,
 							boolean readOnly) {
@@ -40,7 +41,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 		this.readOnly = readOnly;
 	}
 
-	public MysqlSchemaStore(MaxwellContext context, BinlogPosition initialPosition) throws SQLException {
+	public MysqlSchemaStore(MaxwellContext context, Position initialPosition) throws SQLException {
 		this(
 			context.getMaxwellConnectionPool(),
 			context.getReplicationConnectionPool(),
@@ -87,7 +88,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 	}
 
 
-	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError {
+	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Position position) throws SchemaStoreException, InvalidSchemaError {
 		List<ResolvedSchemaChange> resolvedSchemaChanges = resolveSQL(getSchema(), sql, currentDatabase);
 
 		if ( resolvedSchemaChanges.size() > 0 ) {
@@ -101,7 +102,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 		return resolvedSchemaChanges;
 	}
 
-	private Long saveSchema(Schema updatedSchema, List<ResolvedSchemaChange> changes, BinlogPosition p) throws SQLException {
+	private Long saveSchema(Schema updatedSchema, List<ResolvedSchemaChange> changes, Position p) throws SQLException {
 		if ( readOnly )
 			return null;
 
@@ -111,7 +112,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 		}
 	}
 
-	public void clone(Long serverID, BinlogPosition position) throws SchemaStoreException {
+	public void clone(Long serverID, Position position) throws SchemaStoreException {
 		List<ResolvedSchemaChange> empty = Collections.emptyList();
 
 		try (Connection c = maxwellConnectionPool.getConnection()) {

--- a/src/main/java/com/zendesk/maxwell/schema/ReadOnlyMysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ReadOnlyMysqlPositionStore.java
@@ -1,6 +1,6 @@
 package com.zendesk.maxwell.schema;
 
-import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import snaq.db.ConnectionPool;
 
 /**
@@ -13,7 +13,7 @@ public class ReadOnlyMysqlPositionStore extends MysqlPositionStore {
 	}
 
 	@Override
-	public void set(BinlogPosition p) { }
+	public void set(Position p) { }
 
 	@Override
 	public void heartbeat() throws Exception { }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -1,6 +1,6 @@
 package com.zendesk.maxwell.schema;
 
-import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 import com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange;
 
@@ -26,5 +26,5 @@ public interface SchemaStore {
 	 * @param position The position of the DDL statement
 	 * @return A list of the schema changes parsed from the SQL.
 	 */
-	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, BinlogPosition position) throws SchemaStoreException, InvalidSchemaError;
+	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Position position) throws SchemaStoreException, InvalidSchemaError;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -14,6 +14,8 @@ import java.io.InputStreamReader;
 import java.io.BufferedReader;
 import java.io.IOException;
 
+import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
@@ -179,7 +181,11 @@ public class SchemaStoreSchema {
 		ResultSet rs = c.createStatement().executeQuery("select * from `schemas`");
 		while (rs.next()) {
 			Long id = rs.getLong("id");
-			String sha = MysqlSavedSchema.getSchemaPositionSHA(rs.getLong("server_id"), rs.getString("binlog_file"), rs.getLong("binlog_position"));
+			Position position = new Position(
+				new BinlogPosition(rs.getLong("binlog_position"), rs.getString("binlog_file")),
+				rs.getLong("last_heartbeat_read")
+			);
+			String sha = MysqlSavedSchema.getSchemaPositionSHA(rs.getLong("server_id"), position);
 			c.createStatement().executeUpdate("update `schemas` set `position_sha` = '" + sha + "' where id = " + id);
 		}
 		rs.close();

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DDLMap.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DDLMap.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 
 import java.io.IOException;
@@ -15,9 +16,9 @@ public class DDLMap extends RowMap {
 	private final ResolvedSchemaChange change;
 	private final Long timestamp;
 	private final String sql;
-	private BinlogPosition nextPosition;
+	private Position nextPosition;
 
-	public DDLMap(ResolvedSchemaChange change, Long timestamp, String sql, BinlogPosition nextPosition) {
+	public DDLMap(ResolvedSchemaChange change, Long timestamp, String sql, Position nextPosition) {
 		super("ddl", "database", "table", timestamp, new ArrayList<String>(0), nextPosition);
 		this.change = change;
 		this.timestamp = timestamp;
@@ -48,11 +49,12 @@ public class DDLMap extends RowMap {
 		Map<String, Object> changeMixin = mapper.convertValue(change, new TypeReference<Map<String, Object>>() { });
 		changeMixin.put("ts", timestamp);
 		changeMixin.put("sql", sql);
+		BinlogPosition binlogPosition = nextPosition.getBinlogPosition();
 		if ( outputConfig.includesBinlogPosition ) {
-			changeMixin.put("position", this.nextPosition.getFile() + ":" + this.nextPosition.getOffset());
+			changeMixin.put("position", binlogPosition.getFile() + ":" + binlogPosition.getOffset());
 		}
 		if ( outputConfig.includesGtidPosition) {
-			changeMixin.put("gtid", this.nextPosition.getGtid());
+			changeMixin.put("gtid", binlogPosition.getGtid());
 		}
 		return mapper.writeValueAsString(changeMixin);
 	}

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaCapturer;
@@ -93,7 +94,7 @@ public class MaxwellTestSupport {
 	}
 
 
-	public static MaxwellContext buildContext(int port, BinlogPosition p, MaxwellFilter filter) throws SQLException {
+	public static MaxwellContext buildContext(int port, Position p, MaxwellFilter filter) throws SQLException {
 		MaxwellConfig config = new MaxwellConfig();
 
 		config.replicationMysql.host = "127.0.0.1";
@@ -141,8 +142,8 @@ public class MaxwellTestSupport {
 		return System.getenv(MaxwellConfig.GTID_MODE_ENV) != null;
 	}
 
-	public static BinlogPosition capture(Connection c) throws SQLException {
-		return BinlogPosition.capture(c, inGtidMode());
+	public static Position capture(Connection c) throws SQLException {
+		return Position.capture(c, inGtidMode());
 	}
 
 	public static List<RowMap> getRowsWithReplicator(final MysqlIsolatedServer mysql, MaxwellFilter filter, MaxwellTestSupportCallback callback, MaxwellOutputConfig outputConfig) throws Exception {
@@ -192,11 +193,11 @@ public class MaxwellTestSupport {
 		callback.afterReplicatorStart(mysql);
 		maxwell.context.getPositionStore().heartbeat();
 
-		BinlogPosition finalPosition = capture(mysql.getConnection());
+		Position finalPosition = capture(mysql.getConnection());
 		LOGGER.debug("running replicator up to " + finalPosition);
 
 		Long pollTime = 2000L;
-		BinlogPosition lastPositionRead = null;
+		Position lastPositionRead = null;
 
 		for ( ;; ) {
 			RowMap row = maxwell.poll(pollTime);

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import org.junit.*;
 
@@ -75,7 +76,7 @@ public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 		return MaxwellTestSupport.buildContext(server.getPort(), null, null);
 	}
 
-	protected MaxwellContext buildContext(BinlogPosition p) throws Exception {
+	protected MaxwellContext buildContext(Position p) throws Exception {
 		return MaxwellTestSupport.buildContext(server.getPort(), p, null);
 	}
 

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.producer;
 
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -10,9 +11,9 @@ import static org.junit.Assert.*;
  * Created by ben on 5/25/16.
  */
 public class InflightMessageListTest {
-	static BinlogPosition p1 = BinlogPosition.at(1, "f");
-	static BinlogPosition p2 = BinlogPosition.at(2, "f");
-	static BinlogPosition p3 = BinlogPosition.at(3, "f");
+	static Position p1 = new Position(BinlogPosition.at(1, "f"), 0L);
+	static Position p2 = new Position(BinlogPosition.at(2, "f"), 0L);
+	static Position p3 = new Position(BinlogPosition.at(3, "f"), 0L);
 	InflightMessageList list;
 
 	@Before
@@ -25,7 +26,7 @@ public class InflightMessageListTest {
 
 	@Test
 	public void testInOrderCompletion() {
-		BinlogPosition ret;
+		Position ret;
 
 
 		ret = list.completeMessage(p1);
@@ -42,7 +43,7 @@ public class InflightMessageListTest {
 
 	@Test
 	public void testOutOfOrderComplete() {
-		BinlogPosition ret;
+		Position ret;
 
 		ret = list.completeMessage(p3);
 		assert(ret == null);

--- a/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.Timer;
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
@@ -22,7 +23,7 @@ public class KafkaCallbackTest {
 		when(context.getConfig()).thenReturn(config);
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
 		KafkaCallback callback = new KafkaCallback(cc,
-			new BinlogPosition(1, "binlog-1"), "key", "value",
+			new Position(new BinlogPosition(1, "binlog-1"), 0L), "key", "value",
 			new Timer(), new Counter(), new Counter(), new Meter(), new Meter(),
 			context);
 		NotEnoughReplicasException error = new NotEnoughReplicasException("blah");
@@ -38,7 +39,7 @@ public class KafkaCallbackTest {
 		when(context.getConfig()).thenReturn(config);
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
 		KafkaCallback callback = new KafkaCallback(cc,
-			new BinlogPosition(1, "binlog-1"), "key", "value",
+			new Position(new BinlogPosition(1, "binlog-1"), 0L), "key", "value",
 			new Timer(), new Counter(), new Counter(), new Meter(), new Meter(),
 			context);
 		NotEnoughReplicasException error = new NotEnoughReplicasException("blah");

--- a/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.kinesis.producer.IrrecoverableError;
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import org.junit.Test;
 
 import static org.mockito.Mockito.*;
@@ -17,7 +18,7 @@ public class KinesisCallbackTest {
 		when(context.getConfig()).thenReturn(config);
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
 		KinesisCallback callback = new KinesisCallback(cc,
-			new BinlogPosition(1, "binlog-1"), "key", "value",
+			new Position(new BinlogPosition(1, "binlog-1"), 0L), "key", "value",
 			context);
 		IrrecoverableError error = new IrrecoverableError("blah");
 		callback.onFailure(error);
@@ -32,7 +33,7 @@ public class KinesisCallbackTest {
 		when(context.getConfig()).thenReturn(config);
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
 		KinesisCallback callback = new KinesisCallback(cc,
-			new BinlogPosition(1, "binlog-1"), "key", "value",
+			new Position(new BinlogPosition(1, "binlog-1"), 0L), "key", "value",
 			context);
 		IrrecoverableError error = new IrrecoverableError("blah");
 		callback.onFailure(error);

--- a/src/test/java/com/zendesk/maxwell/row/RowMapBufferTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapBufferTest.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell.row;
 
 import com.zendesk.maxwell.TestWithNameLogging;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -15,9 +16,9 @@ public class RowMapBufferTest extends TestWithNameLogging {
 		RowMapBuffer buffer = new RowMapBuffer(2, 250); // allow about 250 bytes of memory to be used
 
 		RowMap r;
-		buffer.add(new RowMap("insert", "foo", "bar", 1L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));
-		buffer.add(new RowMap("insert", "foo", "bar", 2L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));
-		buffer.add(new RowMap("insert", "foo", "bar", 3L, new ArrayList<String>(), new BinlogPosition(3, "mysql.1")));
+		buffer.add(new RowMap("insert", "foo", "bar", 1L, new ArrayList<String>(), new Position(new BinlogPosition(3, "mysql.1"), 0L)));
+		buffer.add(new RowMap("insert", "foo", "bar", 2L, new ArrayList<String>(), new Position(new BinlogPosition(3, "mysql.1"), 0L)));
+		buffer.add(new RowMap("insert", "foo", "bar", 3L, new ArrayList<String>(), new Position(new BinlogPosition(3, "mysql.1"), 0L)));
 
 		assertThat(buffer.size(), is(3L));
 		assertThat(buffer.inMemorySize(), is(2L));

--- a/src/test/java/com/zendesk/maxwell/schema/PositionStoreThreadTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/PositionStoreThreadTest.java
@@ -4,6 +4,7 @@ import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.MaxwellTestSupport;
 import com.zendesk.maxwell.MaxwellTestWithIsolatedServer;
 import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -19,8 +20,8 @@ public class PositionStoreThreadTest extends MaxwellTestWithIsolatedServer {
 	public void testStoresFinalPosition() throws Exception {
 		MaxwellContext context = buildContext();
 		MysqlPositionStore store = buildStore(context);
-		BinlogPosition initialPosition = new BinlogPosition(4L, "file", 0L);
-		BinlogPosition finalPosition = new BinlogPosition(88L, "file", 1L);
+		Position initialPosition = new Position(new BinlogPosition(4L, "file"), 0L);
+		Position finalPosition = new Position(new BinlogPosition(88L, "file"), 1L);
 		PositionStoreThread thread = new PositionStoreThread(store, context);
 
 		thread.setPosition(initialPosition);
@@ -34,7 +35,7 @@ public class PositionStoreThreadTest extends MaxwellTestWithIsolatedServer {
 	public void testDoesNotStoreUnchangedPosition() throws Exception {
 		MaxwellContext context = buildContext();
 		MysqlPositionStore store = buildStore(context);
-		BinlogPosition initialPosition = new BinlogPosition(4L, "file", 0L);
+		Position initialPosition = new Position(new BinlogPosition(4L, "file"), 0L);
 		PositionStoreThread thread = new PositionStoreThread(store, context);
 
 		thread.setPosition(initialPosition);


### PR DESCRIPTION
Compatibility note: the --init_position config format has changed to include
":HEARTBEAT" - i.e. it is now "BINLOG_FILE:POSITION:HEARTBEAT"

Benefits: the compiler enforces the presence of `lastHeartbeatRead` instead of relying on assertions at runtime. This makes a clear distinction between DB events which only have a binlog position, and positions used in the replicator which also have heartbeat information.

This also changes the position sha calculation to include lastHeartbeat. This has a small chance of allowing multiple concurrent maxwell instances to store duplicate schema changes if they are using different versions. That shouldn't break anything, and they will stop creating duplicates once all clients are upgraded to the new version.

Fixes #636 