### PR TITLE
report lag metrics only on commits events

### DIFF
--- a/src/main/java/com/zendesk/maxwell/metrics/MaxwellMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/metrics/MaxwellMetrics.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.metrics;
 
 import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheckRegistry;
@@ -124,6 +125,11 @@ public class MaxwellMetrics implements Metrics {
 	@Override
 	public MetricRegistry getRegistry() {
 		return metricRegistry;
+	}
+
+	@Override
+	public <T extends Metric> void register(String name, T metric) throws IllegalArgumentException {
+		metricRegistry.register(name, metric);
 	}
 
 	public void startBackgroundTasks(MaxwellContext context) throws IOException {

--- a/src/main/java/com/zendesk/maxwell/metrics/Metrics.java
+++ b/src/main/java/com/zendesk/maxwell/metrics/Metrics.java
@@ -1,10 +1,12 @@
 package com.zendesk.maxwell.metrics;
 
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.zendesk.maxwell.MaxwellContext;
 
 public interface Metrics {
 	String metricName(String... names);
 	MetricRegistry getRegistry();
+	<T extends Metric> void register(String name, T metric) throws IllegalArgumentException;
 }
 

--- a/src/main/java/com/zendesk/maxwell/metrics/NoOpMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/metrics/NoOpMetrics.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.metrics;
 
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 
@@ -18,5 +19,9 @@ public class NoOpMetrics implements Metrics {
 
 	public MetricRegistry getRegistry() {
 		return metricRegistry;
+	}
+
+	@Override
+	public <T extends Metric> void register(String name, T metric) throws IllegalArgumentException {
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -61,7 +61,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 		MetricRegistry metricRegistry = metrics.getRegistry();
 
 		String gaugeName = metrics.metricName("inflightmessages", "count");
-		metricRegistry.register(
+		metrics.register(
 			gaugeName,
 			new Gauge<Long>() {
 				@Override

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -33,7 +33,6 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 
 	private final Counter rowCounter;
 	private final Meter rowMeter;
-	private Long replicationLag = 0L;
 
 	public AbstractReplicator(
 		String clientID,
@@ -49,18 +48,6 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 		this.producer = producer;
 		this.lastHeartbeatPosition = initialPosition;
 
-		final AbstractReplicator self = this;
-
-		String lagGaugeName = metrics.metricName("replication", "lag");
-		metrics.getRegistry().register(
-			lagGaugeName,
-			new Gauge<Long>() {
-				@Override
-				public Long getValue() {
-					return self.replicationLag;
-				}
-			}
-		);
 		rowCounter = metrics.getRegistry().counter(
 			metrics.metricName("row", "count")
 		);
@@ -161,7 +148,6 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 
 		rowCounter.inc();
 		rowMeter.mark();
-		replicationLag = System.currentTimeMillis() - row.getTimestampMillis();
 
 		processRow(row);
 	}

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
@@ -86,6 +86,8 @@ public class BinlogConnectorEvent {
 		if (eventType == EventType.XID) {
 			return true;
 		} else if (eventType == EventType.QUERY) {
+			// MyISAM will output a "COMMIT" QUERY_EVENT instead of a XID_EVENT.
+			// There's no transaction ID but we can still set "commit: true"
 			return COMMIT.equals(queryData().getSql());
 		}
 

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
@@ -9,6 +9,9 @@ import java.io.Serializable;
 import java.util.*;
 
 public class BinlogConnectorEvent {
+	public static final String BEGIN = "BEGIN";
+	public static final String COMMIT = "COMMIT";
+	public static final String SAVEPOINT = "SAVEPOINT";
 	private BinlogPosition position;
 	private BinlogPosition nextPosition;
 	private final Event event;
@@ -76,6 +79,17 @@ public class BinlogConnectorEvent {
 				return ((TableMapEventData) data).getTableId();
 		}
 		return null;
+	}
+
+	public boolean isCommitEvent() {
+		EventType eventType = getType();
+		if (eventType == EventType.XID) {
+			return true;
+		} else if (eventType == EventType.QUERY) {
+			return COMMIT.equals(queryData().getSql());
+		}
+
+		return false;
 	}
 
 	private void writeData(Table table, RowMap row, Serializable[] data, BitSet includedColumns) {

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
@@ -23,6 +23,7 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener,
 	protected final AtomicBoolean mustStop = new AtomicBoolean(false);
 	private final BinaryLogClient client;
 	private long replicationLag;
+	private String gtid;
 
 	public BinlogConnectorEventListener(
 		BinaryLogClient client,
@@ -50,7 +51,6 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener,
 
 	@Override
 	public void onEvent(Event event) {
-		String gtid = null;
 		long eventSeenAt = 0;
 		boolean trackMetrics = false;
 

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -1,21 +1,20 @@
 package com.zendesk.maxwell.replication;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Timer;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
-import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.QueryEventData;
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.MaxwellMysqlConfig;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
-import com.zendesk.maxwell.metrics.MaxwellMetrics;
 import com.zendesk.maxwell.metrics.Metrics;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMapBuffer;
-import com.zendesk.maxwell.schema.*;
+import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaStore;
+import com.zendesk.maxwell.schema.SchemaStoreException;
+import com.zendesk.maxwell.schema.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,10 +68,7 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 		eventDeserializer.setCompatibilityMode(EventDeserializer.CompatibilityMode.DATE_AND_TIME_AS_LONG_MICRO,
 			EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY);
 		this.client.setEventDeserializer(eventDeserializer);
-
-		Timer replicationQueueTimer = metrics.getRegistry().timer(metrics.metricName("replication", "queue", "time"));
-		Timer mysqlTxExecutionTimer = metrics.getRegistry().timer(metrics.metricName("mysql", "transaction", "execution", "time"));
-		this.binlogEventListener = new BinlogConnectorEventListener(client, queue, replicationQueueTimer, mysqlTxExecutionTimer);
+		this.binlogEventListener = new BinlogConnectorEventListener(client, queue, metrics);
 
 		this.client.setBlocking(!stopOnEOF);
 		this.client.registerEventListener(binlogEventListener);

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -51,6 +51,7 @@ public class ListWithDiskBuffer<T> {
 	public T getLast() {
 		return list.getLast();
 	}
+	public T getFirst() { return list.getFirst(); }
 
 	public T removeFirst(Class<T> clazz) throws IOException, ClassNotFoundException {
 		if ( elementsInFile > 0 ) {

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -51,7 +51,6 @@ public class ListWithDiskBuffer<T> {
 	public T getLast() {
 		return list.getLast();
 	}
-	public T getFirst() { return list.getFirst(); }
 
 	public T removeFirst(Class<T> clazz) throws IOException, ClassNotFoundException {
 		if ( elementsInFile > 0 ) {

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -190,7 +190,7 @@ public class MysqlIsolatedServer {
 
 	private String getVersionString() {
 		String mysqlVersion = System.getenv("MYSQL_VERSION");
-		return mysqlVersion == null ? "5.5" : mysqlVersion;
+		return mysqlVersion == null ? "5.6" : mysqlVersion;
 	}
 
 	public MysqlVersion getVersion() {


### PR DESCRIPTION

### Description

Only report lag on commit events as when MySQL is slow on transactions, the lag will be incorrect based on the timestamp of every event (row change).

Also measure the execution time internally instead of using the value in the header.

/cc @timbertson @ericwush 