### PR TITLE
[MELINF-159] Make release script compatible with Ruby 2.4

### DIFF
--- a/build/release
+++ b/build/release
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
+require 'tempfile'
 require 'octokit'
 
 REPO="zendesk/maxwell"


### PR DESCRIPTION
@zendesk/goanna 

Explicitly require tempfile for release script to make Ruby 2.4 happy.