### PR TITLE
fix incorrect division / modulus operations on negative (pre-epoch) dates

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -22,7 +22,7 @@ public class DateTimeColumnDef extends ColumnDefWithLength {
 
 	protected String formatValue(Object value) {
 		Timestamp ts = DateFormatter.extractTimestamp(value);
-		String dateString = DateFormatter.formatDateTime(value);
+		String dateString = DateFormatter.formatDateTime(value, ts);
 		if ( dateString == null )
 			return null;
 		else

--- a/src/test/resources/sql/json/test_time
+++ b/src/test/resources/sql/json/test_time
@@ -6,5 +6,10 @@ set global time_zone = '-0:00';
 CREATE TABLE tt ( t time(6), small_t time(3), dt datetime(6), small_dt datetime(3), ts timestamp(4) NULL );
 
 insert into tt set t = '12:23:33.123456', small_t = '12:23:33.345', dt = '2012-01-01 22:32:34.222222', small_dt = '2012-01-01 22:32:34.123', ts = '2012-01-01 22:32:34.1234';
-
 -> { "database": "timedb", "table": "tt", "type": "insert", "data": {"t": "12:23:33.123456", "small_t": "12:23:33.345", "dt": "2012-01-01 22:32:34.222222", "small_dt": "2012-01-01 22:32:34.123", "ts": "2012-01-01 22:32:34.1234" } }
+
+insert into tt (dt) values('2000-01-01 01:00:00.999999');
+-> { "database": "timedb", "table": "tt", "type": "insert", "data": {"t": null, "small_t": null, "dt": "2000-01-01 01:00:00.999999", "small_dt": null, "ts": null } }
+
+insert into tt (dt) values('1950-01-01 01:00:00.999999');
+-> { "database": "timedb", "table": "tt", "type": "insert", "data": {"t": null, "small_t": null, "dt": "1950-01-01 01:00:00.999999", "small_dt": null, "ts": null } }


### PR DESCRIPTION
> DATETIMEs prior to 1970 that have a fractional seconds part cause a crash.

Reported in https://github.com/zendesk/maxwell/issues/681

Java's truncation and modulus operations for negative numbers are mechanical, they don't quite match mathematics when dealing with negative numbers. This causes bounds errors and then rounding errors, fixed by using (backported versions of) `java.Math.{floorDiv,floorMod}` from java 8 instead of the native operators.

/cc @zendesk/goanna 
