### PR TITLE
Custom rowmap attributes

### DIFF
--- a/src/main/java/com/zendesk/maxwell/errors/ProtectedAttributeNameException.java
+++ b/src/main/java/com/zendesk/maxwell/errors/ProtectedAttributeNameException.java
@@ -1,0 +1,7 @@
+package com.zendesk.maxwell.errors;
+
+public class ProtectedAttributeNameException extends RuntimeException {
+	public ProtectedAttributeNameException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/row/FieldNames.java
+++ b/src/main/java/com/zendesk/maxwell/row/FieldNames.java
@@ -1,0 +1,40 @@
+package com.zendesk.maxwell.row;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by jensgeyti on 08/02/2018.
+ */
+public class FieldNames {
+	public static final String COMMIT = "commit";
+	public static final String DATA = "data";
+	public static final String DATABASE = "database";
+	public static final String GTID = "gtid";
+	public static final String OLD = "old";
+	public static final String POSITION = "position";
+	public static final String QUERY = "query";
+	public static final String SERVER_ID = "server_id";
+	public static final String TABLE = "table";
+	public static final String THREAD_ID = "thread_id";
+	public static final String TIMESTAMP = "ts";
+	public static final String TRANSACTION_ID = "xid";
+	public static final String TYPE = "type";
+	public static final String UUID = "_uuid";
+
+	private static List<String> fieldNamesList = Arrays.asList(COMMIT, DATA, DATABASE,
+	GTID, OLD, POSITION, QUERY, SERVER_ID, TABLE, THREAD_ID, TIMESTAMP, TRANSACTION_ID, TYPE, UUID);
+
+	private static final Set<String> fieldNamesSet = new HashSet<>(fieldNamesList);
+
+	public static boolean isProtected(String key) {
+		return fieldNamesSet.contains(key);
+	}
+
+	public static List<String> getFieldnames() {
+		return fieldNamesList;
+	}
+
+}

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -12,7 +12,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 
@@ -37,7 +41,9 @@ public class RowMap implements Serializable {
 
 	private final LinkedHashMap<String, Object> data;
 	private final LinkedHashMap<String, Object> oldData;
+
 	private final LinkedHashMap<String, Object> extraAttributes;
+
 	private final List<String> pkColumns;
 
 	private static final JsonFactory jsonFactory = new JsonFactory();

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -15,6 +15,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -101,8 +101,6 @@ public class RowMapTest {
 
 		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"pk.id\":\"9001\",\"pk.name\":\"example\"}",
 				jsonString);
-
-
 	}
 
 

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.row;
 
 import com.zendesk.maxwell.MaxwellTestJSON;
+import com.zendesk.maxwell.errors.ProtectedAttributeNameException;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
@@ -67,6 +68,12 @@ public class RowMapTest {
 
 		// Assert original extra RowMap attributes was not changed.
 		Assert.assertEquals("bar", rowMap.getExtraAttribute("foo"));
+	}
+
+	@Test(expected = ProtectedAttributeNameException.class)
+	public void testFailOnProtectedAttributes() throws Exception {
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", 1234567890L, new ArrayList<String>(), null);
+		rowMap.putExtraAttribute("table", "bar");
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -48,6 +48,28 @@ public class RowMapTest {
 	}
 
 	@Test
+	public void testGetExtraAttributesMaps() throws Exception {
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", 1234567890L, new ArrayList<String>(), null);
+		rowMap.putExtraAttribute("foo", "bar");
+
+		// Sanity check.
+		Assert.assertEquals("bar", rowMap.getExtraAttribute("foo"));
+
+		// Get extra attributes map.
+		LinkedHashMap<String, Object> extraAttributes = rowMap.getExtraAttributes();
+		Assert.assertEquals("bar", extraAttributes.get("foo"));
+
+		// Manipulate extra attributes map extracted from RowMap.
+		extraAttributes.put("foo", "BAR");
+
+		// Another sanity check.
+		Assert.assertEquals("BAR", extraAttributes.get("foo"));
+
+		// Assert original extra RowMap attributes was not changed.
+		Assert.assertEquals("bar", rowMap.getExtraAttribute("foo"));
+	}
+
+	@Test
 	public void testTimestampConversion() throws Exception {
 		long timestampSeconds = 1496712943;
 

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -205,15 +205,20 @@ public class RowMapTest {
 		rowMap.setServerId(7653213L);
 		rowMap.setThreadId(6532312L);
 
+		rowMap.putExtraAttribute("int", 1234);
+		rowMap.putExtraAttribute("str", "foo");
+
 		rowMap.putData("id", "9001");
 		rowMap.putData("first_name", "foo");
 		rowMap.putData("last_name", "bar");
         rowMap.putData("rawJSON", new RawJSONString("{\"UserID\":20}"));
+
 		MaxwellOutputConfig outputConfig = getMaxwellOutputConfig();
 
 		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"type\":\"insert\"," +
-				"\"ts\":1496712943,\"position\":\"binlog-0001:1\",\"gtid\":null,\"server_id\":7653213,\"thread_id\":6532312," +
-				"\"data\":{\"id\":\"9001\",\"first_name\":\"foo\",\"last_name\":\"bar\",\"rawJSON\":{\"UserID\":20}}}", rowMap.toJSON(outputConfig));
+				"\"ts\":1496712943,\"position\":\"binlog-0001:1\",\"gtid\":null,\"server_id\":7653213," +
+				"\"thread_id\":6532312,\"int\":1234,\"str\":\"foo\",\"data\":{\"id\":\"9001\",\"first_name\":\"foo\"," +
+				"\"last_name\":\"bar\",\"rawJSON\":{\"UserID\":20}}}", rowMap.toJSON(outputConfig));
 
 	}
 
@@ -222,17 +227,23 @@ public class RowMapTest {
 		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", TIMESTAMP_MILLISECONDS,
 				new ArrayList<String>(), POSITION);
 
+		rowMap.setServerId(7653213L);
+		rowMap.setThreadId(6532312L);
+
+		rowMap.putExtraAttribute("int", 1234);
+		rowMap.putExtraAttribute("str", "foo");
+
 		rowMap.putData("id", "9001");
 		rowMap.putData("first_name", "foo");
 		rowMap.putData("last_name", "bar");
 		rowMap.putData("interests", Arrays.asList("hiking", "programming"));
-		rowMap.setServerId(7653213L);
-		rowMap.setThreadId(6532312L);
+
 		MaxwellOutputConfig outputConfig = getMaxwellOutputConfig(Pattern.compile("^.*name.*$"));
 
-		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"type\":\"insert\",\"ts\":1496712943," +
-				"\"position\":\"binlog-0001:1\",\"gtid\":null,\"server_id\":7653213,\"thread_id\":6532312," +
-				"\"data\":{\"id\":\"9001\",\"interests\":[\"hiking\",\"programming\"]}}", rowMap.toJSON(outputConfig));
+		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"type\":\"insert\"," +
+				"\"ts\":1496712943,\"position\":\"binlog-0001:1\",\"gtid\":null,\"server_id\":7653213," +
+				"\"thread_id\":6532312,\"int\":1234,\"str\":\"foo\",\"data\":{\"id\":\"9001\"," +
+				"\"interests\":[\"hiking\",\"programming\"]}}", rowMap.toJSON(outputConfig));
 	}
 
 	private MaxwellOutputConfig getMaxwellOutputConfig(Pattern... patterns) {


### PR DESCRIPTION
With the new ability to create custom producer, it would be nice to be able to add extra attributes to RowMaps. This PR adds a Map holding extra attributes, which are simply added to the root json object is `toJSON`.