### PR TITLE
terminate with an exception when the main thread throws an exception

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -147,8 +147,15 @@ public class Maxwell implements Runnable {
 		MaxwellMetrics.setup(config, context);
 		try {
 			startInner();
+		} catch ( Exception e) {
+			this.context.terminate(e);
 		} finally {
 			this.context.terminate();
+		}
+
+		Exception error = this.context.getError();
+		if (error != null) {
+			throw error;
 		}
 	}
 
@@ -208,10 +215,6 @@ public class Maxwell implements Runnable {
 		}
 
 		replicator.runLoop();
-		Exception error = this.context.getError();
-		if (error != null) {
-			throw error;
-		}
 	}
 
 	public static void main(String[] args) {


### PR DESCRIPTION
As of #652 the shutdown logic cares about whether shutdown is due to an exception or not, so make sure we propagate an error from the main thread.

/cc @zendesk/goanna 