### PR TITLE
Update list of IAM permissions needed for Kinesis producer

### DIFF
--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -103,7 +103,13 @@ SchemaException: Error reading field 'throttle_time_ms': java.nio.BufferUnderflo
 
 ### Kinesis AWS credentials
 ***
-You will need to obtain an IAM user that has the permission "kinesis:PutRecord" for the stream you are planning on producing to.
+You will need to obtain an IAM user that has the following permissions for the stream you are planning on producing to:
+
+- "kinesis:PutRecord"
+- "kinesis:PutRecords"
+- "kinesis:DescribeStream"
+- "cloudwatch:PutMetricData"
+
 See the [AWS docs](http://docs.aws.amazon.com/streams/latest/dev/controlling-access.html#kinesis-using-iam-examples) for the latest examples on which permissions are needed.
 
 


### PR DESCRIPTION
I think it would be helpful to keep this up-to-date, to the extent possible.

Also, the linked AWS docs are actually wrong: "cloudwatch:PutMetricData" permission is needed for the producer. (This AWS docs state that only the consumer needs that permission.)
