### PR TITLE
Pass around MaxwellMetrics instance instead of using static methods

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -133,7 +133,6 @@ public class Maxwell implements Runnable {
 
 	protected void onReplicatorStart() {}
 	private void start() throws Exception {
-		MaxwellMetrics.setup(config, context);
 		try {
 			startInner();
 		} catch ( Exception e) {
@@ -186,22 +185,6 @@ public class Maxwell implements Runnable {
 		context.setReplicator(replicator);
 		this.context.start();
 		this.onReplicatorStart();
-
-		// Dropwizard throws an exception if you try to register multiple metrics with the same name.
-		// Since there are codepaths that create multiple replicators (at least in the tests) we need to protect
-		// against that.
-		String lagGaugeName = MetricRegistry.name(MaxwellMetrics.getMetricsPrefix(), "replication", "lag");
-		if ( !(MaxwellMetrics.metricRegistry.getGauges().containsKey(lagGaugeName)) ) {
-			MaxwellMetrics.metricRegistry.register(
-					lagGaugeName,
-					new Gauge<Long>() {
-						@Override
-						public Long getValue() {
-							return replicator.getReplicationLag();
-						}
-					}
-			);
-		}
 
 		replicator.runLoop();
 	}

--- a/src/main/java/com/zendesk/maxwell/metrics/MaxwellHealthCheck.java
+++ b/src/main/java/com/zendesk/maxwell/metrics/MaxwellHealthCheck.java
@@ -1,26 +1,21 @@
 package com.zendesk.maxwell.metrics;
 
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.health.HealthCheck;
-import com.zendesk.maxwell.producer.AbstractAsyncProducer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.zendesk.maxwell.producer.AbstractProducer;
 
 
 public class MaxwellHealthCheck extends HealthCheck {
+	private final Meter failedMessageMeter;
 
-	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellHealthCheck.class);
-
-	private MetricRegistry metricRegistry;
-
-	public MaxwellHealthCheck(MetricRegistry metricRegistry) {
-		this.metricRegistry = metricRegistry;
+	public MaxwellHealthCheck(AbstractProducer producer) {
+		this.failedMessageMeter = producer.getFailedMessageMeter();
 	}
 
 	@Override
 	protected Result check() throws Exception {
 		// TODO: this should be configurable.
-		if (this.metricRegistry.getMeters().get(AbstractAsyncProducer.failedMessageMeterName).getFifteenMinuteRate() > 0) {
+		if (failedMessageMeter != null && failedMessageMeter.getFiveMinuteRate() > 0) {
 			return Result.unhealthy(">1 messages failed to be sent to Kafka in the past 15minutes");
 		} else {
 			return Result.healthy();

--- a/src/main/java/com/zendesk/maxwell/metrics/MaxwellMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/metrics/MaxwellMetrics.java
@@ -6,6 +6,8 @@ import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.producer.AbstractAsyncProducer;
+import com.zendesk.maxwell.util.StoppableTask;
 import org.apache.commons.lang.StringUtils;
 import org.coursera.metrics.datadog.DatadogReporter;
 import org.coursera.metrics.datadog.transport.HttpTransport;
@@ -14,15 +16,17 @@ import org.coursera.metrics.datadog.transport.UdpTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.coursera.metrics.datadog.DatadogReporter.Expansion.*;
 
-public class MaxwellMetrics {
-	public static final MetricRegistry metricRegistry = new MetricRegistry();
-	public static final HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
+public class MaxwellMetrics implements Metrics {
+	private final MetricRegistry metricRegistry;
+	private final HealthCheckRegistry healthCheckRegistry;
 
 	public static final String reportingTypeSlf4j = "slf4j";
 	public static final String reportingTypeJmx = "jmx";
@@ -30,10 +34,18 @@ public class MaxwellMetrics {
 	public static final String reportingTypeDataDog = "datadog";
 
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellMetrics.class);
+	private final MaxwellConfig config;
 
-	private static String metricsPrefix;
+	private String metricsPrefix;
 
-	public static void setup(MaxwellConfig config, MaxwellContext context) {
+	public MaxwellMetrics(MaxwellConfig config) {
+		healthCheckRegistry = new HealthCheckRegistry();
+		metricRegistry = new MetricRegistry();
+		this.config = config;
+		setup(config);
+	}
+
+	private void setup(MaxwellConfig config) {
 		if (config.metricsReportingType == null) {
 			LOGGER.warn("Metrics will not be exposed: metricsReportingType not configured.");
 			return;
@@ -68,14 +80,6 @@ public class MaxwellMetrics {
 					LOGGER.info("JMX running on port " + Integer.parseInt(portString));
 				}
 			}
-		}
-
-		if (config.metricsReportingType.contains(reportingTypeHttp)) {
-			healthCheckRegistry.register("MaxwellHealth", new MaxwellHealthCheck(metricRegistry));
-
-			LOGGER.info("Metrics http server starting");
-			new MaxwellHTTPServer(config.metricsHTTPPort, MaxwellMetrics.metricRegistry, healthCheckRegistry, context);
-			LOGGER.info("Metrics http server started on port " + config.metricsHTTPPort);
 		}
 
 		if (config.metricsReportingType.contains(reportingTypeDataDog)) {
@@ -116,7 +120,22 @@ public class MaxwellMetrics {
 		return tags;
 	}
 
-	public static String getMetricsPrefix() {
-		return metricsPrefix;
+	public String metricName(String... names) {
+		return MetricRegistry.name(metricsPrefix, names);
+	}
+
+	@Override
+	public MetricRegistry getRegistry() {
+		return metricRegistry;
+	}
+
+	public void startBackgroundTasks(MaxwellContext context) throws IOException {
+		String metricsReportingType = config.metricsReportingType;
+		if (metricsReportingType != null && metricsReportingType.contains(reportingTypeHttp)) {
+			LOGGER.info("Metrics http server starting");
+			new MaxwellHTTPServer(config.metricsHTTPPort, metricRegistry, healthCheckRegistry, context);
+			healthCheckRegistry.register("MaxwellHealth", new MaxwellHealthCheck(context.getProducer()));
+			LOGGER.info("Metrics http server started on port " + config.metricsHTTPPort);
+		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/metrics/Metrics.java
+++ b/src/main/java/com/zendesk/maxwell/metrics/Metrics.java
@@ -1,0 +1,10 @@
+package com.zendesk.maxwell.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.zendesk.maxwell.MaxwellContext;
+
+public interface Metrics {
+	String metricName(String... names);
+	MetricRegistry getRegistry();
+}
+

--- a/src/main/java/com/zendesk/maxwell/metrics/NoOpMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/metrics/NoOpMetrics.java
@@ -1,0 +1,22 @@
+package com.zendesk.maxwell.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+public class NoOpMetrics implements Metrics {
+	public final MetricRegistry metricRegistry;
+	public final HealthCheckRegistry healthCheckRegistry;
+
+	public NoOpMetrics() {
+		metricRegistry = new MetricRegistry();
+		healthCheckRegistry = new HealthCheckRegistry();
+	}
+
+	public String metricName(String... names) {
+		return MetricRegistry.name("noop", names);
+	}
+
+	public MetricRegistry getRegistry() {
+		return metricRegistry;
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.producer;
 
+import com.codahale.metrics.Meter;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.util.StoppableTask;
@@ -16,6 +17,10 @@ public abstract class AbstractProducer {
 	abstract public void push(RowMap r) throws Exception;
 
 	public StoppableTask getStoppableTask() {
+		return null;
+	}
+
+	public Meter getFailedMessageMeter() {
 		return null;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -6,6 +6,7 @@ package com.zendesk.maxwell.producer;
    Assumes .addInflight(position) will be call monotonically.
    */
 
+import com.codahale.metrics.Gauge;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.metrics.MaxwellMetrics;
+import com.zendesk.maxwell.metrics.Metrics;
 import com.zendesk.maxwell.producer.partitioners.MaxwellKafkaPartitioner;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
@@ -130,11 +131,6 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	private Thread thread;
 	private StoppableTaskState taskState;
 
-	private final Counter succeededMessageCount = MaxwellMetrics.metricRegistry.counter(succeededMessageCountName);
-	private final Meter succeededMessageMeter = MaxwellMetrics.metricRegistry.meter(succeededMessageMeterName);
-	private final Counter failedMessageCount = MaxwellMetrics.metricRegistry.counter(failedMessageCountName);
-	private final Meter failedMessageMeter = MaxwellMetrics.metricRegistry.meter(failedMessageMeterName);
-
 	public MaxwellKafkaProducerWorker(MaxwellContext context, Properties kafkaProperties, String kafkaTopic, ArrayBlockingQueue<RowMap> queue) {
 		super(context);
 
@@ -159,7 +155,9 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 		else
 			keyFormat = KeyFormat.ARRAY;
 
-		this.metricsTimer = MaxwellMetrics.metricRegistry.timer(MetricRegistry.name(MaxwellMetrics.getMetricsPrefix(), "time", "overall"));
+		Metrics metrics = context.getMetrics();
+		this.metricsTimer = metrics.getRegistry().timer(metrics.metricName("time", "overall"));
+
 		this.queue = queue;
 		this.taskState = new StoppableTaskState("MaxwellKafkaProducerWorker");
 	}

--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -1,6 +1,8 @@
 package com.zendesk.maxwell.recovery;
 
 import com.zendesk.maxwell.*;
+import com.zendesk.maxwell.metrics.Metrics;
+import com.zendesk.maxwell.metrics.NoOpMetrics;
 import com.zendesk.maxwell.replication.BinlogConnectorReplicator;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.MaxwellReplicator;
@@ -51,11 +53,11 @@ public class Recovery {
 		);
 
 		LOGGER.warn("attempting to recover from master-change: " + recoveryMsg);
-
 		List<BinlogPosition> list = getBinlogInfo();
 		for ( int i = list.size() - 1; i >= 0 ; i-- ) {
 			BinlogPosition binlogPosition = list.get(i);
 			Position position = recoveryInfo.position.withBinlogPosition(binlogPosition);
+			Metrics metrics = new NoOpMetrics();
 
 			LOGGER.debug("scanning binlog: " + binlogPosition);
 			Replicator replicator;
@@ -67,6 +69,7 @@ public class Recovery {
 						replicationConfig,
 						0L, // server-id of 0 activates "mysqlbinlog" behavior where the server will stop after each binlog
 						maxwellDatabaseName,
+						metrics,
 						position,
 						true,
 						recoveryInfo.clientID
@@ -80,6 +83,7 @@ public class Recovery {
 						0L, // server-id of 0 activates "mysqlbinlog" behavior where the server will stop after each binlog
 						false,
 						maxwellDatabaseName,
+						metrics,
 						position,
 						true,
 						recoveryInfo.clientID

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -8,6 +8,8 @@ import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.MaxwellMysqlConfig;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
+import com.zendesk.maxwell.metrics.MaxwellMetrics;
+import com.zendesk.maxwell.metrics.Metrics;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMapBuffer;
@@ -41,11 +43,12 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 		MaxwellMysqlConfig mysqlConfig,
 		Long replicaServerID,
 		String maxwellSchemaDatabaseName,
+		Metrics metrics,
 		Position start,
 		boolean stopOnEOF,
 		String clientID
 	) {
-		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer, start);
+		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer, metrics, start);
 		this.schemaStore = schemaStore;
 
 		this.client = new BinaryLogClient(mysqlConfig.host, mysqlConfig.port, mysqlConfig.user, mysqlConfig.password);
@@ -81,6 +84,7 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 			ctx.getConfig().replicationMysql,
 			ctx.getConfig().replicaServerID,
 			ctx.getConfig().databaseName,
+			ctx.getMetrics(),
 			start,
 			false,
 			ctx.getConfig().clientID

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -8,6 +8,7 @@ import com.google.code.or.net.TransportException;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.MaxwellMysqlConfig;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
+import com.zendesk.maxwell.metrics.Metrics;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMapBuffer;
@@ -44,11 +45,12 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 		Long replicaServerID,
 		boolean shouldHeartbeat,
 		String maxwellSchemaDatabaseName,
+		Metrics metrics,
 		Position start,
 		boolean stopOnEOF,
 		String clientID
 	) {
-		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer, start);
+		super(clientID, bootstrapper, maxwellSchemaDatabaseName, producer, metrics, start);
 		this.schemaStore = schemaStore;
 		this.binlogEventListener = new BinlogEventListener(queue);
 
@@ -82,6 +84,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 			ctx.getConfig().replicaServerID,
 			ctx.shouldHeartbeat(),
 			ctx.getConfig().databaseName,
+			ctx.getMetrics(),
 			start,
 			false,
 			ctx.getConfig().clientID

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell.producer;
 
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.metrics.NoOpMetrics;
 import org.junit.Test;
 
 import java.util.Properties;
@@ -16,6 +17,7 @@ public class MaxwellKafkaProducerWorkerTest {
 		MaxwellContext context = mock(MaxwellContext.class);
 		MaxwellConfig config = new MaxwellConfig();
 		when(context.getConfig()).thenReturn(config);
+		when(context.getMetrics()).thenReturn(new NoOpMetrics());
 		Properties kafkaProperties = new Properties();
 		kafkaProperties.put("bootstrap.servers", "localhost:9092");
 		String kafkaTopic = null;

--- a/src/test/java/com/zendesk/maxwell/support/TestReplicator.java
+++ b/src/test/java/com/zendesk/maxwell/support/TestReplicator.java
@@ -1,7 +1,7 @@
 package com.zendesk.maxwell.support;
 
 import com.zendesk.maxwell.MaxwellContext;
-import com.zendesk.maxwell.producer.AbstractProducer;
+import com.zendesk.maxwell.metrics.NoOpMetrics;
 import com.zendesk.maxwell.producer.BufferedProducer;
 import com.zendesk.maxwell.replication.AbstractReplicator;
 import com.zendesk.maxwell.row.RowMap;
@@ -12,7 +12,10 @@ import com.zendesk.maxwell.util.RunState;
 public class TestReplicator extends AbstractReplicator {
 
 	public TestReplicator(MaxwellContext context) {
-		super(null, null, null, new BufferedProducer(context, 10), null);
+		super(
+			null, null, null,
+			new BufferedProducer(context, 10), new NoOpMetrics(), null
+		);
 	}
 
 	public BufferedProducer getProducer() {


### PR DESCRIPTION
Mainly this allows us to drop the awkward "only add a gauge if there isn't one with this name already" code whenever we add a custom gauge, but it should help with #634 too.

/cc @zendesk/goanna @smferguson 