### PR TITLE
RowMap minor fixes, optimizations and test cases

### DIFF
--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -97,7 +97,7 @@ public class RowMap implements Serializable {
 		g.writeStringField("database", database);
 		g.writeStringField("table", table);
 
-		if (pkColumns == null || pkColumns.isEmpty()) {
+		if (pkColumns.isEmpty()) {
 			g.writeStringField("_uuid", UUID.randomUUID().toString());
 		} else {
 			for (String pk : pkColumns) {

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -97,7 +97,7 @@ public class RowMap implements Serializable {
 		g.writeStringField("database", database);
 		g.writeStringField("table", table);
 
-		if (pkColumns.isEmpty()) {
+		if (pkColumns == null || pkColumns.isEmpty()) {
 			g.writeStringField("_uuid", UUID.randomUUID().toString());
 		} else {
 			for (String pk : pkColumns) {
@@ -141,31 +141,31 @@ public class RowMap implements Serializable {
 		if (pkColumns.isEmpty()) {
 			return database + table;
 		}
-		String keys="";
+		StringBuilder keys = new StringBuilder();
 		for (String pk : pkColumns) {
 			Object pkValue = null;
 			if (data.containsKey(pk))
 				pkValue = data.get(pk);
 			if (pkValue != null)
-				keys += pkValue.toString();
+				keys.append(pkValue.toString());
 		}
-		if (keys.isEmpty())
+		if (keys.length() == 0)
 			return "None";
-		return keys;
+		return keys.toString();
 	}
 
 	public String buildPartitionKey(List<String> partitionColumns, String partitionKeyFallback) {
-		String partitionKey="";
+		StringBuilder partitionKey= new StringBuilder();
 		for (String pc : partitionColumns) {
 			Object pcValue = null;
 			if (data.containsKey(pc))
 				pcValue = data.get(pc);
 			if (pcValue != null)
-				partitionKey += pcValue.toString();
+				partitionKey.append(pcValue.toString());
 		}
-		if (partitionKey.isEmpty())
+		if (partitionKey.length() == 0)
 			return getPartitionKeyFallback(partitionKeyFallback);
-		return partitionKey;
+		return partitionKey.toString();
 	}
 
 	private String getPartitionKeyFallback(String partitionKeyFallback) {

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -1,14 +1,15 @@
 package com.zendesk.maxwell.row;
 
 import com.zendesk.maxwell.MaxwellTestJSON;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.regex.Pattern;
 
 public class RowMapTest {
 	@Test
@@ -54,5 +55,199 @@ public class RowMapTest {
 
 		int ts = (int) output.get("ts");
 		Assert.assertEquals(ts, timestampSeconds);
+	}
+
+	@Test
+	public void testPkToJsonHash() throws IOException {
+
+		long timestampMillis = 1496712943447L;
+
+		List<String> pKeys = new ArrayList<>();
+
+		pKeys.add("id");
+
+		pKeys.add("name");
+
+		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", timestampMillis, pKeys, position);
+
+		rowMap.putData("id", "9001");
+		rowMap.putData("name", "example");
+
+		String jsonString = rowMap.pkToJson(RowMap.KeyFormat.HASH);
+
+		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"pk.id\":\"9001\",\"pk.name\":\"example\"}",
+				jsonString);
+
+
+	}
+
+
+	@Test
+	public void testPkToJsonHashWithEmptyData() throws Exception {
+
+		long timestampMillis = 1496712943447L;
+
+		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", timestampMillis, null, position);
+
+
+		String jsonString = rowMap.pkToJson(RowMap.KeyFormat.HASH);
+
+		Map<String, Object> jsonMap = MaxwellTestJSON.parseJSON(jsonString);
+
+		Assert.assertTrue(jsonMap.containsKey("_uuid"));
+		Assert.assertEquals("MyDatabase", jsonMap.get("database"));
+		Assert.assertEquals("MyTable", jsonMap.get("table"));
+
+
+	}
+
+	@Test
+	public void testPkToJsonArray() throws IOException {
+
+		long timestampMillis = 1496712943447L;
+
+		List<String> pKeys = new ArrayList<>();
+
+		pKeys.add("id");
+
+		pKeys.add("name");
+
+		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", timestampMillis, pKeys, position);
+
+		rowMap.putData("id", "9001");
+		rowMap.putData("name", "example");
+
+		String jsonString = rowMap.pkToJson(RowMap.KeyFormat.ARRAY);
+
+		Assert.assertEquals("[\"MyDatabase\",\"MyTable\",[{\"id\":\"9001\"},{\"name\":\"example\"}]]",
+				jsonString);
+
+
+	}
+
+	@Test
+	public void testBuildPartitionKey() {
+		long timestampMillis = 1496712943447L;
+
+		List<String> pKeys = new ArrayList<>();
+
+		pKeys.add("id");
+
+		pKeys.add("first_name");
+
+		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", timestampMillis, pKeys, position);
+
+		rowMap.putData("id", "9001");
+		rowMap.putData("first_name", "foo");
+		rowMap.putData("middle_name", "buzz");
+		rowMap.putData("last_name", "bar");
+		rowMap.putData("salary", "4000");
+		rowMap.putData("department", "science");
+
+		List<String> partitionColumns = Arrays.asList("id", "first_name", "middle_name", "last_name", "salary", "department");
+
+		String partitionKey = rowMap.buildPartitionKey(partitionColumns, "primary_key");
+
+		Assert.assertEquals("9001foobuzzbar4000science", partitionKey);
+
+	}
+
+	@Test
+	public void testBuildPartitionKeyWithEmptyList() {
+		long timestampMillis = 1496712943447L;
+
+		List<String> pKeys = new ArrayList<>();
+
+		pKeys.add("id");
+
+		pKeys.add("first_name");
+
+		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", timestampMillis, pKeys, position);
+
+		rowMap.putData("id", "9001");
+		rowMap.putData("first_name", "foo");
+		rowMap.putData("middle_name", "buzz");
+		rowMap.putData("last_name", "bar");
+		rowMap.putData("salary", "4000");
+		rowMap.putData("department", "science");
+
+		List<String> partitionColumns = new ArrayList<>();
+
+		String partitionKey = rowMap.buildPartitionKey(partitionColumns, "primary_key");
+
+		Assert.assertEquals("9001foo", partitionKey);
+
+	}
+
+	@Test
+	public void testToJSONWithRawJSONData() throws IOException {
+		long timestampMillis = 1496712943487L;
+
+		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", timestampMillis,
+				null, position);
+
+		rowMap.putData("id", "9001");
+		rowMap.putData("first_name", "foo");
+		rowMap.putData("middle_name", "buzz");
+		rowMap.putData("last_name", "bar");
+		rowMap.putData("salary", "4000");
+		rowMap.putData("department", "science");
+        rowMap.putData("rawJSON", new RawJSONString("{\"database\":\"MyDatabase\",\"table\":\"User\",\"type\":\"insert\",\"ts\":1486439516,\"xid\":5694,\"commit\":true,\"data\":{\"UserID\":20,\"FirstName\":\"Fiz\",\"MiddleName\":null,\"LastName\":\"Buz\",\"Version\":1486703131000}}\n"));
+		MaxwellOutputConfig outputConfig = getMaxwellOutputConfig();
+
+		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"type\":\"insert\",\"ts\":1496712943,\"position\":\"binlog-0001:1\",\"gtid\":null,\"data\":{\"id\":\"9001\",\"salary\":\"4000\",\"department\":\"science\",\"rawJSON\":{\"database\":\"MyDatabase\",\"table\":\"User\",\"type\":\"insert\",\"ts\":1486439516,\"xid\":5694,\"commit\":true,\"data\":{\"UserID\":20,\"FirstName\":\"Fiz\",\"MiddleName\":null,\"LastName\":\"Buz\",\"Version\":1486703131000}}\n" +
+				"}}", rowMap.toJSON(outputConfig));
+	}
+
+	@Test
+	public void testToJSONWithListData() throws IOException {
+		long timestampMillis = 1496712943487L;
+
+		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", timestampMillis,
+				null, position);
+
+		rowMap.putData("id", "9001");
+		rowMap.putData("first_name", "foo");
+		rowMap.putData("middle_name", "buzz");
+		rowMap.putData("last_name", "bar");
+		rowMap.putData("salary", "4000");
+		rowMap.putData("department", "science");
+		rowMap.putData("interests", Arrays.asList("classical music", "hiking", "biking", "programming"));
+		MaxwellOutputConfig outputConfig = getMaxwellOutputConfig();
+
+		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"type\":\"insert\",\"ts\":1496712943,\"position\":\"binlog-0001:1\",\"gtid\":null,\"data\":{\"id\":\"9001\",\"salary\":\"4000\",\"department\":\"science\",\"interests\":[\"classical music\",\"hiking\",\"biking\",\"programming\"]}}", rowMap.toJSON(outputConfig));
+	}
+
+	private MaxwellOutputConfig getMaxwellOutputConfig() {
+		MaxwellOutputConfig outputConfig = new MaxwellOutputConfig();
+
+
+
+		List<Pattern> patterns = new ArrayList<>();
+		Pattern pattern = Pattern.compile("^.*name.*$");
+		patterns.add(pattern);
+
+		outputConfig.includesBinlogPosition = true;
+		outputConfig.includesCommitInfo = true;
+		outputConfig.includesGtidPosition = true;
+		outputConfig.includesServerId = true;
+		outputConfig.includesThreadId = true;
+		outputConfig.includesNulls = true;
+		outputConfig.excludeColumns = patterns;
+
+		return outputConfig;
+
 	}
 }


### PR DESCRIPTION
- Added a null check for pkColumns. I felt this was required as pkColumns was being passed as null in other RowMap test cases. Thus, we must account for the possibility of null values of pkColumns. In the current code passing a null pkColumn value will result in a NullpointerException when calling pkToJsonHash() method.

- Convert String concatenation operation to append operation of StringBuilder. String concatenation would be a huge overhead, especially in loops.

- I've written JUnit test cases for the code around these changes. 