### PR TITLE
Remove JQuery from markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,3 @@ advanced features:
     "old":  {"daemon": "Stanislaw Lem"}
   }
 ```
-
-
-
-<script>
-  jQuery(document).ready(function () {
-    jQuery("#maxwell-header").append(
-      jQuery("<img alt='The Daemon, maybe' src='./img/cyberiad_1.jpg' id='maxwell-daemon-image'>")
-    );
-    jQuery("pre").addClass("home-code");
-  });
-</script>
-

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -184,13 +184,13 @@ blacklist_tables               | PATTERN                             | ignore up
 &nbsp;
 **monitoring**
 metrics_prefix | STRING | the prefix maxwell will apply to all metrics | MaxwellMetrics
-metrics_type         | [slf4j &#124; jmx &#124; http &#124; datadog]      | how maxwell metrics will be reported, at least one of slf4j &#124; jmx &#124; http &#124; datadog| 
+metrics_type         | [slf4j &#124; jmx &#124; http &#124; datadog]      | how maxwell metrics will be reported, at least one of slf4j &#124; jmx &#124; http &#124; datadog|
 metrics_slf4j_interval     | INT                                 | the frequency metrics are emitted to the log, in seconds, when slf4j reporting is configured | 60
 metrics_http_port         | INT                                 | the port the server will bind to when http reporting is configured | 8080
 metrics_datadog_type | [udp &#124; http] | when metrics_type includes `datadog` this is the way metrics will be reported, can only be one of [udp &#124; http] | udp
-metrics_datadog_tags | STRING | datadog tags that should be supplied, e.g. tag1:value1,tag2:value2 | 
+metrics_datadog_tags | STRING | datadog tags that should be supplied, e.g. tag1:value1,tag2:value2 |
 metrics_datadog_interval | INT | the frequency metrics are pushed to datadog, in seconds | 60
-metrics_datadog_apikey | STRING | the datadog api key to use when metrics_datadog_type = `http` | 
+metrics_datadog_apikey | STRING | the datadog api key to use when metrics_datadog_type = `http` |
 metrics_datadog_host | STRING | the host to publish metrics to when metrics_datadog_type = `udp` | localhost
 metrics_datadog_port | INT | the port to publish metrics to when metrics_datadog_type = `udp` | 8125
 &nbsp;
@@ -198,11 +198,3 @@ metrics_datadog_port | INT | the port to publish metrics to when metrics_datadog
 bootstrapper                   | [async &#124; sync &#124; none]                   | bootstrapper type.  See bootstrapping docs.        | async
 init_position                  | FILE:POSITION:HEARTBEAT             | ignore the information in maxwell.positions and start at the given binlog position. Not available in config.properties. |
 replay                         | BOOLEAN                             | enable maxwell's read-only "replay" mode: don't store a binlog position or schema changes.  Not available in config.properties. |
-
-
-<script>
-  jQuery(document).ready(function () {
-    jQuery("table").addClass("table table-condensed table-bordered table-hover");
-  });
-</script>
-

--- a/docs/docs/dataformat.md
+++ b/docs/docs/dataformat.md
@@ -305,51 +305,44 @@ mysql>   insert into test_sets set setcol = 'b_val,c_val';
 Maxwell will accept a variety of character encodings, but will always output UTF-8 strings.  The following table
 describes support for mysql's character sets:
 
-charset  | status
----------| ------
-utf8     | supported
-utf8mb4  | supported
-latin1   | supported
-latin2   | supported
-ascii    | supported
-ucs2     | supported
-binary   | supported (as base64)
-utf16    | supported, not tested in production
-utf32    | supported, not tested in production
-big5     | supported, not tested in production
-cp850    | supported, not tested in production
-sjis     | supported, not tested in production
-hebrew   | supported, not tested in production
-tis620   | supported, not tested in production
-euckr    | supported, not tested in production
-gb2312   | supported, not tested in production
-greek    | supported, not tested in production
-cp1250   | supported, not tested in production
-gbk      | supported, not tested in production
-latin5   | supported, not tested in production
-macroman | supported, not tested in production
-cp852    | supported, not tested in production
-cp1251   | supported, not tested in production
-cp866    | supported, not tested in production
-cp1256   | supported, not tested in production
-cp1257   | supported, not tested in production
-dec8     | unsupported
-hp8      | unsupported
-koi8r    | unsupported
-swe7     | unsupported
-ujis     | unsupported
-koi8u    | unsupported
-armscii8 | unsupported
-keybcs2  | unsupported
-macce    | unsupported
-latin7   | unsupported
-geostd8  | unsupported
-cp932    | unsupported
-eucjpms  | unsupported
-
-
-<script>
-  jQuery(document).ready(function () {
-    jQuery("table").addClass("table table-condensed table-bordered table-hover");
-  });
-</script>
+| charset  | status                              |
+|:---------|:------------------------------------|
+| utf8     | supported                           |
+| utf8mb4  | supported                           |
+| latin1   | supported                           |
+| latin2   | supported                           |
+| ascii    | supported                           |
+| ucs2     | supported                           |
+| binary   | supported (as base64)               |
+| utf16    | supported, not tested in production |
+| utf32    | supported, not tested in production |
+| big5     | supported, not tested in production |
+| cp850    | supported, not tested in production |
+| sjis     | supported, not tested in production |
+| hebrew   | supported, not tested in production |
+| tis620   | supported, not tested in production |
+| euckr    | supported, not tested in production |
+| gb2312   | supported, not tested in production |
+| greek    | supported, not tested in production |
+| cp1250   | supported, not tested in production |
+| gbk      | supported, not tested in production |
+| latin5   | supported, not tested in production |
+| macroman | supported, not tested in production |
+| cp852    | supported, not tested in production |
+| cp1251   | supported, not tested in production |
+| cp866    | supported, not tested in production |
+| cp1256   | supported, not tested in production |
+| cp1257   | supported, not tested in production |
+| dec8     | unsupported                         |
+| hp8      | unsupported                         |
+| koi8r    | unsupported                         |
+| swe7     | unsupported                         |
+| ujis     | unsupported                         |
+| koi8u    | unsupported                         |
+| armscii8 | unsupported                         |
+| keybcs2  | unsupported                         |
+| macce    | unsupported                         |
+| latin7   | unsupported                         |
+| geostd8  | unsupported                         |
+| cp932    | unsupported                         |
+| eucjpms  | unsupported                         |

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -27,11 +27,11 @@ metric                         | description
 ### HTTP Endpoints
 When the HTTP server is enabled the following endpoints are exposed:
 
-endpoint                       | description
--------------------------------|-------------
-`/metrics`                     | return all metrics as JSON
-`/healthcheck`                 | run Maxwell's healthcheck(s) and return success or failure based on the result
-`/ping`                        | a simple ping test, responds with `pong`
+| endpoint       | description                                                                    |
+|:---------------|:-------------------------------------------------------------------------------|
+| `/metrics`     | return all metrics as JSON                                                     |
+| `/healthcheck` | run Maxwell's healthcheck(s) and return success or failure based on the result |
+| `/ping`        | a simple ping test, responds with `pong`                                       |
 
 ### Healthcheck
 The `/healthcheck` endpoint will return unhealthy when there is more than 1 message that failed to be sent to Kafka in the past 15 minutes.
@@ -51,12 +51,3 @@ export JAVA_OPTS="-Dcom.sun.management.jmxremote \
 -Dcom.sun.management.jmxremote.ssl=false \
 -Djava.rmi.server.hostname=SERVER_IP_ADDRESS"
 ```
-
-
-
-<script>
-  jQuery(document).ready(function () {
-    jQuery("table").addClass("table table-condensed table-bordered table-hover");
-  });
-</script>
-

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -117,10 +117,3 @@ Set the output stream in `config.properties` by setting the `kinesis_stream` pro
 The producer uses the [KPL (Kinesis Producer Library](http://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-kpl.html) and uses the KPL built in configurations.
 Copy `kinesis-producer-library.properties.example` to `kinesis-producer-library.properties` and configure the properties file to your needs.
 The most important option here is configuring the region.
-
-<script>
-  jQuery(document).ready(function () {
-    jQuery("table").addClass("table table-condensed table-bordered table-hover");
-  });
-</script>
-


### PR DESCRIPTION
There was some JQuery code showing in some of the markdown files.  I also reformatted some of the tables in the documentation.  