### PR TITLE
added setSSLMode for JDBC options passed into BinlogConnectorReplicator

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -7,6 +7,7 @@ import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.QueryEventData;
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.network.SSLMode;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.MaxwellMysqlConfig;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
@@ -63,6 +64,13 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 			LOGGER.info("Setting initial binlog pos to: " + startBinlog.getFile() + ":" + startBinlog.getOffset());
 			this.client.setBinlogFilename(startBinlog.getFile());
 			this.client.setBinlogPosition(startBinlog.getOffset());
+		}
+
+		if (mysqlConfig.jdbcOptions.contains("verifyServerCertificate=true")) {
+			this.client.setSSLMode(SSLMode.VERIFY_CA);
+		}
+		else if (mysqlConfig.jdbcOptions.contains("requireSSL=true")) {
+			this.client.setSSLMode(SSLMode.REQUIRED);
 		}
 
 		EventDeserializer eventDeserializer = new EventDeserializer();


### PR DESCRIPTION
Added setSSLMode for JDBC options passed into BinlogConnectorReplicator to allow SSL in mysql-binlog-connector-java.

This will resolve #738.