### PR TITLE
bump kpl to 0.12.8 (ATS cert compat)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
-      <version>0.12.3</version>
+      <version>0.12.8</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
AWS is requiring kinesis clients to upgrade to KPL version >= `0.12.6` to support ATS tickets. This pull updates the KPL to the latest version of `0.12.8`, which is in the same major/minor family as the current dependency of `0.12.3`. We've been running this since last night in [our fork](https://github.com/meetup/maxwell) with no problems so far.