### PR TITLE
[MELINF-157] Listen to binlog connector lifecycle events

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
@@ -14,7 +14,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-class BinlogConnectorEventListener implements BinaryLogClient.EventListener, BinaryLogClient.LifecycleListener {
+class BinlogConnectorEventListener implements BinaryLogClient.EventListener {
 	private static final Logger LOGGER = LoggerFactory.getLogger(BinlogConnectorEventListener.class);
 
 	private final BlockingQueue<BinlogConnectorEvent> queue;
@@ -70,26 +70,6 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener, Bin
 		if (trackMetrics) {
 			queueTimer.update(System.currentTimeMillis() - eventSeenAt, TimeUnit.MILLISECONDS);
 		}
-	}
-
-	@Override
-	public void onConnect(BinaryLogClient client) {
-		LOGGER.info("Binlog connected.");
-	};
-
-	@Override
-	public void onCommunicationFailure(BinaryLogClient client, Exception ex) {
-		LOGGER.warn("Communication failure.", ex);
-	}
-
-	@Override
-	public void onEventDeserializationFailure(BinaryLogClient client, Exception ex) {
-		LOGGER.warn("Event deserialization failure.", ex);
-	}
-
-	@Override
-	public void onDisconnect(BinaryLogClient client) {
-		LOGGER.info("Binlog disconnected.");
 	}
 }
 

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorLifecycleListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorLifecycleListener.java
@@ -4,16 +4,8 @@ import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 class BinlogConnectorLifecycleListener implements BinaryLogClient.LifecycleListener {
 	private static final Logger LOGGER = LoggerFactory.getLogger(BinlogConnectorLifecycleListener.class);
-
-	protected final AtomicBoolean mustStop = new AtomicBoolean(false);
-
-	public void stop() {
-		mustStop.set(true);
-	}
 
 	@Override
 	public void onConnect(BinaryLogClient client) {

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorLifecycleListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorLifecycleListener.java
@@ -1,0 +1,38 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class BinlogConnectorLifecycleListener implements BinaryLogClient.LifecycleListener {
+	private static final Logger LOGGER = LoggerFactory.getLogger(BinlogConnectorLifecycleListener.class);
+
+	protected final AtomicBoolean mustStop = new AtomicBoolean(false);
+
+	public void stop() {
+		mustStop.set(true);
+	}
+
+	@Override
+	public void onConnect(BinaryLogClient client) {
+		LOGGER.info("Binlog connected.");
+	};
+
+	@Override
+	public void onCommunicationFailure(BinaryLogClient client, Exception ex) {
+		LOGGER.warn("Communication failure.", ex);
+	}
+
+	@Override
+	public void onEventDeserializationFailure(BinaryLogClient client, Exception ex) {
+		LOGGER.warn("Event deserialization failure.", ex);
+	}
+
+	@Override
+	public void onDisconnect(BinaryLogClient client) {
+		LOGGER.info("Binlog disconnected.");
+	}
+}
+

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -125,7 +125,6 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 	@Override
 	protected void beforeStop() throws Exception {
 		this.binlogEventListener.stop();
-		this.binlogLifecycleListener.stop();
 		this.client.disconnect();
 	}
 
@@ -288,7 +287,6 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 					tableCache.clear();
 					if ( stopOnEOF && event.getPosition().getOffset() > 0 ) {
 						this.binlogEventListener.mustStop.set(true);
-						this.binlogLifecycleListener.mustStop.set(true);
 						this.client.disconnect();
 						this.hitEOF = true;
 						return null;


### PR DESCRIPTION
@zendesk/goanna 

- `BinlogConnectorLifecycleListener` is splitted out of `BinlogConnectorEventListener`, and is registered to the binlog connector to listen for lifecycle events.
- `binlogEventListener` is changed from `protected` to `private`