### PR TITLE
Add virtual hosts to RabbitMQ producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 </div>
 
 This is Maxwell's daemon, an application that reads MySQL binlogs and writes
-row updates to Kafka, Kinesis, or Google Cloud Pub/Sub as JSON.  Maxwell has a
+row updates to Kafka, Kinesis, RabbitMQ, or Google Cloud Pub/Sub as JSON.  Maxwell has a
 low operational bar and produces a consistent, easy to ingest stream of updates.
 It allows you to easily "bolt on" some of the benefits of stream processing
 systems without going through your entire code base to add (unreliable)

--- a/config.properties.example
+++ b/config.properties.example
@@ -12,7 +12,7 @@ password=maxwell
 
 ######### general stuff #############
 
-# choose where to produce data to. currently this is one of: stdout|file|kafka|pubsub
+# choose where to produce data to. currently this is one of: stdout|file|kafka|pubsub|rabbitmq
 #producer=kafka
 
 # set delivery timeout (including acknowledgement) in milliseconds for a COMMIT row message that has been sent by the producer,
@@ -150,6 +150,16 @@ kinesis_stream=maxwell
 #pubsub_project_id=maxwell
 #pubsub_topic=maxwell
 #ddl_pubsub_topic=maxwell_ddl
+
+######### rabbitmq ###################
+#rabbitmq_host=rabbitmq_hostname
+#rabbitmq_user=guest
+#rabbitmq_pass=guest
+#rabbitmq_virtual_host=/
+#rabbitmq_exchange=maxwell
+#rabbitmq_exchange_type=fanout
+#rabbitmq_exchange_durable=false
+#rabbitmq_routing_key_template=%db%.%table%
 
 ######### filter stuff ###############
 

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -154,3 +154,19 @@ Set the output stream in `config.properties` by setting the `pubsub_project_id` 
 for DDL updates by setting the `ddl_pubsub_topic` property.
 
 The producer uses the [Google Cloud Java Library for Pub/Sub](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-pubsub) and uses its built-in configurations.
