### PR TITLE
Bugfix, Filter fails to parse alter database when "exclude_tables" option is enabled

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -95,6 +95,9 @@ public class MaxwellFilter {
 	}
 
 	private boolean filterListsInclude(List<Pattern> includeList, List<Pattern> excludeList, String name) {
+		if ( name == null ) {
+			return false;
+		}
 		if ( includeList.size() > 0 ) {
 			boolean found = false;
 			for ( Pattern p : includeList ) {


### PR DESCRIPTION
Fixed NPE when com.zendesk.maxwell.schema.ddl.ResolvedSchemaChange.shouldOutput is invoked.