### PR TITLE
Dockerfile: use bash to start maxwell to ensure signal propagation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update \
 
 WORKDIR /app
 
-CMD bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT $MAXWELL_OPTIONS
+CMD [ "/bin/bash", "-c", "bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT $MAXWELL_OPTIONS" ]


### PR DESCRIPTION
If the shell form of `CMD` is used, the application will be run in `/bin/sh -c`. If the application is attempted to be stopped using `docker stop`, which triggers a `SIGTERM`, it's expected that the signal is propagated to the application for graceful shutdown. Although not a problem with the current base image, all shells don't guarantee signal propagation (`ash` for eg., which is the default shell for alipine-linux). Explicitly using `bash` ensures that this is indeed handled correctly.
https://docs.docker.com/engine/reference/builder/#cmd
https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/