### PR TITLE
additional metrics

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -117,7 +117,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 				type,
 				table.getDatabase(),
 				table.getName(),
-				System.currentTimeMillis() / 1000,
+				System.currentTimeMillis(),
 				table.getPKList(),
 				position);
 	}

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -60,6 +60,17 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 		Metrics metrics = context.getMetrics();
 		MetricRegistry metricRegistry = metrics.getRegistry();
 
+		String gaugeName = metrics.metricName("inflightmessages", "count");
+		metricRegistry.register(
+			gaugeName,
+			new Gauge<Long>() {
+				@Override
+				public Long getValue() {
+					return (long) inflightMessages.size();
+				}
+			}
+		);
+
 		this.succeededMessageCount = metricRegistry.counter(metrics.metricName("messages", "succeeded"));
 		this.succeededMessageMeter = metricRegistry.meter(metrics.metricName("messages", "succeeded", "meter"));
 		this.failedMessageCount = metricRegistry.counter(metrics.metricName("messages", "failed"));

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -156,7 +156,7 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 			keyFormat = KeyFormat.ARRAY;
 
 		Metrics metrics = context.getMetrics();
-		this.metricsTimer = metrics.getRegistry().timer(metrics.metricName("time", "overall"));
+		this.metricsTimer = metrics.getRegistry().timer(metrics.metricName("message", "publish", "time"));
 
 		this.queue = queue;
 		this.taskState = new StoppableTaskState("MaxwellKafkaProducerWorker");

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -2,13 +2,10 @@ package com.zendesk.maxwell.producer;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.zendesk.maxwell.MaxwellContext;
-import com.zendesk.maxwell.metrics.MaxwellMetrics;
 import com.zendesk.maxwell.metrics.Metrics;
 import com.zendesk.maxwell.producer.partitioners.MaxwellKafkaPartitioner;
-import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMap.KeyFormat;

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractRowsEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractRowsEvent.java
@@ -151,7 +151,7 @@ public abstract class AbstractRowsEvent extends AbstractRowEvent {
 				getType(),
 				this.database,
 				getTable().getName(),
-				getHeader().getTimestamp() / 1000,
+				getHeader().getTimestamp(),
 				table.getPKList(),
 				this.getNextPosition());
 	}

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
@@ -128,7 +128,7 @@ public class BinlogConnectorEvent {
 			type,
 			table.getDatabase(),
 			table.getName(),
-			event.getHeader().getTimestamp() / 1000,
+			event.getHeader().getTimestamp(),
 			table.getPKList(),
 			position
 		);

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
@@ -4,6 +4,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.codahale.metrics.Timer;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventType;
@@ -17,30 +18,65 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener,
 	private static final Logger LOGGER = LoggerFactory.getLogger(BinlogConnectorEventListener.class);
 
 	private final BlockingQueue<BinlogConnectorEvent> queue;
+	private Timer queueTimer;
 	protected final AtomicBoolean mustStop = new AtomicBoolean(false);
 	private final BinaryLogClient client;
 	private String gtid;
 
-	public BinlogConnectorEventListener(BinaryLogClient client, BlockingQueue<BinlogConnectorEvent> q) {
+	private long replicationWait = 0L;
+	private long lastProcessedEventTimestamp = 0L;
+	private long lastProcessedEventAt;
+
+	public BinlogConnectorEventListener(BinaryLogClient client, BlockingQueue<BinlogConnectorEvent> q, Timer queueTimer) {
 		this.client = client;
 		this.queue = q;
+		this.queueTimer = queueTimer;
+		this.lastProcessedEventAt = System.currentTimeMillis();
 	}
+
 	public void stop() {
 		mustStop.set(true);
 	}
 
 	@Override
 	public void onEvent(Event event) {
+		long eventSeenAt = 0L;
+		long eventTimestamp = 0L;
+
+		boolean trackMetrics = event.getHeader().getEventType() == EventType.XID;
+		if (trackMetrics) {
+			// replicationWait is not lag, but a measure of how much we're
+			// waiting for events - if events come in with timestamp intervals smaller
+			// than the clock time we spend waiting, the DB is slowing us down.
+			eventSeenAt = System.currentTimeMillis();
+			eventTimestamp = event.getHeader().getTimestamp();
+
+			long eventTimeDiff = eventTimestamp - this.lastProcessedEventTimestamp;
+			long clockTimeDiff = eventSeenAt - this.lastProcessedEventAt;
+			this.replicationWait = Math.max(0L, this.replicationWait + (
+				clockTimeDiff - eventTimeDiff
+			));
+		}
+
 		while (mustStop.get() != true) {
 			if (event.getHeader().getEventType() == EventType.GTID) {
 				gtid = ((GtidEventData)event.getData()).getGtid();
 			}
+
 			BinlogConnectorEvent ep = new BinlogConnectorEvent(event, client.getBinlogFilename(), client.getGtidSet(), gtid);
 			try {
 				if ( queue.offer(ep, 100, TimeUnit.MILLISECONDS ) ) {
-					return;
+					break;
 				}
-			} catch (InterruptedException e) { }
+			} catch (InterruptedException e) {
+				return;
+			}
+		}
+
+		if (trackMetrics) {
+			queueTimer.update(System.currentTimeMillis() - eventSeenAt, TimeUnit.MILLISECONDS);
+			this.lastProcessedEventAt = eventSeenAt;
+			this.lastProcessedEventTimestamp = eventTimestamp;
 		}
 	}
 
