### PR TITLE
Add rabbitmq config option for persistent messages

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -161,6 +161,7 @@ kinesis_stream=maxwell
 #rabbitmq_exchange_durable=false
 #rabbitmq_exchange_autodelete=false
 #rabbitmq_routing_key_template=%db%.%table%
+#rabbitmq_message_persistent=false
 
 ######### redis ######################
 #redis_host=redis_host

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -169,6 +169,7 @@ The remaining configurable properties are:
 - `rabbitmq_exchange_autodelete` - defaults to **false**
 - `rabbitmq_routing_key_template` - defaults to **%db%.%table%**
     - This config controls the routing key, where `%db%` and `%table%` are placeholders that will be substituted at runtime
+- `rabbitmq_message_persistent` - defaults to **false**
 
 For more details on these options, you are encouraged to the read official RabbitMQ documentation here: https://www.rabbitmq.com/documentation.html
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -104,6 +104,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public boolean rabbitMqExchangeDurable;
 	public boolean rabbitMqExchangeAutoDelete;
 	public String rabbitmqRoutingKeyTemplate;
+	public boolean rabbitmqMessagePersistent;
 
 	public String redisHost;
 	public int redisPort;
@@ -234,6 +235,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "rabbitmq_exchange_durable", "Exchange durability. Default is disabled" ).withOptionalArg();
 		parser.accepts( "rabbitmq_exchange_autodelete", "If set, the exchange is deleted when all queues have finished using it. Defaults to false" ).withOptionalArg();
 		parser.accepts( "rabbitmq_routing_key_template", "A string template for the routing key, '%db%' and '%table%' will be substituted. Default is '%db%.%table%'." ).withRequiredArg();
+		parser.accepts( "rabbitmq_message_persistent", "Message persistence. Defaults to false" ).withOptionalArg();
 
 		parser.accepts( "__separator_9" );
 
@@ -349,6 +351,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.rabbitMqExchangeDurable = fetchBooleanOption("rabbitmq_exchange_durable", options, properties, false);
 		this.rabbitMqExchangeAutoDelete = fetchBooleanOption("rabbitmq_exchange_autodelete", options, properties, false);
 		this.rabbitmqRoutingKeyTemplate   = fetchOption("rabbitmq_routing_key_template", options, properties, "%db%.%table%");
+		this.rabbitmqMessagePersistent    = fetchBooleanOption("rabbitmq_message_persistent", options, properties, false);
 
 		this.redisHost			= fetchOption("redis_host", options, properties, "localhost");
 		this.redisPort			= Integer.parseInt(fetchOption("redis_port", options, properties, "6379"));

--- a/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
@@ -1,7 +1,9 @@
 package com.zendesk.maxwell.producer;
 
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.MessageProperties;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.row.RowMap;
 import org.slf4j.Logger;
@@ -14,10 +16,12 @@ public class RabbitmqProducer extends AbstractProducer {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(RabbitmqProducer.class);
 	private static String exchangeName;
+	private static BasicProperties props;
 	private Channel channel;
 	public RabbitmqProducer(MaxwellContext context) {
 		super(context);
 		exchangeName = context.getConfig().rabbitmqExchange;
+		props = context.getConfig().rabbitmqMessagePersistent ? MessageProperties.MINIMAL_PERSISTENT_BASIC : null;
 
 		ConnectionFactory factory = new ConnectionFactory();
 		factory.setHost(context.getConfig().rabbitmqHost);
@@ -43,7 +47,7 @@ public class RabbitmqProducer extends AbstractProducer {
 		String value = r.toJSON(outputConfig);
 		String routingKey = getRoutingKeyFromTemplate(r);
 
-		channel.basicPublish(exchangeName, routingKey, null, value.getBytes());
+		channel.basicPublish(exchangeName, routingKey, props, value.getBytes());
 		if ( r.isTXCommit() ) {
 			context.setPosition(r.getPosition());
 		}


### PR DESCRIPTION
Adds RabbitMQ config option to publish messages using `MINIMAL_PERSISTENT_BASIC` properties instead of the `MINIMAL_BASIC` which `null` props defaults to.