### PR TITLE
Stop processing RDS heartbeat events; improve shutdown heartbeat logic

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -49,18 +49,7 @@ public class Maxwell implements Runnable {
 	}
 
 	public void terminate() {
-		if (this.context.getError() == null) {
-			LOGGER.info("starting shutdown");
-			try {
-				// send a final heartbeat through the system
-				context.heartbeat();
-				Thread.sleep(100);
-				context.terminate();
-			} catch (InterruptedException e) {
-			} catch (Exception e) {
-				LOGGER.error("failed graceful shutdown", e);
-			}
-		}
+		this.context.terminate();
 	}
 
 	private Position attemptMasterRecovery() throws Exception {
@@ -187,7 +176,7 @@ public class Maxwell implements Runnable {
 
 		replicator.setFilter(context.getFilter());
 
-		this.context.addTask(replicator);
+		context.setReplicator(replicator);
 		this.context.start();
 		this.onReplicatorStart();
 

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -91,11 +91,6 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 		tableCache.clear();
 	}
 
-	protected void processRDSHeartbeatInsertEvent(String database, Position position) throws Exception {
-		HeartbeatRowMap hbr = new HeartbeatRowMap(database, position);
-		this.producer.push(hbr);
-	}
-
 	/**
 	 * Should we output an event for the given database and table?
 	 *

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -177,6 +177,10 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 						// to us starting on a WRITE_ROWS event -- we sync the schema position somewhere
 						// kinda unsafe.
 						processQueryEvent(event);
+					} else if (sql.toUpperCase().startsWith("INSERT INTO MYSQL.RDS_HEARTBEAT")) {
+						// RDS heartbeat events take the following form:
+						// INSERT INTO mysql.rds_heartbeat2(id, value) values (1,1483041015005) ON DUPLICATE KEY UPDATE value = 1483041015005
+						// We don't need to process them, just ignore
 					} else {
 						LOGGER.warn("Unhandled QueryEvent inside transaction: " + qe);
 					}

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -260,9 +260,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 					} else if (sql.toUpperCase().startsWith("INSERT INTO MYSQL.RDS_HEARTBEAT")) {
 						// RDS heartbeat events take the following form:
 						// INSERT INTO mysql.rds_heartbeat2(id, value) values (1,1483041015005) ON DUPLICATE KEY UPDATE value = 1483041015005
-						// As a result they are processed as query events.
-						// When these occur we need to update to update our position.
-						processRDSHeartbeatInsertEvent(qe);
+						// We don't need to process them, just ignore
 					} else {
 						LOGGER.warn("Unhandled QueryEvent inside transaction: " + qe);
 					}
@@ -370,13 +368,6 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 			this.schemaStore,
 			eventPosition(event),
 			event.getHeader().getTimestamp() / 1000
-		);
-	}
-
-	private void processRDSHeartbeatInsertEvent(QueryEvent event) throws Exception {
-		processRDSHeartbeatInsertEvent(
-			event.getDatabaseName().toString(),
-			eventPosition(event)
 		);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/replication/Replicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/Replicator.java
@@ -17,5 +17,6 @@ public interface Replicator extends StoppableTask {
 	Schema getSchema() throws SchemaStoreException;
 	Long getReplicationLag();
 
-	boolean runLoop() throws Exception;
+	void stopAtHeartbeat(long heartbeat);
+	void runLoop() throws Exception;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -78,9 +78,9 @@ public class MysqlPositionStore {
 		}
 	}
 
-	public synchronized void heartbeat() throws Exception {
+	public synchronized long heartbeat() throws Exception {
 		try ( Connection c = connectionPool.getConnection() ) {
-			heartbeat(c);
+			return heartbeat(c);
 		}
 	}
 
@@ -108,8 +108,8 @@ public class MysqlPositionStore {
 		}
 	}
 
-	private void heartbeat(Connection c) throws SQLException, DuplicateProcessException, InterruptedException {
-		Long thisHeartbeat = System.currentTimeMillis();
+	private long heartbeat(Connection c) throws SQLException, DuplicateProcessException, InterruptedException {
+		long thisHeartbeat = System.currentTimeMillis();
 
 		if ( lastHeartbeat == null ) {
 			PreparedStatement s = c.prepareStatement("SELECT `heartbeat` from `heartbeats` where server_id = ? and client_id = ?");
@@ -120,7 +120,7 @@ public class MysqlPositionStore {
 			if ( !rs.next() ) {
 				insertHeartbeat(c, thisHeartbeat);
 				lastHeartbeat = thisHeartbeat;
-				return;
+				return thisHeartbeat;
 			} else {
 				lastHeartbeat = rs.getLong("heartbeat");
 			}
@@ -146,6 +146,7 @@ public class MysqlPositionStore {
 		}
 
 		lastHeartbeat = thisHeartbeat;
+		return thisHeartbeat;
 	}
 
 	public Position get() throws SQLException {

--- a/src/main/java/com/zendesk/maxwell/schema/ReadOnlyMysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ReadOnlyMysqlPositionStore.java
@@ -16,5 +16,7 @@ public class ReadOnlyMysqlPositionStore extends MysqlPositionStore {
 	public void set(Position p) { }
 
 	@Override
-	public void heartbeat() throws Exception { }
+	public long heartbeat() throws Exception {
+		return System.currentTimeMillis();
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/util/RunLoopProcess.java
+++ b/src/main/java/com/zendesk/maxwell/util/RunLoopProcess.java
@@ -7,6 +7,7 @@ abstract public class RunLoopProcess implements StoppableTask {
 	private Thread thread;
 
 	public RunLoopProcess() {
+		this.taskState = new StoppableTaskState(this.getClass().getName());
 	}
 
 	public void requestStop() {
@@ -17,11 +18,7 @@ abstract public class RunLoopProcess implements StoppableTask {
 		this.taskState.awaitStop(thread, timeout);
 	}
 
-	public boolean runLoop() throws Exception {
-		if ( this.taskState != null )
-			return false;
-
-		this.taskState = new StoppableTaskState(this.getClass().getName());
+	public void runLoop() throws Exception {
 		this.thread = Thread.currentThread();
 		this.beforeStart();
 
@@ -33,8 +30,6 @@ abstract public class RunLoopProcess implements StoppableTask {
 			this.beforeStop();
 			this.taskState.stopped();
 		}
-
-		return true;
 	}
 
 	protected abstract void work() throws Exception;

--- a/src/main/java/com/zendesk/maxwell/util/TaskManager.java
+++ b/src/main/java/com/zendesk/maxwell/util/TaskManager.java
@@ -19,10 +19,19 @@ public class TaskManager {
 
 	// Can be invoked multiple times, will only return `true`
 	// for the first invocation.
-	public synchronized boolean stop(Exception error) {
-		if (this.state != RunState.RUNNING) {
-			LOGGER.debug("stop() called multiple times");
+	public synchronized boolean requestStop() {
+		if (state == RunState.RUNNING) {
+			state = RunState.REQUEST_STOP;
+			return true;
+		} else {
 			return false;
+		}
+	}
+
+	public synchronized void stop(Exception error) {
+		if (this.state == RunState.STOPPED) {
+			LOGGER.debug("stop() called multiple times");
+			return;
 		}
 		this.state = RunState.REQUEST_STOP;
 
@@ -49,7 +58,6 @@ public class TaskManager {
 
 		this.state = RunState.STOPPED;
 		LOGGER.info("stopped all tasks");
-		return true;
 	}
 
 	public synchronized void add(StoppableTask task) {

--- a/src/test/java/com/zendesk/maxwell/replication/AbstractReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/AbstractReplicatorTest.java
@@ -1,0 +1,32 @@
+package com.zendesk.maxwell.replication;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.MaxwellTestSupport;
+import com.zendesk.maxwell.MaxwellTestWithIsolatedServer;
+import com.zendesk.maxwell.row.HeartbeatRowMap;
+import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.support.TestReplicator;
+import com.zendesk.maxwell.util.RunState;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class AbstractReplicatorTest extends MaxwellTestWithIsolatedServer {
+
+	private RowMap heartbeatRow(long ts) {
+		return new HeartbeatRowMap("db", new Position(new BinlogPosition(0L, "binlog-file"), ts));
+	}
+
+	@Test
+	public void testStopsAfterTargetHeartbeatReceived() throws Exception {
+		TestReplicator replicator = new TestReplicator(buildContext());
+		replicator.stopAtHeartbeat(2L);
+
+		replicator.processRow(heartbeatRow(1L));
+		assertThat(replicator.getState(), is(RunState.RUNNING));
+
+		replicator.processRow(heartbeatRow(2L));
+		assertThat(replicator.getState(), is(RunState.STOPPED));
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/support/TestReplicator.java
+++ b/src/test/java/com/zendesk/maxwell/support/TestReplicator.java
@@ -1,0 +1,48 @@
+package com.zendesk.maxwell.support;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.producer.AbstractProducer;
+import com.zendesk.maxwell.producer.BufferedProducer;
+import com.zendesk.maxwell.replication.AbstractReplicator;
+import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaStoreException;
+import com.zendesk.maxwell.util.RunState;
+
+public class TestReplicator extends AbstractReplicator {
+
+	public TestReplicator(MaxwellContext context) {
+		super(null, null, null, new BufferedProducer(context, 10), null);
+	}
+
+	public BufferedProducer getProducer() {
+		return (BufferedProducer) producer;
+	}
+
+	public void processRow(RowMap row) throws Exception {
+		super.processRow(row);
+	}
+
+	public RunState getState() {
+		return taskState.getState();
+	}
+
+	@Override
+	public void startReplicator() throws Exception {
+	}
+
+	@Override
+	public Schema getSchema() throws SchemaStoreException {
+		return null;
+	}
+
+	@Override
+	public Long getReplicationLag() {
+		return null;
+	}
+
+	@Override
+	public RowMap getRow() throws Exception {
+		return null;
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/util/TaskManagerTest.java
+++ b/src/test/java/com/zendesk/maxwell/util/TaskManagerTest.java
@@ -99,8 +99,10 @@ public class TaskManagerTest {
 		TaskManager manager = new TaskManager();
 		manager.add(task);
 
-		assertThat(manager.stop(null), equalTo(true));
-		assertThat(manager.stop(null), equalTo(false));
+		assertThat(manager.requestStop(), equalTo(true));
+		assertThat(manager.requestStop(), equalTo(false));
+		manager.stop(null);
+		manager.stop(null);
 
 		assertThat(log, equalTo(Arrays.asList(
 			new Event(EventType.REQUEST_STOP, "task"),


### PR DESCRIPTION
Instead, we just cause maxwell to heartbeat at least every 10s.

Follow-on to #650 , and related to #636 .

Support for recognising RDS heartbeats was initially added (in #523) to ensure that quiet DBs still update their positions, this achieves the same result for non-RDS DBs as well.

In addition, for a clean shutdown we now always send a heartbeat and wait up to 10s until that heartbeat row has been fully processed. This ensures we actually see the final heartbeat (as long as we're not 10s lagged), and won't publish any events beyond this heartbeat. This means there'll be no duplicate events when maxwell starts up again.

Sample shutdown logs:

```
^C06:23:27,725 INFO  MaxwellContext - sending final heartbeat: 1495088607725
06:23:27,728 INFO  AbstractReplicator - received final heartbeat 1495088607725; stopping replicator
06:23:27,730 INFO  TaskManager - stopping 3 tasks
06:23:27,730 INFO  StoppableTaskState - MaxwellKafkaProducerWorker requestStop() called (in state: RUNNING)
06:23:27,735 INFO  KafkaProducer - Closing the Kafka producer with timeoutMillis = 9223372036854775807 ms.
06:23:27,743 INFO  StoppableTaskState - com.zendesk.maxwell.schema.PositionStoreThread requestStop() called (in state: RUNNING)
06:23:27,744 INFO  PositionStoreThread - Storing final position: Position[BinlogPosition[master.000004:66843351], lastHeartbeat=1495088607725]
06:23:27,749 INFO  StoppableTaskState - com.zendesk.maxwell.replication.MaxwellReplicator requestStop() called (in state: STOPPED)
06:23:28,592 INFO  TaskManager - stopped all tasks
```

/cc @zendesk/goanna @smferguson 