### PR TITLE
cleanup old recovery infos before maxwell starts repliction

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -81,8 +81,6 @@ public class Maxwell implements Runnable {
 				);
 
 				oldServerSchemaStore.clone(context.getServerID(), recoveredPosition);
-
-				positionStore.delete(recoveryInfo.serverID, recoveryInfo.clientID, recoveryInfo.position);
 			}
 		}
 		return recoveredPosition;
@@ -105,12 +103,11 @@ public class Maxwell implements Runnable {
 				}
 			}
 
-			if (initial != null) {
-				/* if the initial position didn't come from the store, store it */
-				context.getPositionStore().set(initial);
-			}
+			/* if the initial position didn't come from the store, store it */
+			context.getPositionStore().set(initial);
 		}
 
+		this.context.getPositionStore().cleanupOldPositions();
 		return initial;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -107,7 +107,10 @@ public class Maxwell implements Runnable {
 			context.getPositionStore().set(initial);
 		}
 
-		this.context.getPositionStore().cleanupOldPositions();
+		if (config.masterRecovery) {
+			this.context.getPositionStore().cleanupOldRecoveryInfos();
+		}
+
 		return initial;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -251,14 +251,19 @@ public class MysqlPositionStore {
 		return result;
 	}
 
-	public void cleanupOldPositions() throws SQLException {
-		try ( Connection c = connectionPool.getConnection()) {
-			PreparedStatement s = c.prepareStatement(
-				"DELETE FROM `positions` WHERE server_id <> ? AND client_id = ?"
-			);
-			s.setLong(1, serverID);
-			s.setString(2, clientID);
-			s.execute();
+	public void cleanupOldRecoveryInfos() throws SQLException {
+		List<RecoveryInfo> allRecoveryInfos = getAllRecoveryInfos();
+		if (allRecoveryInfos.size() > 1) {
+			LOGGER.warn("Multiple recovery infos found: " + allRecoveryInfos);
+			LOGGER.warn("Cleaning up the old recovery infos");
+			try (Connection c = connectionPool.getConnection()) {
+				PreparedStatement s = c.prepareStatement(
+					"DELETE FROM `positions` WHERE server_id <> ? AND client_id = ?"
+				);
+				s.setLong(1, serverID);
+				s.setString(2, clientID);
+				s.execute();
+			}
 		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -246,23 +246,19 @@ public class MysqlPositionStore {
 
 		result.add("Most likely the first is the most recent master, in which case you should:");
 		result.add("1. stop maxwell");
-		result.add("2. execute: DELETE FROM " + config.databaseName + ".positions WHERE server_id <> " + mostRecentMaster + ";");
+		result.add("2. execute: DELETE FROM " + config.databaseName + ".positions WHERE server_id <> " + mostRecentMaster + " AND client_id = '<your_client_id>';");
 		result.add("3. restart maxwell");
 		return result;
 	}
 
-	public int delete(Long serverID, String clientID, Position position) throws SQLException {
+	public void cleanupOldPositions() throws SQLException {
 		try ( Connection c = connectionPool.getConnection()) {
 			PreparedStatement s = c.prepareStatement(
-				"DELETE from `positions` where server_id = ? and client_id = ? and binlog_file = ? and binlog_position = ?"
+				"DELETE FROM `positions` WHERE server_id <> ? AND client_id = ?"
 			);
-			BinlogPosition binlogPosition = position.getBinlogPosition();
 			s.setLong(1, serverID);
 			s.setString(2, clientID);
-			s.setString(3, binlogPosition.getFile());
-			s.setLong(4, binlogPosition.getOffset());
 			s.execute();
-			return s.getUpdateCount();
 		}
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
@@ -135,7 +135,12 @@ public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
-	public void testCleanupOldPositions() throws Exception {
+	public void testCleanupOldRecoveryInfos() throws Exception {
+		if (MaxwellTestSupport.inGtidMode()) {
+			// gtid mode can't get into a multiple recovery state
+			return;
+		}
+
 		MaxwellContext context = buildContext();
 		Long activeServerID = context.getServerID();
 		Long oldServerID1 = activeServerID + 1;

--- a/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
@@ -150,7 +150,7 @@ public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 		testStore.set(new Position(new BinlogPosition(0L, binlogFile), 3L));
 
 		assertEquals(3, testStore.getAllRecoveryInfos().size());
-		testStore.cleanupOldPositions();
+		testStore.cleanupOldRecoveryInfos();
 		assertEquals(1, testStore.getAllRecoveryInfos().size());
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/MysqlPositionStoreTest.java
@@ -29,6 +29,10 @@ public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 		return new MysqlPositionStore(context.getMaxwellConnectionPool(), serverID, "maxwell", MaxwellTestSupport.inGtidMode());
 	}
 
+	private MysqlPositionStore buildStore(MaxwellContext context, Long serverID, String clientId) throws Exception {
+		return new MysqlPositionStore(context.getMaxwellConnectionPool(), serverID, clientId, MaxwellTestSupport.inGtidMode());
+	}
+
 	@Test
 	public void testSetBinlogPosition() throws Exception {
 		MysqlPositionStore store = buildStore();
@@ -127,6 +131,26 @@ public class MysqlPositionStoreTest extends MaxwellTestWithIsolatedServer {
 		for (RecoveryInfo recovery: recoveries) {
 			assertThat(errorMessage, containsString(" - " + recovery));
 		}
-		assertThat(errorMessage, containsString("execute: DELETE FROM maxwell.positions WHERE server_id <> " + newestServerID + ";"));
+		assertThat(errorMessage, containsString("execute: DELETE FROM maxwell.positions WHERE server_id <> " + newestServerID + " AND client_id = '<your_client_id>';"));
+	}
+
+	@Test
+	public void testCleanupOldPositions() throws Exception {
+		MaxwellContext context = buildContext();
+		Long activeServerID = context.getServerID();
+		Long oldServerID1 = activeServerID + 1;
+		Long oldServerID2 = activeServerID + 2;
+
+		String binlogFile = "bin.log";
+		String clientId = "client-123";
+
+		buildStore(context, oldServerID1, clientId).set(new Position(new BinlogPosition(0L, binlogFile), 1L));
+		buildStore(context, oldServerID2, clientId).set(new Position(new BinlogPosition(0L, binlogFile), 2L));
+		MysqlPositionStore testStore = buildStore(context, activeServerID, clientId);
+		testStore.set(new Position(new BinlogPosition(0L, binlogFile), 3L));
+
+		assertEquals(3, testStore.getAllRecoveryInfos().size());
+		testStore.cleanupOldPositions();
+		assertEquals(1, testStore.getAllRecoveryInfos().size());
 	}
 }


### PR DESCRIPTION

### Description

We can only have one recovery info per client id when `masterRecovery` is enabled to prevent pollution of start position when failing over to the previous server. 

/cc @timbertson @ericwush 

