### PR TITLE
Update for data format section in bootstrapping documentation

### DIFF
--- a/docs/docs/bootstrapping.md
+++ b/docs/docs/bootstrapping.md
@@ -41,7 +41,7 @@ In this async mode, non-bootstrapped tables are replicated as normal by the main
 * a bootstrap starts with a document with `type = "bootstrap-start"`
 * then documents with `type = "bootstrap-insert"` (one per row in the table)
 * then one document per `INSERT`, `UPDATE` or `DELETE` with standard document types i.e. `type = "insert"`, `type = "update"` or `type = "delete"` that occurred since the beginning of bootstrap
-* finally a document with `type = "booitstrap-complete"` 
+* finally a document with `type = "bootstrap-complete"`
 
 Here's a complete example:
 ```

--- a/docs/docs/bootstrapping.md
+++ b/docs/docs/bootstrapping.md
@@ -38,10 +38,10 @@ In this async mode, non-bootstrapped tables are replicated as normal by the main
 ### Bootstrapping Data Format
 ***
 
-* a bootstrap starts with a document with `type = "bootstrap-start"`
-* then documents with `type = "bootstrap-insert"` (one per row in the table)
-* then one document per `INSERT`, `UPDATE` or `DELETE` with standard document types i.e. `type = "insert"`, `type = "update"` or `type = "delete"` that occurred since the beginning of bootstrap
-* finally a document with `type = "bootstrap-complete"`
+* a bootstrap starts with an event of `type = "bootstrap-start"`
+* then events with `type = "bootstrap-insert"` (one per row in the table)
+* then one event per `INSERT`, `UPDATE` or `DELETE` with standard event types i.e. `type = "insert"`, `type = "update"` or `type = "delete"` that occurred since the beginning of bootstrap
+* finally an event with `type = "bootstrap-complete"`
 
 Here's a complete example:
 ```

--- a/docs/docs/bootstrapping.md
+++ b/docs/docs/bootstrapping.md
@@ -40,7 +40,7 @@ In this async mode, non-bootstrapped tables are replicated as normal by the main
 
 * a bootstrap starts with a document with `type = "bootstrap-start"`
 * then documents with `type = "bootstrap-insert"` (one per row in the table)
-* then one document per `INSERT`, `UPDATE` or `DELETE` with standard document types i.e. `type = "insert"`, `type = "update"` or `type = "delete"` that occurred since the beginning of bootstrap.
+* then one document per `INSERT`, `UPDATE` or `DELETE` with standard document types i.e. `type = "insert"`, `type = "update"` or `type = "delete"` that occurred since the beginning of bootstrap
 * finally a document with `type = "bootstrap-complete"`
 
 Here's a complete example:

--- a/docs/docs/bootstrapping.md
+++ b/docs/docs/bootstrapping.md
@@ -41,7 +41,7 @@ In this async mode, non-bootstrapped tables are replicated as normal by the main
 * a bootstrap starts with a document with `type = "bootstrap-start"`
 * then documents with `type = "bootstrap-insert"` (one per row in the table)
 * then one document per `INSERT`, `UPDATE` or `DELETE` with standard document types i.e. `type = "insert"`, `type = "update"` or `type = "delete"` that occurred since the beginning of bootstrap
-* finally a document with `type = "bootstrap-complete"`
+* finally a document with `type = "booitstrap-complete"` 
 
 Here's a complete example:
 ```

--- a/docs/docs/bootstrapping.md
+++ b/docs/docs/bootstrapping.md
@@ -39,8 +39,8 @@ In this async mode, non-bootstrapped tables are replicated as normal by the main
 ***
 
 * a bootstrap starts with a document with `type = "bootstrap-start"`
-* then documents with `type = "insert"` (one per row in the table)
-* then one document per `INSERT`, `UPDATE` or `DELETE` that occurred since the beginning of bootstrap
+* then documents with `type = "bootstrap-insert"` (one per row in the table)
+* then one document per `INSERT`, `UPDATE` or `DELETE` with standard document types i.e. `type = "insert"`, `type = "update"` or `type = "delete"` that occurred since the beginning of bootstrap.
 * finally a document with `type = "bootstrap-complete"`
 
 Here's a complete example:


### PR DESCRIPTION
* Specify document types explicitly in the data format section for bootstrapping
* Helps clarify #659 in the documentation  
