### PR TITLE
support double-quoted database and table names

### DIFF
--- a/src/main/antlr4/imports/mysql_idents.g4
+++ b/src/main/antlr4/imports/mysql_idents.g4
@@ -15,7 +15,7 @@ table_name: (db_name '.' name)
 user: user_token ('@' user_token)?;
 user_token: (IDENT | QUOTED_IDENT | string_literal);
 
-name: ( id | tokens_available_for_names | INTEGER_LITERAL);
+name: ( id | tokens_available_for_names | INTEGER_LITERAL | DBL_STRING_LITERAL );
 id: ( IDENT | QUOTED_IDENT );
 literal: (float_literal | integer_literal | string_literal | NULL | TRUE | FALSE);
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
@@ -40,7 +40,10 @@ public class MysqlParserListener extends mysqlBaseListener {
 	}
 
 	private String unquote(String ident) {
-		return ident.replaceFirst("^`", "").replaceFirst("`$", "");
+		if ( ident.startsWith("`") || ident.startsWith("\"")) {
+			return ident.substring(1, ident.length() - 1);
+		} else
+			return ident;
 	}
 
 	private String unquote_literal(String ident) {

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -299,6 +299,23 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
+	public void testDoubleQuotedTables() throws Exception {
+		String sql[] = {
+			"create DATABASE \"tt_db\"",
+			"create table \"tt_db\".\"tt_tt\" ( \"id\" int )",
+			"create table \"tt_db\".\"`weird_quote`\" ( \"id\" int )",
+		};
+
+		server.execute("SET @old_mode = @@SESSION.sql_mode");
+		server.execute("SET SESSION sql_mode = CONCAT('ANSI_QUOTES,', @@SESSION.sql_mode)");
+
+
+		testIntegration(sql);
+		server.execute("SET SESSION sql_mode = @old_mode");
+	}
+
+
+	@Test
 	public void testNationChar() throws Exception {
 		testIntegration("create table t1 ( a CHAR(10) CHARACTER SET utf8, " +
 			"b NATIONAL CHARACTER(10), " +

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -207,6 +207,7 @@ public class DDLParserTest {
 			"ALTER TABLE foo RENAME INDEX index_quote_request_follow_on_data_on_model_name TO index_quote_request_follow_on_data_on_model_class_name",
 			"ALTER TABLE foo DROP COLUMN `ducati` CASCADE",
 			"CREATE TABLE account_groups ( visible_to_all CHAR(1) DEFAULT 'N' NOT NULL CHECK (visible_to_all IN ('Y','N')))",
+			"ALTER TABLE \"foo\" drop column a", // ansi-double-quoted tables
 			"create table vc11( id serial, name varchar(10) not null default \"\")"
 
 		};


### PR DESCRIPTION
this is possible when ANSI_QUOTES is on.

Addresses #831 