### PR TITLE
MELINF-114: terminate maxwell if message is stuck in inflight message list

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -15,6 +15,12 @@ password=maxwell
 # choose where to produce data to. currently this is one of: stdout|file|kafka
 #producer=kafka
 
+# set delivery timeout (including acknowledgement) in milliseconds for a COMMIT row message that has been sent by the producer,
+# where producer is either kafka or kinesis
+# maxwell may be terminated if the timeout has expired, when majority of the COMMIT row messages have been acknowledged
+# set it to 0 to turn off this check
+#producer_ack_timeout=120000 # default 0
+
 # set the log level.  note that you can configure things further in log4j2.xml
 #log_level=DEBUG # [DEBUG, INFO, WARN, ERROR]
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -59,6 +59,8 @@ public class MaxwellConfig extends AbstractConfig {
 	public String kinesisStream;
 	public boolean kinesisMd5Keys;
 
+	public Long producerAckTimeout;
+
 	public String outputFile;
 	public MaxwellOutputConfig outputConfig;
 	public String log_level;
@@ -142,6 +144,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts("__separator_3");
 
 		parser.accepts( "producer", "producer type: stdout|file|kafka|kinesis" ).withRequiredArg();
+		parser.accepts( "producer_ack_timeout", "producer message acknowledgement timeout" ).withRequiredArg();
 		parser.accepts( "output_file", "output file for 'file' producer" ).withRequiredArg();
 
 		parser.accepts( "producer_partition_by", "database|table|primary_key|column, kafka/kinesis producers will partition by this value").withRequiredArg();
@@ -284,6 +287,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.maxwellMysql.database = this.databaseName;
 
 		this.producerType       = fetchOption("producer", options, properties, "stdout");
+		this.producerAckTimeout = fetchLongOption("producer_ack_timeout", options, properties, 0L);
 		this.bootstrapperType   = fetchOption("bootstrapper", options, properties, "async");
 		this.clientID           = fetchOption("client_id", options, properties, "maxwell");
 		this.replicaServerID    = fetchLongOption("replica_server_id", options, properties, 6379L);

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -84,7 +84,7 @@ class KafkaCallback implements Callback {
 		}
 
 		cc.markCompleted();
-		timer.update(cc.timeToSendMS(), TimeUnit.MILLISECONDS);
+		timer.update(cc.timeSinceSendMS(), TimeUnit.MILLISECONDS);
 	}
 }
 

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -1,67 +1,135 @@
 package com.zendesk.maxwell.producer;
 
