### PR TITLE
Exposed sql value in DDLMap

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DDLMap.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DDLMap.java
@@ -63,4 +63,8 @@ public class DDLMap extends RowMap {
 	public boolean shouldOutput(MaxwellOutputConfig outputConfig) {
 		return outputConfig.outputDDL;
 	}
+
+	public String getSql() {
+		return sql;
+	}
 }


### PR DESCRIPTION
This PR is related to my previous requirement (https://github.com/zendesk/maxwell/issues/819). As I mentioned, the maxwell runs as embedding mode. It would be great if DDLMap exposes sql value when transferring a POJO