### PR TITLE
Enable succeeded and failed counters and metrics for Kinesis producer

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -10,6 +10,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.partitioners.MaxwellKinesisPartitioner;
 import com.zendesk.maxwell.replication.BinlogPosition;
@@ -33,12 +35,22 @@ class KinesisCallback implements FutureCallback<UserRecordResult> {
 	private final String json;
 	private MaxwellContext context;
 	private final String key;
+	private Counter succeededMessageCount;
+	private Counter failedMessageCount;
+	private Meter succeededMessageMeter;
+	private Meter failedMessageMeter;
 
-	public KinesisCallback(AbstractAsyncProducer.CallbackCompleter cc, Position position, String key, String json, MaxwellContext context) {
+	public KinesisCallback(AbstractAsyncProducer.CallbackCompleter cc, Position position, String key, String json,
+						   Counter producedMessageCount, Counter failedMessageCount, Meter producedMessageMeter,
+						   Meter failedMessageMeter, MaxwellContext context) {
 		this.cc = cc;
 		this.position = position;
 		this.key = key;
 		this.json = json;
+		this.succeededMessageCount = producedMessageCount;
+		this.failedMessageCount = failedMessageCount;
+		this.succeededMessageMeter = producedMessageMeter;
+		this.failedMessageMeter = failedMessageMeter;
 		this.context = context;
 	}
 
@@ -46,6 +58,8 @@ class KinesisCallback implements FutureCallback<UserRecordResult> {
 	public void onFailure(Throwable t) {
 		logger.error(t.getClass().getSimpleName() + " @ " + position + " -- " + key);
 		logger.error(t.getLocalizedMessage());
+		this.failedMessageCount.inc();
+		this.failedMessageMeter.mark();
 
 		if(t instanceof UserRecordFailedException) {
 			Attempt last = Iterables.getLast(((UserRecordFailedException) t).getResult().getAttempts());
@@ -63,6 +77,8 @@ class KinesisCallback implements FutureCallback<UserRecordResult> {
 
 	@Override
 	public void onSuccess(UserRecordResult result) {
+		this.succeededMessageCount.inc();
+		this.succeededMessageMeter.mark();
 		if(logger.isDebugEnabled()) {
 			logger.debug("->  key:" + key + ", shard id:" + result.getShardId() + ", sequence number:" + result.getSequenceNumber());
 			logger.debug("   " + json);
@@ -113,7 +129,8 @@ public class MaxwellKinesisProducer extends AbstractAsyncProducer {
 			value = null;
 		}
 
-		FutureCallback<UserRecordResult> callback = new KinesisCallback(cc, r.getPosition(), key, value, this.context);
+		FutureCallback<UserRecordResult> callback = new KinesisCallback(cc, r.getPosition(), key, value,
+				this.succeededMessageCount, this.failedMessageCount, this.succeededMessageMeter, this.failedMessageMeter, this.context);
 
 		Futures.addCallback(future, callback);
 	}

--- a/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.producer;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.amazonaws.services.kinesis.producer.IrrecoverableError;
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
@@ -19,7 +21,7 @@ public class KinesisCallbackTest {
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
 		KinesisCallback callback = new KinesisCallback(cc,
 			new Position(new BinlogPosition(1, "binlog-1"), 0L), "key", "value",
-			context);
+				new Counter(), new Counter(), new Meter(), new Meter(), context);
 		IrrecoverableError error = new IrrecoverableError("blah");
 		callback.onFailure(error);
 		verify(cc).markCompleted();
@@ -34,7 +36,7 @@ public class KinesisCallbackTest {
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
 		KinesisCallback callback = new KinesisCallback(cc,
 			new Position(new BinlogPosition(1, "binlog-1"), 0L), "key", "value",
-			context);
+				new Counter(), new Counter(), new Meter(), new Meter(), context);
 		IrrecoverableError error = new IrrecoverableError("blah");
 		callback.onFailure(error);
 		verify(context).terminate(any(RuntimeException.class));


### PR DESCRIPTION
This updates the Kinesis callback to track the same metrics being tracked by the Kafka callback.

Sample output:

```json
{
  "version": "3.0.0",
  "gauges": {
    "MaxwellMetrics.inflightmessages.count": {
      "value": 0
    },
    "MaxwellMetrics.replication.lag": {
      "value": 416
    }
  },
  "counters": {
    "MaxwellMetrics.messages.failed": {
      "count": 0
    },
    "MaxwellMetrics.messages.succeeded": {
      "count": 2
    },
    "MaxwellMetrics.row.count": {
      "count": 89
    }
  },
  "histograms": {
    "MaxwellMetrics.transaction.execution_time": {
      "count": 89,
      "max": 0,
      "mean": 0,
      "min": 0,
      "p50": 0,
      "p75": 0,
      "p95": 0,
      "p98": 0,
      "p99": 0,
      "p999": 0,
      "stddev": 0
    },
    "MaxwellMetrics.transaction.row_count": {
      "count": 89,
      "max": 1,
      "mean": 0.9999999999999998,
      "min": 1,
      "p50": 1,
      "p75": 1,
      "p95": 1,
      "p98": 1,
      "p99": 1,
      "p999": 1,
      "stddev": 2.2204460492503128e-16
    }
  },
  "meters": {
    "MaxwellMetrics.messages.failed.meter": {
      "count": 0,
      "m15_rate": 0,
      "m1_rate": 0,
      "m5_rate": 0,
      "mean_rate": 0,
      "units": "events/second"
    },
    "MaxwellMetrics.messages.succeeded.meter": {
      "count": 2,
      "m15_rate": 0.0014407726135806508,
      "m1_rate": 0.000050172662964483956,
      "m5_rate": 0.0018169627361459563,
      "mean_rate": 0.004856139435746407,
      "units": "events/second"
    },
    "MaxwellMetrics.row.meter": {
      "count": 89,
      "m15_rate": 0.4584759968957633,
      "m1_rate": 0.19464147699133633,
      "m5_rate": 0.30715579314969543,
      "mean_rate": 0.2168926046505079,
      "units": "events/second"
    }
  },
  "timers": {
    "MaxwellMetrics.message.publish.time": {
      "count": 2,
      "max": 0.24200000000000002,
      "mean": 0.2313299010356271,
      "min": 0.22,
      "p50": 0.24200000000000002,
      "p75": 0.24200000000000002,
      "p95": 0.24200000000000002,
      "p98": 0.24200000000000002,
      "p99": 0.24200000000000002,
      "p999": 0.24200000000000002,
      "stddev": 0.010995051855570863,
      "m15_rate": 0.0014407726135806508,
      "m1_rate": 0.000050172662964483956,
      "m5_rate": 0.0018169627361459563,
      "mean_rate": 0.004856185299371454,
      "duration_units": "seconds",
      "rate_units": "calls/second"
    },
    "MaxwellMetrics.replication.queue.time": {
      "count": 90,
      "max": 0.001,
      "mean": 0.000015078772405953998,
      "min": 0,
      "p50": 0,
      "p75": 0,
      "p95": 0,
      "p98": 0,
      "p99": 0.001,
      "p999": 0.001,
      "stddev": 0.00012186633262999031,
      "m15_rate": 0.585989417736234,
      "m1_rate": 0.19251477992478233,
      "m5_rate": 0.3588963594086804,
      "mean_rate": 0.2193424536179091,
      "duration_units": "seconds",
      "rate_units": "calls/second"
    }
  }
}
```