### PR TITLE
Make RecoveryTest.drainReplication more reliable with an explicit heartbeat

### DIFF
--- a/src/main/java/com/zendesk/maxwell/BufferedMaxwell.java
+++ b/src/main/java/com/zendesk/maxwell/BufferedMaxwell.java
@@ -21,4 +21,7 @@ public class BufferedMaxwell extends Maxwell {
 		return p.poll(ms, TimeUnit.MILLISECONDS);
 	}
 
+	public MaxwellContext getContext() {
+		return context;
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -118,8 +118,8 @@ public class MaxwellContext {
 		getPositionStoreThread(); // boot up thread explicitly.
 	}
 
-	public void heartbeat() throws Exception {
-		this.positionStore.heartbeat();
+	public long heartbeat() throws Exception {
+		return this.positionStore.heartbeat();
 	}
 
 	public void addTask(StoppableTask task) {

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -152,6 +152,10 @@ public class MysqlPositionStore {
 		lastHeartbeat = thisHeartbeat;
 	}
 
+	public Long getLastHeartbeatSent() {
+		return lastHeartbeat;
+	}
+
 	public Position get() throws SQLException {
 		try ( Connection c = connectionPool.getConnection() ) {
 			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? and client_id = ?");

--- a/src/main/java/com/zendesk/maxwell/util/TaskManager.java
+++ b/src/main/java/com/zendesk/maxwell/util/TaskManager.java
@@ -47,7 +47,7 @@ public class TaskManager {
 		}
 
 		// then wait for everything to stop
-		Long timeout = 500L;
+		Long timeout = 1000L;
 		for (StoppableTask task: this.tasks) {
 			try {
 				task.awaitStop(timeout);


### PR DESCRIPTION
`drainReplication` used to end when no event is received for 500ms, but we see these tests failing sporadically in CI. By using an explicit heartbeat we can stop the drain as soon as we see the heartbeat row (and not before), which will hopefully make these tests more precise.

/cc @zendesk/goanna 