### PR TITLE
Shutdown hardening

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,7 @@ before_install:
   - sudo apt-get install pastebinit
 install: true
 script:
-  - echo travis_fold:start:compile
-  - KAFKA_VERSION=0.8.2.2 make depclean compile
-  - KAFKA_VERSION=0.10.0.1 make depclean compile
-  - KAFKA_VERSION=0.10.1.0 make depclean compile
-  - KAFKA_VERSION=0.10.2.1 make depclean compile
-  - make depclean
-  - echo travis_fold:end:compile
-  - make test
+  - src/test/travis.sh
 after_script:
   - pastebinit -i test.log
 env:

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -154,10 +154,18 @@ public class MaxwellContext {
 					LOGGER.error("failed graceful shutdown", e);
 				}
 			}
-			taskManager.stop(this.error);
-			this.replicationConnectionPool.release();
-			this.maxwellConnectionPool.release();
-			this.rawMaxwellConnectionPool.release();
+			try {
+				taskManager.stop(this.error);
+				this.replicationConnectionPool.release();
+				this.maxwellConnectionPool.release();
+				this.rawMaxwellConnectionPool.release();
+			} catch (Exception e) {
+				LOGGER.error("Exception occurred during graceful shutdown:", e);
+				if (this.error != null) {
+					LOGGER.error("Termination reason:", this.error);
+				}
+				System.exit(1);
+			}
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -221,11 +221,8 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	@Override
 	public void requestStop() {
 		taskState.requestStop();
-		try {
-			kafka.close(3L, TimeUnit.SECONDS);
-		} catch (Exception e) {
-			LOGGER.info("Failed to close kafka producer:", e);
-		}
+		// TODO: set a timeout once we drop support for kafka 0.8
+		kafka.close();
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -10,6 +10,7 @@ import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMap.KeyFormat;
 import com.zendesk.maxwell.schema.ddl.DDLMap;
+import com.zendesk.maxwell.util.Logging;
 import com.zendesk.maxwell.util.StoppableTask;
 import com.zendesk.maxwell.util.StoppableTaskState;
 import org.apache.kafka.clients.producer.Callback;
@@ -220,7 +221,11 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	@Override
 	public void requestStop() {
 		taskState.requestStop();
-		kafka.close();
+		try {
+			kafka.close(5L, TimeUnit.SECONDS);
+		} catch (Exception e) {
+			LOGGER.info("Failed to close kafka producer:", e);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -222,7 +222,7 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	public void requestStop() {
 		taskState.requestStop();
 		try {
-			kafka.close(5L, TimeUnit.SECONDS);
+			kafka.close(3L, TimeUnit.SECONDS);
 		} catch (Exception e) {
 			LOGGER.info("Failed to close kafka producer:", e);
 		}

--- a/src/main/java/com/zendesk/maxwell/util/TaskManager.java
+++ b/src/main/java/com/zendesk/maxwell/util/TaskManager.java
@@ -28,14 +28,14 @@ public class TaskManager {
 		}
 	}
 
-	public synchronized void stop(Exception error) {
+	public synchronized void stop(Exception error) throws TimeoutException, InterruptedException {
 		if (this.state == RunState.STOPPED) {
-			LOGGER.debug("stop() called multiple times");
+			LOGGER.debug("Stop() called multiple times");
 			return;
 		}
 		this.state = RunState.REQUEST_STOP;
 
-		LOGGER.info("stopping " + tasks.size() + " tasks");
+		LOGGER.info("Stopping " + tasks.size() + " tasks");
 
 		if (error != null) {
 			LOGGER.error("cause: ", error);
@@ -43,21 +43,19 @@ public class TaskManager {
 
 		// tell everything to stop
 		for (StoppableTask task: this.tasks) {
+			LOGGER.info("Stopping: " + task);
 			task.requestStop();
 		}
 
 		// then wait for everything to stop
 		Long timeout = 500L;
 		for (StoppableTask task: this.tasks) {
-			try {
-				task.awaitStop(timeout);
-			} catch (TimeoutException e) {
-				LOGGER.error(e.getMessage());
-			}
+			LOGGER.debug("Awaiting stop of: " + task);
+			task.awaitStop(timeout);
 		}
 
 		this.state = RunState.STOPPED;
-		LOGGER.info("stopped all tasks");
+		LOGGER.info("Stopped all tasks");
 	}
 
 	public synchronized void add(StoppableTask task) {

--- a/src/test/travis.sh
+++ b/src/test/travis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eux
+echo travis_fold:start:compile
+KAFKA_VERSION=0.8.2.2 make depclean compile
+KAFKA_VERSION=0.10.0.1 make depclean compile
+KAFKA_VERSION=0.10.1.0 make depclean compile
+KAFKA_VERSION=0.10.2.1 make depclean compile
+make depclean
+echo travis_fold:end:compile
+make test


### PR DESCRIPTION
When `ignore_producer_error` is `false`, a kafka producer in certain bad states can prevent shutting down (even when closed with a timeout), leaving a maxwell process which is neither replicating nor publishing events.

This branch attempts to ensure the shutdown of maxwell under all circumstances, by force if necessary. The basic flow is:

 - entire shutdown logic (in MaxwellContext) has been moved to a thread. That thread gets 10 seconds to shutdown successfully. If an exception is thrown, or the thread doesn't complete in 10 seconds, the entire process is forcefully halted.

/cc @zendesk/goanna 