### PR TITLE
Stop metrics related threads when shutdown

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -163,6 +163,7 @@ public class MaxwellContext {
 			this.replicationConnectionPool.release();
 			this.maxwellConnectionPool.release();
 			this.rawMaxwellConnectionPool.release();
+			metrics.stop();
 			complete.set(true);
 		} catch (Exception e) {
 			LOGGER.error("Exception occurred during shutdown:", e);


### PR DESCRIPTION
I've noticed maxwell doesn't stop metrics related threads when shutdown. This bug makes a trouble if maxwell is embedded to another application especially. All metrics keep reported as wrong numbers even if maxwell stopped successfully. This PR is for closing all threads, that is enabled in `MaxwellMetrics` class, when shutdown process.