### PR TITLE
Fix EOFException on empty JSON column operations

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
@@ -20,7 +20,8 @@ public class JsonColumnDef extends ColumnDef {
 	@Override
 	public Object asJSON(Object value) {
 		try {
-			String jsonString = JsonBinary.parseAsString((byte[]) value);
+			byte[] bytes = (byte[]) value;
+			String jsonString = bytes.length > 0 ? JsonBinary.parseAsString(bytes) : "null";
 			return new RawJSONString(jsonString);
 		} catch (IOException e) {
 			throw new RuntimeException(e);

--- a/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
@@ -14,6 +14,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import com.zendesk.maxwell.TestWithNameLogging;
+import com.zendesk.maxwell.row.RawJSONString;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -119,11 +120,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 
 	@Test
 	public void TestAsciiString() {
-		byte input[] = new byte[4];
-		input[0] = Byte.valueOf((byte) 126);
-		input[1] = Byte.valueOf((byte) 126);
-		input[2] = Byte.valueOf((byte) 126);
-		input[3] = Byte.valueOf((byte) 126);
+		byte input[] = new byte[] { (byte) 126, (byte) 126, (byte) 126, (byte) 126 };
 
 		ColumnDef d = ColumnDef.build("bar", "ascii", "varchar", 1, false, null, null);
 		assertThat((String) d.asJSON(input), is("~~~~"));
@@ -131,15 +128,32 @@ public class ColumnDefTest extends TestWithNameLogging {
 
 	@Test
 	public void TestStringAsJSON() {
-		byte input[] = new byte[4];
-		input[0] = Byte.valueOf((byte) 169);
-		input[1] = Byte.valueOf((byte) 169);
-		input[2] = Byte.valueOf((byte) 169);
-		input[3] = Byte.valueOf((byte) 169);
+		byte input[] = new byte[] { (byte) 169, (byte) 169, (byte) 169, (byte) 169 };
 
 		ColumnDef d = ColumnDef.build("bar", "latin1", "varchar", 1, false, null, null);
 
 		assertThat((String) d.asJSON(input), is("©©©©"));
+	}
+
+	@Test
+	public void TestJSON() {
+		byte input[] = new byte[] { (byte) 0, (byte) 1, (byte) 0, (byte) 13, (byte) 0, (byte) 11,
+				(byte) 0, (byte) 2, (byte) 0, (byte) 5, (byte) 3, (byte) 0, (byte) 105, (byte) 100 };
+
+		ColumnDef d = ColumnDef.build("bar", "ascii", "json", 1, false, null, null);
+
+		RawJSONString result = (RawJSONString) d.asJSON(input);
+		assertThat(result.json, is("{\"id\":3}"));
+	}
+
+	@Test
+	public void TestEmptyJSON() {
+		byte input[] = new byte[0];
+
+		ColumnDef d = ColumnDef.build("bar", "ascii", "json", 1, false, null, null);
+
+		RawJSONString result = (RawJSONString) d.asJSON(input);
+		assertThat(result.json, is("null"));
 	}
 
 	@Test


### PR DESCRIPTION
@zendesk/goanna 
Fix is based on scenario described in #722 regarding returning `null` for empty JSON column value.

`INSERT INTO test_table (props) VALUES (null);` -> `{"database":"A","table":"test_table","type":"insert","ts":1502241788,"xid":1435,"commit":true,"data":{"id":9,"props":null}}`

`INSERT INTO test_table () VALUES ();` -> 
`{"database":"A","table":"test_table","type":"insert","ts":1502241791,"xid":1442,"commit":true,"data":{"id":10,"props":null}}`