+import com.zendesk.maxwell.MaxwellConfig;
+import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by ben on 5/25/16.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class InflightMessageListTest {
-	static int capacity = 3;
-	static Position p1 = new Position(BinlogPosition.at(1, "f"), 0L);
-	static Position p2 = new Position(BinlogPosition.at(2, "f"), 0L);
-	static Position p3 = new Position(BinlogPosition.at(3, "f"), 0L);
-	static Position p4 = new Position(BinlogPosition.at(4, "f"), 0L);
-	InflightMessageList list;
-
-	@Before
-	public void setupBefore() throws InterruptedException {
-		list = new InflightMessageList(capacity);
-		list.addMessage(p1);
-		list.addMessage(p2);
-		list.addMessage(p3);
-	}
+	private static int capacity = 3;
+	private static Position p1 = new Position(BinlogPosition.at(1, "f"), 0L);
+	private static Position p2 = new Position(BinlogPosition.at(2, "f"), 0L);
+	private static Position p3 = new Position(BinlogPosition.at(3, "f"), 0L);
+	private static Position p4 = new Position(BinlogPosition.at(4, "f"), 0L);
+	private InflightMessageList list;
+	private MaxwellContext context;
+	@Captor
+	private ArgumentCaptor<RuntimeException> captor;
 
 	@Test
-	public void testInOrderCompletion() {
+	public void testInOrderCompletion() throws InterruptedException {
+		setupWithInflightRequestTimeout(0, 0.1);
+
 		Position ret;
 
-
-		ret = list.completeMessage(p1);
+		ret = list.completeMessage(p1).position;
 		assert(ret.equals(p1));
 
-		ret = list.completeMessage(p2);
+		ret = list.completeMessage(p2).position;
 		assert(ret.equals(p2));
 
-		ret = list.completeMessage(p3);
+		ret = list.completeMessage(p3).position;
 		assert(ret.equals(p3));
 
 		assert(list.size() == 0);
 	}
 
 	@Test
-	public void testOutOfOrderComplete() {
+	public void testOutOfOrderComplete() throws InterruptedException {
+		setupWithInflightRequestTimeout(0, 0.1);
+
 		Position ret;
+		InflightMessageList.InflightMessage m;
 
-		ret = list.completeMessage(p3);
-		assert(ret == null);
+		m = list.completeMessage(p3);
+		assert(m == null);
 
-		ret = list.completeMessage(p2);
-		assert(ret == null);
+		m = list.completeMessage(p2);
+		assert(m == null);
 
-		ret = list.completeMessage(p1);
+		ret = list.completeMessage(p1).position;
 		assertEquals(p3, ret);
 	}
 
 	@Test
+	public void testMaxwellWillTerminateWhenHeadOfInflightMsgListIsStuckAndListFullAndMostCompletedAndCheckTurnedOn() throws InterruptedException {
+		// Given
+		long inflightRequestTimeout = 100;
+		setupWithInflightRequestTimeout(inflightRequestTimeout, 0.1);
+		list.completeMessage(p2);
+		Thread.sleep(inflightRequestTimeout + 5);
+
+		// When
+		list.completeMessage(p3);
+
+		// Then
+		verify(context).terminate(captor.capture());
+		assertThat(captor.getValue().getMessage(), is("Did not receive acknowledgement for the head of the inflight message list for " + inflightRequestTimeout + " ms"));
+	}
+
+	@Test
+	public void testMaxwellWillNotTerminateWhenHeadOfInflightMsgListIsStuckAndCheckTurnedOff() throws InterruptedException {
+		// Given
+		setupWithInflightRequestTimeout(0, 0.1);
+		list.completeMessage(p2);
+
+		// When
+		list.completeMessage(p3);
+
+		// Then
+		verify(context, never()).terminate(any(RuntimeException.class));
+	}
+
+	@Test
+	public void testMaxwellWillNotTerminateWhenHeadOfInflightMsgListIsStuckAndListNotFullAndMostCompletedAndCheckTurnedOn() throws InterruptedException {
+		// Given
+		long inflightRequestTimeout = 100;
+		setupWithInflightRequestTimeout(inflightRequestTimeout, 0.1);
+		list.completeMessage(p1);
+		Thread.sleep(inflightRequestTimeout + 5);
+
+		// When
+		list.completeMessage(p3);
+
+		// Then
+		verify(context, never()).terminate(any(RuntimeException.class));
+	}
+
+	@Test
+	public void testMaxwellWillNotTerminateWhenHeadOfInflightMsgListIsStuckAndListFullAndMostCompletedAndCheckTurnedOn() throws InterruptedException {
+		// Given
+		long inflightRequestTimeout = 100;
+		setupWithInflightRequestTimeout(inflightRequestTimeout, 0.9);
+		list.completeMessage(p2);
+		Thread.sleep(inflightRequestTimeout + 5);
+
+		// When
+		list.completeMessage(p3);
+
+		// Then
+		verify(context, never()).terminate(any(RuntimeException.class));
+	}
+
+	@Test
 	public void testAddMessageWillWaitWhenCapacityIsFull() throws InterruptedException {
+		setupWithInflightRequestTimeout(0, 0.1);
+
 		AddMessage addMessage = new AddMessage();
 		Thread add = new Thread(addMessage);
 		add.start();
@@ -91,5 +159,16 @@ public class InflightMessageListTest {
 			}
 			end = System.currentTimeMillis();
 		}
+	}
+
+	private void setupWithInflightRequestTimeout(long timeout, double completePercentageThreshold) throws InterruptedException {
+		context = mock(MaxwellContext.class);
+		MaxwellConfig config = new MaxwellConfig();
+		config.producerAckTimeout = timeout;
+		when(context.getConfig()).thenReturn(config);
+		list = new InflightMessageList(context, capacity, completePercentageThreshold);
+		list.addMessage(p1);
+		list.addMessage(p2);
+		list.addMessage(p3);
 	}
 }


### PR DESCRIPTION
@zendesk/goanna 
- As discussed, we will only track publish+ack time for commit rows. 
- Please give feedback on the description in config example for `inflight_ack_timeout`. I want it to be neat and clear without exposing too many implementation details. 
