### PR TITLE
BufferedProducer: set position immediately for heartbeat rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config/*.yml
 .DS_Store
 /test.log
 .sw?
+/config

--- a/src/main/java/com/zendesk/maxwell/producer/BufferedProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/BufferedProducer.java
@@ -1,7 +1,7 @@
 package com.zendesk.maxwell.producer;
 
-import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
 
 import java.sql.SQLException;
@@ -18,6 +18,10 @@ public class BufferedProducer extends AbstractProducer {
 
 	@Override
 	public void push(RowMap r) throws Exception {
+		// set position on heartbeats immediately to ensure we terminate cleanly
+		if (r instanceof HeartbeatRowMap) {
+			this.context.setPosition(r);
+		}
 		try {
 			this.queue.put(r);
 		} catch ( InterruptedException e ) {}


### PR DESCRIPTION
Test times increased dramatically after #652, because MaxwellTestSupport's use of a BufferedProducer in a way that never consumes the final heartbeat row, leading to timeouts at the end of every test which uses it. This PR sends heartbeats to the position store immediately.

There's a slim chance of false positives/negatives since now the position thread's position will be updated when a heartbeat row is _queued_, not _processed_. But I've eyeballed all the tests which make use of the position and they don't seem to be affected.

Another alternative would be to not bother with the heartbeat dance when we're using a buffered producer, but I like that we exercise this termination logic in the tests.

/cc @zendesk/goanna 