### PR TITLE
Add Timeout binary log client into configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ config/*.yml
 /test.log
 .sw?
 /config
+.classpath
+.project
+.settings

--- a/config.properties.example
+++ b/config.properties.example
@@ -4,6 +4,9 @@ log_level=info
 producer=kafka
 kafka.bootstrap.servers=localhost:9092
 
+Set Timeout for connect to binary client, default is 5000ms
+#timeout_binary_log_client=50000
+
 # mysql login info
 host=localhost
 user=maxwell

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -36,7 +36,9 @@ public class MaxwellConfig extends AbstractConfig {
 	public Boolean gtidMode;
 
 	public String databaseName;
-
+	
+	public long timeoutBinaryLogClient;
+	
 	public String includeDatabases, excludeDatabases, includeTables, excludeTables, excludeColumns, blacklistDatabases, blacklistTables;
 
 	public ProducerFactory producerFactory; // producerFactory has precedence over producerType
@@ -129,6 +131,8 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "password", "password for host" ).withRequiredArg();
 		parser.accepts( "jdbc_options", "additional jdbc connection options" ).withRequiredArg();
 		parser.accepts( "binlog_connector", "[deprecated]" ).withRequiredArg();
+		
+		parser.accepts( "timeout_binary_log_client", "Timeout to connect client for mysql binary log" ).withRequiredArg();
 
 		parser.accepts("__separator_2");
 
@@ -288,7 +292,9 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.databaseName       = fetchOption("schema_database", options, properties, "maxwell");
 		this.maxwellMysql.database = this.databaseName;
-
+			
+		this.timeoutBinaryLogClient = fetchLongOption("timeout_binary_log_client", options, properties, 50000L);
+		
 		this.producerType       = fetchOption("producer", options, properties, "stdout");
 		this.producerAckTimeout = fetchLongOption("producer_ack_timeout", options, properties, 0L);
 		this.bootstrapperType   = fetchOption("bootstrapper", options, properties, "async");

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -16,7 +16,7 @@ public class MaxwellMysqlConfig {
 	public String user;
 	public String password;
 	public ArrayList<String> jdbcOptions = new ArrayList<String>();
-	public Integer connectTimeoutMS = 5000;
+	public Integer connectTimeoutMS = 50000;
 
 	public MaxwellMysqlConfig() {
 		this.host = null;

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -16,7 +16,7 @@ public class MaxwellMysqlConfig {
 	public String user;
 	public String password;
 	public ArrayList<String> jdbcOptions = new ArrayList<String>();
-	public Integer connectTimeoutMS = 50000;
+	public Integer connectTimeoutMS = 5000;
 
 	public MaxwellMysqlConfig() {
 		this.host = null;


### PR DESCRIPTION
I add this feature because in my country, internet connection is not good and i ended timeout binary client after 5000ms, so i make connection timeout for binary client to configuration, it will give default value for 5000ms, but it can be configured by set those value on config.properties.