### PR TITLE
Improve mysql version logic in tests

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/MysqlVersion.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MysqlVersion.java
@@ -21,13 +21,6 @@ public class MysqlVersion {
 		return atLeast(version.major, version.minor);
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj.getClass() != this.getClass() ) return false;
-		MysqlVersion other = (MysqlVersion) obj;
-		return other.major == major && other.minor == minor;
-	}
-
 	public static MysqlVersion capture(Connection c) throws SQLException {
 		DatabaseMetaData meta = c.getMetaData();
 		return new MysqlVersion(meta.getDatabaseMajorVersion(), meta.getDatabaseMinorVersion());

--- a/src/main/java/com/zendesk/maxwell/replication/MysqlVersion.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MysqlVersion.java
@@ -1,0 +1,35 @@
+package com.zendesk.maxwell.replication;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+public class MysqlVersion {
+	private final int major;
+	private final int minor;
+
+	public MysqlVersion(int major, int minor) {
+		this.major = major;
+		this.minor = minor;
+	}
+
+	public boolean atLeast(int major, int minor) {
+		return (this.major > major) || (this.major == major && this.minor >= minor);
+	}
+
+	public boolean atLeast(MysqlVersion version) {
+		return atLeast(version.major, version.minor);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj.getClass() != this.getClass() ) return false;
+		MysqlVersion other = (MysqlVersion) obj;
+		return other.major == major && other.minor == minor;
+	}
+
+	public static MysqlVersion capture(Connection c) throws SQLException {
+		DatabaseMetaData meta = c.getMetaData();
+		return new MysqlVersion(meta.getDatabaseMajorVersion(), meta.getDatabaseMinorVersion());
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
@@ -115,7 +115,7 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 		testColumnType("date", "'2015-11-07'","2015-11-07");
 		testColumnType("datetime", "'2015-11-07 01:02:03'","2015-11-07 01:02:03");
 
-		if ( !server.getVersion().equals("5.7") ) {
+		if (server.supportsZeroDates()) {
 			testColumnType("date", "'0000-00-00'",null);
 			testColumnType("datetime", "'0000-00-00 00:00:00'", null);
 			testColumnType("timestamp", "'0000-00-00 00:00:00'","" + epoch.substring(0, epoch.length() - 2) + "", null);

--- a/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
@@ -132,24 +132,23 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testSubsecondTypes() throws Exception {
-		if ( server.getVersion().equals("5.6") ) {
-			testColumnType("timestamp(6)", "'2015-11-07 01:02:03.333444'","2015-11-07 01:02:03.333444");
-			testColumnType("timestamp(6)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123000");
-			testColumnType("timestamp(6)", "'2015-11-07 01:02:03.0'","2015-11-07 01:02:03.000000");
+		requireMinimumVersion(server.VERSION_5_6);
+		testColumnType("timestamp(6)", "'2015-11-07 01:02:03.333444'","2015-11-07 01:02:03.333444");
+		testColumnType("timestamp(6)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123000");
+		testColumnType("timestamp(6)", "'2015-11-07 01:02:03.0'","2015-11-07 01:02:03.000000");
 
-			testColumnType("timestamp(3)", "'2015-11-07 01:02:03.123456'","2015-11-07 01:02:03.123");
-			testColumnType("timestamp(3)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123");
-			testColumnType("timestamp(3)", "'2015-11-07 01:02:03.1'","2015-11-07 01:02:03.100");
-			testColumnType("timestamp(3)", "'2015-11-07 01:02:03.0'","2015-11-07 01:02:03.000");
+		testColumnType("timestamp(3)", "'2015-11-07 01:02:03.123456'","2015-11-07 01:02:03.123");
+		testColumnType("timestamp(3)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123");
+		testColumnType("timestamp(3)", "'2015-11-07 01:02:03.1'","2015-11-07 01:02:03.100");
+		testColumnType("timestamp(3)", "'2015-11-07 01:02:03.0'","2015-11-07 01:02:03.000");
 
-			testColumnType("datetime(6)", "'2015-11-07 01:02:03.123456'","2015-11-07 01:02:03.123456");
-			testColumnType("datetime(6)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123000");
-			testColumnType("datetime(3)", "'2015-11-07 01:02:03.123456'","2015-11-07 01:02:03.123");
-			testColumnType("datetime(3)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123");
-			testColumnType("time(3)", "'01:02:03.123456'","01:02:03.123");
-			testColumnType("time(6)", "'01:02:03.123456'","01:02:03.123456");
-			testColumnType("time(3)", "'01:02:03.123'","01:02:03.123");
-		}
+		testColumnType("datetime(6)", "'2015-11-07 01:02:03.123456'","2015-11-07 01:02:03.123456");
+		testColumnType("datetime(6)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123000");
+		testColumnType("datetime(3)", "'2015-11-07 01:02:03.123456'","2015-11-07 01:02:03.123");
+		testColumnType("datetime(3)", "'2015-11-07 01:02:03.123'","2015-11-07 01:02:03.123");
+		testColumnType("time(3)", "'01:02:03.123456'","01:02:03.123");
+		testColumnType("time(6)", "'01:02:03.123456'","01:02:03.123456");
+		testColumnType("time(3)", "'01:02:03.123'","01:02:03.123");
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -410,8 +410,8 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testTime() throws Exception {
-		if ( server.getVersion().equals("5.6") )
-			runJSON("/json/test_time");
+		requireMinimumVersion(server.VERSION_5_6);
+		runJSON("/json/test_time");
 	}
 
 	@Test
@@ -436,8 +436,8 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testJson() throws Exception {
-		if ( server.getVersion().equals("5.7") )
-			runJSON("/json/test_json");
+		requireMinimumVersion(server.VERSION_5_7);
+		runJSON("/json/test_json");
 	}
 
 	static String[] createDBSql = {

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.row.RowMap;
@@ -320,8 +321,7 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testRunMinimalBinlog() throws Exception {
-		if ( server.getVersion().equals("5.5") )
-			return;
+		requireMinimumVersion(server.VERSION_5_6);
 
 		try {
 			server.getConnection().createStatement().execute("set global binlog_row_image='minimal'");
@@ -370,8 +370,8 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testZeroCreatedAtJSON() throws Exception {
-		if ( server.getVersion().equals("5.5") ) // 5.6 not yet supported for this test
-			runJSON("/json/test_zero_created_at");
+		assumeTrue(server.supportsZeroDates());
+		runJSON("/json/test_zero_created_at");
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -65,10 +65,10 @@ public class MaxwellTestSupport {
 		}
 
 		String shardedFileName;
-		if ( server.getVersion().equals(server.VERSION_5_6) )
-			shardedFileName = "sharded_56.sql";
-		else
+		if ( server.getVersion().atLeast(server.VERSION_5_6) )
 			shardedFileName = "sharded.sql";
+		else
+			shardedFileName = "sharded_55.sql";
 
 		File shardedFile = new File(getSQLDir() + "/schema/" + shardedFileName);
 		byte[] sql = Files.readAllBytes(shardedFile.toPath());

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -65,7 +65,7 @@ public class MaxwellTestSupport {
 		}
 
 		String shardedFileName;
-		if ( server.getVersion().equals("5.6") )
+		if ( server.getVersion().equals(server.VERSION_5_6) )
 			shardedFileName = "sharded_56.sql";
 		else
 			shardedFileName = "sharded.sql";

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -5,10 +5,12 @@ import java.sql.SQLException;
 import java.util.*;
 
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
-import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.MysqlVersion;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import org.junit.*;
+
+import static org.junit.Assume.assumeTrue;
 
 
 public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
@@ -90,5 +92,10 @@ public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 		MaxwellFilter filter = new MaxwellFilter();
 		filter.excludeDatabase(name);
 		return filter;
+	}
+
+	protected void requireMinimumVersion(MysqlVersion minimum) {
+		// skips this test if running an older MYSQL version
+		assumeTrue(server.getVersion().atLeast(minimum));
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zendesk.maxwell.replication.MysqlVersion;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,10 @@ import java.util.Map;
 
 public class MysqlIsolatedServer {
 	public static final Long SERVER_ID = 4321L;
+
+	public final MysqlVersion VERSION_5_6 = new MysqlVersion(5, 6);
+	public final MysqlVersion VERSION_5_7 = new MysqlVersion(5, 7);
+
 	private Connection connection; private String baseDir;
 	private int port;
 	private int serverPid;
@@ -51,7 +56,7 @@ public class MysqlIsolatedServer {
 
 		ProcessBuilder pb = new ProcessBuilder(
 				dir + "/src/test/onetimeserver",
-				"--mysql-version=" + this.getVersion(),
+				"--mysql-version=" + this.getVersionString(),
 				"--log-slave-updates",
 				"--log-bin=master",
 				"--binlog_format=row",
@@ -182,9 +187,13 @@ public class MysqlIsolatedServer {
 		} catch ( IOException e ) {}
 	}
 
-	public String getVersion() {
+	private String getVersionString() {
 		String mysqlVersion = System.getenv("MYSQL_VERSION");
 		return mysqlVersion == null ? "5.5" : mysqlVersion;
+	}
 
+	public MysqlVersion getVersion() {
+		String[] parts = getVersionString().split("\\.");
+		return new MysqlVersion(Integer.valueOf(parts[0]), Integer.valueOf(parts[1]));
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -21,6 +21,7 @@ import java.util.Map;
 public class MysqlIsolatedServer {
 	public static final Long SERVER_ID = 4321L;
 
+	public final MysqlVersion VERSION_5_5 = new MysqlVersion(5, 5);
 	public final MysqlVersion VERSION_5_6 = new MysqlVersion(5, 6);
 	public final MysqlVersion VERSION_5_7 = new MysqlVersion(5, 7);
 
@@ -195,5 +196,10 @@ public class MysqlIsolatedServer {
 	public MysqlVersion getVersion() {
 		String[] parts = getVersionString().split("\\.");
 		return new MysqlVersion(Integer.valueOf(parts[0]), Integer.valueOf(parts[1]));
+	}
+
+	public boolean supportsZeroDates() {
+		// https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date
+		return !getVersion().atLeast(VERSION_5_7);
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -46,7 +46,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 
 	@Before
 	public void setUp() throws Exception {
-		if ( server.getVersion().equals("5.6") ) {
+		if ( server.getVersion().atLeast(server.VERSION_5_6) ) {
 			schemaSQL.add("CREATE TABLE shard_1.time_with_length (id int (11), dt2 datetime(3), ts2 timestamp(6), t2 time(6))");
 			schemaSQL.add("CREATE TABLE shard_1.without_col_length (badcol datetime(3))");
 		}
@@ -95,8 +95,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testTimeWithLengthCase() throws Exception {
-		if ( !server.getVersion().equals("5.6") )
-			return;
+		requireMinimumVersion(server.VERSION_5_6);
 
 		this.savedSchema.save(context.getMaxwellConnection());
 
@@ -151,8 +150,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testUpgradeAddColumnLength() throws Exception {
-		if ( !server.getVersion().equals("5.6") )
-			return;
+		requireMinimumVersion(server.VERSION_5_6);
 
 		Connection c = context.getMaxwellConnection();
 		this.savedSchema.save(c);
@@ -167,8 +165,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testUpgradeAddColumnLengthForExistingSchemas() throws Exception {
-		if ( !server.getVersion().equals("5.6") )
-			return;
+		requireMinimumVersion(server.VERSION_5_6);
 
 		Connection c = context.getMaxwellConnection();
 		this.savedSchema.save(c);

--- a/src/test/java/com/zendesk/maxwell/replication/MysqlVersionTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/MysqlVersionTest.java
@@ -1,0 +1,20 @@
+package com.zendesk.maxwell.replication;
+
+import com.zendesk.maxwell.TestWithNameLogging;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MysqlVersionTest extends TestWithNameLogging {
+	@Test
+	public void testVersionComparison() {
+		MysqlVersion version = new MysqlVersion(6, 5);
+		assertTrue(version.atLeast(6, 5));
+		assertTrue(version.atLeast(6, 4));
+		assertTrue(version.atLeast(5, 9));
+
+		assertFalse(version.atLeast(7, 2));
+		assertFalse(version.atLeast(6, 6));
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
@@ -42,7 +42,7 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 		Schema s = capturer.capture();
 		String dbs = StringUtils.join(s.getDatabaseNames().iterator(), ":");
 
-		if ( server.getVersion().equals("5.7") )
+		if ( server.getVersion().atLeast(server.VERSION_5_7) )
 			assertEquals("maxwell:mysql:shard_1:shard_2:sys:test", dbs);
 		else
 			assertEquals("maxwell:mysql:shard_1:shard_2:test", dbs);
@@ -93,7 +93,7 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 		assertThat(columns[1], instanceOf(IntColumnDef.class));
 		assertThat(((IntColumnDef) columns[1]).isSigned(), is(false));
 
-		if ( server.getVersion().equals("5.6") ) {
+		if ( server.getVersion().atLeast(server.VERSION_5_6) ) {
 			assertThat(columns[10].getName(), is("timestamp2_field"));
 			assertThat(columns[10], instanceOf(DateTimeColumnDef.class));
 			assertThat(((DateTimeColumnDef) columns[10]).getColumnLength(), is(3L));

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -81,13 +81,12 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testJSON() throws Exception {
-		if ( server.getVersion().equals("5.7") ) {
-			String sql[] = {
-				"create table shard_1.testJSON ( j json )",
-			};
+		requireMinimumVersion(server.VERSION_5_7);
+		String sql[] = {
+			"create table shard_1.testJSON ( j json )",
+		};
 
-			testIntegration(sql);
-		}
+		testIntegration(sql);
 	}
 
 	@Test
@@ -217,8 +216,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testTimeWithLength() throws Exception {
-		if ( !server.getVersion().equals("5.6") )
-			return;
+		requireMinimumVersion(server.VERSION_5_6);
 
 		String sql[] = {
 			"create TABLE `test_time` ( id time(3) )"
@@ -229,8 +227,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testDatetimeWithLength() throws Exception {
-		if ( !server.getVersion().equals("5.6") )
-			return;
+		requireMinimumVersion(server.VERSION_5_6);
 
 		String sql[] = {
 			"create TABLE `test_datetime` ( id datetime(3) )",
@@ -242,8 +239,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testTimestampWithLength() throws Exception {
-		if ( !server.getVersion().equals("5.6") )
-			return;
+		requireMinimumVersion(server.VERSION_5_6);
 
 		String sql[] = {
 			"create TABLE `test_year` ( id timestamp(3) )"
@@ -376,13 +372,12 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	@Category(Mysql57Tests.class)
 	public void testGeneratedColumns() throws Exception {
-		if ( server.getVersion().equals("5.7") ) {
-			testIntegration("create table t ("
-				+ "a INT GENERATED ALWAYS AS (0) VIRTUAL UNIQUE NOT NULL, "
-				+ "b int AS (a + 0) STORED PRIMARY KEY"
-				+ ")"
-			);
-		}
+		requireMinimumVersion(server.VERSION_5_7);
+		testIntegration("create table t ("
+			+ "a INT GENERATED ALWAYS AS (0) VIRTUAL UNIQUE NOT NULL, "
+			+ "b int AS (a + 0) STORED PRIMARY KEY"
+			+ ")"
+		);
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLSerializationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLSerializationTest.java
@@ -73,7 +73,7 @@ public class DDLSerializationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void TestCreateTableSerialization() throws Exception {
-		if ( server.getVersion().equals("5.6") )
+		if ( server.getVersion().equals(server.VERSION_5_6) )
 			TestDDLSerialization(MaxwellTestSupport.getSQLDir() + "/serialization/create_table_56");
 		else
 			TestDDLSerialization(MaxwellTestSupport.getSQLDir() + "/serialization/create_table");

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLSerializationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLSerializationTest.java
@@ -73,10 +73,10 @@ public class DDLSerializationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void TestCreateTableSerialization() throws Exception {
-		if ( server.getVersion().equals(server.VERSION_5_6) )
-			TestDDLSerialization(MaxwellTestSupport.getSQLDir() + "/serialization/create_table_56");
-		else
+		if ( server.getVersion().atLeast(server.VERSION_5_6) )
 			TestDDLSerialization(MaxwellTestSupport.getSQLDir() + "/serialization/create_table");
+		else
+			TestDDLSerialization(MaxwellTestSupport.getSQLDir() + "/serialization/create_table_55");
 	}
 
 	@Test

--- a/src/test/resources/sql/schema/sharded.sql
+++ b/src/test/resources/sql/schema/sharded.sql
@@ -9,6 +9,11 @@ CREATE TABLE `sharded` (
   `utf8_field` varchar(96) CHARACTER SET utf8 NOT NULL DEFAULT '',
   `float_field` float(5,2),
   `timestamp_field` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `timestamp2_field` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  `datetime2_field` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  -- Can't have a default time
+  -- See http://dev.mysql.com/doc/refman/5.6/en/timestamp-initialization.html
+  `time2_field` time(6),
   `decimal_field` decimal(12,7),
   PRIMARY KEY (`id`, `account_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/src/test/resources/sql/schema/sharded_55.sql
+++ b/src/test/resources/sql/schema/sharded_55.sql
@@ -9,11 +9,6 @@ CREATE TABLE `sharded` (
   `utf8_field` varchar(96) CHARACTER SET utf8 NOT NULL DEFAULT '',
   `float_field` float(5,2),
   `timestamp_field` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `timestamp2_field` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  `datetime2_field` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
-  -- Can't have a default time
-  -- See http://dev.mysql.com/doc/refman/5.6/en/timestamp-initialization.html
-  `time2_field` time(6),
   `decimal_field` decimal(12,7),
   PRIMARY KEY (`id`, `account_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/src/test/resources/sql/serialization/create_table
+++ b/src/test/resources/sql/serialization/create_table
@@ -36,6 +36,25 @@ CREATE table `ser1`.`tbl2` ( id int unsigned, `a` BIT, primary key (id, a));
     }
   }
 
+CREATE table `ser1`.`tbl3` ( id int, `dt` datetime(6), `ts` timestamp(3), `t` time(6), primary key (id));
+->{
+    type: "table-create",
+    database: "ser1",
+    table: "tbl3",
+    def: {
+      database: "ser1",
+      table: "tbl3",
+      columns: [
+        { name: "id", type: "int", signed: true },
+        { name: "dt", type: "datetime", column-length: 6 },
+        { name: "ts", type: "timestamp", column-length: 3 },
+        { name: "t", type: "time", column-length: 6 }
+      ],
+      primary-key: [ "id" ],
+      charset: "utf8"
+    }
+  }
+
 CREATE database `ser1like`;
 CREATE table `ser1like`.`tbllike` LIKE `ser1`.`tbl2`;
 ->{
@@ -53,4 +72,3 @@ CREATE table `ser1like`.`tbllike` LIKE `ser1`.`tbl2`;
       charset: "utf8"
     }
   }
-

--- a/src/test/resources/sql/serialization/create_table_55
+++ b/src/test/resources/sql/serialization/create_table_55
@@ -36,25 +36,6 @@ CREATE table `ser1`.`tbl2` ( id int unsigned, `a` BIT, primary key (id, a));
     }
   }
 
-CREATE table `ser1`.`tbl3` ( id int, `dt` datetime(6), `ts` timestamp(3), `t` time(6), primary key (id));
-->{
-    type: "table-create",
-    database: "ser1",
-    table: "tbl3",
-    def: {
-      database: "ser1",
-      table: "tbl3",
-      columns: [
-        { name: "id", type: "int", signed: true },
-        { name: "dt", type: "datetime", column-length: 6 },
-        { name: "ts", type: "timestamp", column-length: 3 },
-        { name: "t", type: "time", column-length: 6 }
-      ],
-      primary-key: [ "id" ],
-      charset: "utf8"
-    }
-  }
-
 CREATE database `ser1like`;
 CREATE table `ser1like`.`tbllike` LIKE `ser1`.`tbl2`;
 ->{
@@ -72,3 +53,4 @@ CREATE table `ser1like`.`tbllike` LIKE `ser1`.`tbl2`;
       charset: "utf8"
     }
   }
+


### PR DESCRIPTION
Before digging into date formatting, I wanted to clarify the logic behind tests that are specific to mysql versions (since a bunch of them relate to dates). Instead of checking against version strings (which can only do exact equality), I added a MysqlVersion class with an `atLeast` check so that tests run in version `x` and later, not just version `x`.