@@ -62,6 +98,10 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener,
 	@Override
 	public void onDisconnect(BinaryLogClient client) {
 		LOGGER.info("Binlog disconnected.");
+	}
+
+	public long getReplicationWait() {
+		return replicationWait;
 	}
 }
 

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -78,16 +78,6 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 		this.client.setServerId(replicaServerID.intValue());
 
 		this.stopOnEOF = stopOnEOF;
-
-		metrics.getRegistry().register(
-				metrics.metricName("replication", "queue", "count"),
-				new Gauge<Long>() {
-					@Override
-					public Long getValue() {
-						return (long) queue.size();
-					}
-				}
-		);
 	}
 
 	public BinlogConnectorReplicator(SchemaStore schemaStore, AbstractProducer producer, AbstractBootstrapper bootstrapper, MaxwellContext ctx, Position start) throws SQLException {

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -80,16 +80,6 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 		this.stopOnEOF = stopOnEOF;
 
 		metrics.getRegistry().register(
-				metrics.metricName("replication", "wait"),
-				new Gauge<Long>() {
-					@Override
-					public Long getValue() {
-						return binlogEventListener.getReplicationWait();
-					}
-				}
-		);
-
-		metrics.getRegistry().register(
 				metrics.metricName("replication", "queue", "count"),
 				new Gauge<Long>() {
 					@Override

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellReplicator.java
@@ -273,7 +273,6 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 
 					buffer.setXid(xe.getXid());
 
-					replicationLag = System.currentTimeMillis() - xe.getHeader().getTimestamp();
 					if ( !buffer.isEmpty() )
 						buffer.getLast().setTXCommit();
 
@@ -370,7 +369,7 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 			event.getSql().toString(),
 			this.schemaStore,
 			eventPosition(event),
-			event.getHeader().getTimestamp() / 1000
+			event.getHeader().getTimestamp()
 		);
 	}
 
@@ -388,9 +387,5 @@ public class MaxwellReplicator extends AbstractReplicator implements Replicator 
 
 	public OpenReplicator getOpenReplicator() {
 		return replicator;
-	}
-
-	public Long getReplicationLag() {
-		return this.replicationLag;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/Replicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/Replicator.java
@@ -15,7 +15,6 @@ public interface Replicator extends StoppableTask {
 	RowMap getRow() throws Exception;
 	Long getLastHeartbeatRead();
 	Schema getSchema() throws SchemaStoreException;
-	Long getReplicationLag();
 
 	void stopAtHeartbeat(long heartbeat);
 	void runLoop() throws Exception;

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -27,7 +27,8 @@ public class RowMap implements Serializable {
 	private final String rowType;
 	private final String database;
 	private final String table;
-	private final Long timestamp;
+	private final Long timestampMillis;
+	private final Long timestampSeconds;
 	private Position nextPosition;
 
 	private Long xid;
@@ -67,12 +68,13 @@ public class RowMap implements Serializable {
 				}
 			};
 
-	public RowMap(String type, String database, String table, Long timestamp, List<String> pkColumns,
+	public RowMap(String type, String database, String table, Long timestampMillis, List<String> pkColumns,
 			Position nextPosition) {
 		this.rowType = type;
 		this.database = database;
 		this.table = table;
-		this.timestamp = timestamp;
+		this.timestampMillis = timestampMillis;
+		this.timestampSeconds = timestampMillis / 1000;
 		this.data = new LinkedHashMap<>();
 		this.oldData = new LinkedHashMap<>();
 		this.nextPosition = nextPosition;
@@ -220,7 +222,7 @@ public class RowMap implements Serializable {
 		g.writeStringField("database", this.database);
 		g.writeStringField("table", this.table);
 		g.writeStringField("type", this.rowType);
-		g.writeNumberField("ts", this.timestamp);
+		g.writeNumberField("ts", this.timestampSeconds);
 
 		if ( outputConfig.includesCommitInfo ) {
 			if ( this.xid != null )
@@ -364,7 +366,11 @@ public class RowMap implements Serializable {
 	}
 
 	public Long getTimestamp() {
-		return timestamp;
+		return timestampSeconds;
+	}
+
+	public Long getTimestampMillis() {
+		return timestampSeconds;
 	}
 
 	public boolean hasData(String name) {

--- a/src/test/java/com/zendesk/maxwell/support/TestReplicator.java
+++ b/src/test/java/com/zendesk/maxwell/support/TestReplicator.java
@@ -40,11 +40,6 @@ public class TestReplicator extends AbstractReplicator {
 	}
 
 	@Override
-	public Long getReplicationLag() {
-		return null;
-	}
-
-	@Override
 	public RowMap getRow() throws Exception {
 		return null;
 	}


### PR DESCRIPTION
New metrics:

 - `replication.queue.time`: time taken to enqueue a DB event
 - `replication.queue.count`: size of the DB event queue
 - `inflightmessages.count`: number of inflight messages (waiting to be ACKed)
 - `time.overall` renamed to `publish.time` since it tracks the time between constructing a publishable message to that message being completed (ACKed)

The new replication metrics are only implemented for the binlog_connector mode. The inflight messages metric is implemented for async producers.

I refactored `rowMap` to store (and accept) millis instead of seconds so that `replicationLag` ban just be based on this (and because it's the only `seconds` timestamp we have), but aside from the constructor the interface remains unchanged.

/cc @zendesk/goanna @smferguson 