+
+### RabbitMQ Options
+***
+To produce messages to RabbitMQ, you will need to specify a host in `config.properties` with `rabbitmq_host`. This is the only required property, everything else falls back to a sane default.
+
+The remaining configurable properties are:
+- `rabbitmq_user` - defaults to **guest**
+- `rabbitmq_pass` - defaults to **guest**
+- `rabbitmq_virtual_host` - defaults to **/**
+- `rabbitmq_exchange` - defaults to **maxwell**
+- `rabbitmq_exchange_type` - defaults to **fanout**
+- `rabbitmq_exchange_durable` - defaults to **false**
+- `rabbitmq_routing_key_template` - defaults to **%db%.%table%**
+    - This config controls the routing key, where `%db%` and `%table%` are placeholders that will be substituted at runtime
+
+For more details on these options, you are encouraged to the read official RabbitMQ documentation here: https://www.rabbitmq.com/documentation.html

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -128,3 +128,10 @@ bin/maxwell --user='maxwell' --password='XXXXXX' --host='127.0.0.1' \
 ```
 docker run -it --rm zendesk/maxwell bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=pubsub --pubsub_project_id='$PUBSUB_PROJECT_ID' --pubsub_topic='maxwell'
 ```
+
+### RabbitMQ Producer
+
+```
+bin/maxwell --user='maxwell' --password='XXXXXX' --host='127.0.0.1' \
+    --producer=rabbitmq --rabbitmq_host='rabbitmq.hostname'
+```

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -95,6 +95,8 @@ public class MaxwellConfig extends AbstractConfig {
 	public boolean masterRecovery;
 	public boolean ignoreProducerError;
 
+	public String rabbitmqUser;
+	public String rabbitmqPass;
 	public String rabbitmqHost;
 	public String rabbitmqVirtualHost;
 	public String rabbitmqExchange;
@@ -216,6 +218,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "__separator_8" );
 
+		parser.accepts("rabbitmq_user", "Username of Rabbitmq connection. Default is guest").withRequiredArg();
+		parser.accepts("rabbitmq_pass", "Password of Rabbitmq connection. Default is guest").withRequiredArg();
 		parser.accepts("rabbitmq_host", "Host of Rabbitmq machine").withRequiredArg();
 		parser.accepts("rabbitmq_virtual_host", "Virtual Host of Rabbitmq").withRequiredArg();
 		parser.accepts("rabbitmq_exchange", "Name of exchange for rabbitmq publisher").withRequiredArg();
@@ -321,6 +325,8 @@ public class MaxwellConfig extends AbstractConfig {
 		this.ddlPubsubTopic  = fetchOption("ddl_pubsub_topic", options, properties, this.pubsubTopic);
 
 		this.rabbitmqHost           = fetchOption("rabbitmq_host", options, properties, "localhost");
+		this.rabbitmqUser			= fetchOption("rabbitmq_user", options, properties, "guest");
+		this.rabbitmqPass			= fetchOption("rabbitmq_pass", options, properties, "guest");
 		this.rabbitmqVirtualHost    = fetchOption("rabbitmq_virtual_host", options, properties, "/");
 		this.rabbitmqExchange       = fetchOption("rabbitmq_exchange", options, properties, "maxwell");
 		this.rabbitmqExchangeType   = fetchOption("rabbitmq_exchange_type", options, properties, "fanout");

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -96,8 +96,10 @@ public class MaxwellConfig extends AbstractConfig {
 	public boolean ignoreProducerError;
 
 	public String rabbitmqHost;
+	public String rabbitmqVirtualHost;
 	public String rabbitmqExchange;
 	public String rabbitmqExchangeType;
+	public boolean rabbitMqExchangeDurable;
 	public String rabbitmqRoutingKeyTemplate;
 
 	public MaxwellConfig() { // argv is only null in tests
@@ -215,8 +217,10 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "__separator_8" );
 
 		parser.accepts("rabbitmq_host", "Host of Rabbitmq machine").withRequiredArg();
+		parser.accepts("rabbitmq_virtual_host", "Virtual Host of Rabbitmq").withRequiredArg();
 		parser.accepts("rabbitmq_exchange", "Name of exchange for rabbitmq publisher").withRequiredArg();
 		parser.accepts("rabbitmq_exchange_type", "Exchange type for rabbitmq").withRequiredArg();
+		parser.accepts( "rabbitmq_exchange_durable", "Exchange durability. Default is disabled").withOptionalArg();
 		parser.accepts("rabbitmq_routing_key_template", "A string template for the routing key, '%db%' and '%table%' will be substituted. Default is '%db%.%table%'.").withRequiredArg();
 
 		parser.accepts( "__separator_9" );
@@ -317,8 +321,10 @@ public class MaxwellConfig extends AbstractConfig {
 		this.ddlPubsubTopic  = fetchOption("ddl_pubsub_topic", options, properties, this.pubsubTopic);
 
 		this.rabbitmqHost           = fetchOption("rabbitmq_host", options, properties, "localhost");
+		this.rabbitmqVirtualHost    = fetchOption("rabbitmq_virtual_host", options, properties, "/");
 		this.rabbitmqExchange       = fetchOption("rabbitmq_exchange", options, properties, "maxwell");
 		this.rabbitmqExchangeType   = fetchOption("rabbitmq_exchange_type", options, properties, "fanout");
+		this.rabbitMqExchangeDurable = fetchBooleanOption("rabbitmq_exchange_durable", options, properties, false);
 		this.rabbitmqRoutingKeyTemplate   = fetchOption("rabbitmq_routing_key_template", options, properties, "%db%.%table%");
 
 		String kafkaBootstrapServers = fetchOption("kafka.bootstrap.servers", options, properties, null);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -218,14 +218,14 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "__separator_8" );
 
-		parser.accepts("rabbitmq_user", "Username of Rabbitmq connection. Default is guest").withRequiredArg();
-		parser.accepts("rabbitmq_pass", "Password of Rabbitmq connection. Default is guest").withRequiredArg();
-		parser.accepts("rabbitmq_host", "Host of Rabbitmq machine").withRequiredArg();
-		parser.accepts("rabbitmq_virtual_host", "Virtual Host of Rabbitmq").withRequiredArg();
-		parser.accepts("rabbitmq_exchange", "Name of exchange for rabbitmq publisher").withRequiredArg();
-		parser.accepts("rabbitmq_exchange_type", "Exchange type for rabbitmq").withRequiredArg();
-		parser.accepts( "rabbitmq_exchange_durable", "Exchange durability. Default is disabled").withOptionalArg();
-		parser.accepts("rabbitmq_routing_key_template", "A string template for the routing key, '%db%' and '%table%' will be substituted. Default is '%db%.%table%'.").withRequiredArg();
+		parser.accepts( "rabbitmq_user", "Username of Rabbitmq connection. Default is guest" ).withRequiredArg();
+		parser.accepts( "rabbitmq_pass", "Password of Rabbitmq connection. Default is guest" ).withRequiredArg();
+		parser.accepts( "rabbitmq_host", "Host of Rabbitmq machine" ).withRequiredArg();
+		parser.accepts( "rabbitmq_virtual_host", "Virtual Host of Rabbitmq" ).withRequiredArg();
+		parser.accepts( "rabbitmq_exchange", "Name of exchange for rabbitmq publisher" ).withRequiredArg();
+		parser.accepts( "rabbitmq_exchange_type", "Exchange type for rabbitmq" ).withRequiredArg();
+		parser.accepts( "rabbitmq_exchange_durable", "Exchange durability. Default is disabled" ).withOptionalArg();
+		parser.accepts( "rabbitmq_routing_key_template", "A string template for the routing key, '%db%' and '%table%' will be substituted. Default is '%db%.%table%'." ).withRequiredArg();
 
 		parser.accepts( "__separator_9" );
 

--- a/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
@@ -21,6 +21,8 @@ public class RabbitmqProducer extends AbstractProducer {
 
 		ConnectionFactory factory = new ConnectionFactory();
 		factory.setHost(context.getConfig().rabbitmqHost);
+		factory.setUsername(context.getConfig().rabbitmqUser);
+		factory.setPassword(context.getConfig().rabbitmqPass);
 		factory.setVirtualHost(context.getConfig().rabbitmqVirtualHost);
 		try {
 			this.channel = factory.newConnection().createChannel();

--- a/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
@@ -21,9 +21,10 @@ public class RabbitmqProducer extends AbstractProducer {
 
 		ConnectionFactory factory = new ConnectionFactory();
 		factory.setHost(context.getConfig().rabbitmqHost);
+		factory.setVirtualHost(context.getConfig().rabbitmqVirtualHost);
 		try {
 			this.channel = factory.newConnection().createChannel();
-			this.channel.exchangeDeclare(exchangeName, context.getConfig().rabbitmqExchangeType);
+			this.channel.exchangeDeclare(exchangeName, context.getConfig().rabbitmqExchangeType, context.getConfig().rabbitMqExchangeDurable);
 		} catch (IOException | TimeoutException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
This adds the ability to set virtual hosts to the RabbitMQ producer other than the default of `/`.
Also add ability to make the exchange durable or not. Defaults to false.

Both of these options use the defaults so if you don't use them this won't change your producers behaviour at all.