### PR TITLE
--kafka_version: fail on unknown version and name 0.10.2.1 -> 0.10.2

### DIFF
--- a/bin/maxwell
+++ b/bin/maxwell
@@ -6,15 +6,15 @@ args="$@"
 
 # Which version of kafka-clients will be loaded, based on the --kafka_version
 # flag. If none is specified default to 0.9.0
-# valid options are 0.8, 0.9, 0.10, 0.10.1, 0.10.2.1
+# valid options are 0.8, 0.9, 0.10, 0.10.1, 0.10.2
 
 KAFKA_VERSION=0.9
 
 KAFKA_08="0.8.2.2"
 KAFKA_09="0.9.0.1"
 KAFKA_10="0.10.0.1"
-KAFKA_1010="0.10.1.0"
-KAFKA_1021="0.10.2.1"
+KAFKA_101="0.10.1.0"
+KAFKA_102="0.10.2.1"
 
 WANTED_VERSION=""
 
@@ -34,7 +34,7 @@ do
 	shift # past argument or value
 done
 
-case $KAFKA_VERSION in
+case "$KAFKA_VERSION" in
 	0.8)
 	WANTED_VERSION=$KAFKA_08
 	;;
@@ -45,10 +45,14 @@ case $KAFKA_VERSION in
 	WANTED_VERSION=$KAFKA_10
 	;;
 	0.10.1)
-	WANTED_VERSION=$KAFKA_1010
+	WANTED_VERSION=$KAFKA_101
 	;;
-	0.10.2.1)
-	WANTED_VERSION=$KAFKA_1021
+	0.10.2)
+	WANTED_VERSION=$KAFKA_102
+	;;
+	*)
+	echo "Unsupported --kafka_version: $KAFKA_VERSION" >&2
+	exit 1
 	;;
 esac
 

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -161,7 +161,7 @@ producer_partition_columns        | STRING                              | if par
 producer_partition_by_fallback    | [database &#124; table &#124; primary_key]        | required when producer_partition_by=column.  Used when the column is missing |
 kafka_partition_hash           | [default &#124; murmur3]                   | hash function to use when hoosing kafka partition   | default
 ddl_kafka_topic                | STRING                              | if output_ddl is true, kafka topic to write DDL changes to | *kafka_topic*
-kafka_version                  | [0.8 &#124; 0.9 &#124; 0.10 &#124; 0.10.1]                      | run maxwell with kafka producer 0.8.2, 0.9.0, 0.10.0.1 or 0.10.1.0.  Not available in config.properties. | 0.9.0
+kafka_version                  | [0.8 &#124; 0.9 &#124; 0.10 &#124; 0.10.1 &#124; 0.10.2]                      | run maxwell with kafka producer 0.8.2, 0.9.0, 0.10.0.1, 0.10.1.0 or 0.10.2.1.  Not available in config.properties. | 0.9.0
 &nbsp;
 kinesis_stream                 | STRING                              | kinesis stream name |
 &nbsp;

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -137,8 +137,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "kafka_partition_hash", "default|murmur3, hash function for partitioning").withRequiredArg();
 		parser.accepts( "kafka_topic", "optionally provide a topic name to push to. default: maxwell").withOptionalArg();
 		parser.accepts( "kafka_key_format", "how to format the kafka key; array|hash").withOptionalArg();
-		parser.accepts("kafka_version",
-		    "switch to kafka 0.8, 0.10, 0.10.1, or 0.10.2.1 producer (from 0.9)");
+		parser.accepts( "kafka_version", "use kafka 0.8, 0.9, 0.10, 0.10.1, or 0.10.2 producer (default 0.9)");
 
 		parser.accepts( "kinesis_stream", "kinesis stream name").withOptionalArg();
 


### PR DESCRIPTION
/cc @liulikun 

0.10.2 is consistent with 0.10.1, and we're not expecting to need multiple patch levels of 0.10.2