### PR TITLE
Added mechanism to delay start until MySQL is started

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV KAFKA_VERSION 0.10.1.0
 
 RUN apt-get update && apt-get -y upgrade
 
-RUN apt-get install build-essential ruby -y
+RUN apt-get install build-essential ruby mysql-client -y
 
 COPY . /workspace
 WORKDIR /workspace

--- a/bin/maxwell
+++ b/bin/maxwell
@@ -73,4 +73,10 @@ else
 	JAVA="$JAVA_HOME/bin/java"
 fi
 
+# Dockerfile defaults to MYSQL_HOST variable been set in the environment
+while ! mysqladmin ping -h"$MYSQL_HOST" --silent; do
+    echo Waiting for MySQL server at: $MYSQL_HOST
+    sleep 1
+done
+
 exec $JAVA $JAVA_OPTS -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell $args


### PR DESCRIPTION
For your consideration:
- Added the mysql-client package which provides mysqladmin utility
- Added hook to the maxwell script to ping $MYSQL_HOST and check the DB is available before Maxwell connects to it.