### PR TITLE
Add hook "onReplicatorEnd"

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -129,12 +129,15 @@ public class Maxwell implements Runnable {
 	}
 
 	protected void onReplicatorStart() {}
+	protected void onReplicatorEnd() {}
+
 	private void start() throws Exception {
 		try {
 			startInner();
 		} catch ( Exception e) {
 			this.context.terminate(e);
 		} finally {
+			onReplicatorEnd();
 			this.terminate();
 		}
 


### PR DESCRIPTION
We've been using Maxwell in the "embedded" mode. We'd like a hook for when the
replicator thread dies, for whatever reason, to allow us to clean up our own
resources as well as alert necessary parties that Maxwell is no longer
processing the binlog.