### PR TITLE
mysql config doc fix

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -5,7 +5,7 @@ operate:
 
 ```
 [mysqld]
-server-id=1
+server_id=1
 log-bin=master
 binlog_format=row
 ```
@@ -38,7 +38,7 @@ Here's how you might configure your mysql server for GTID mode:
 $ vi my.cnf
 
 [mysqld]
-server-id=1
+server_id=1
 log-bin=master
 binlog_format=row
 gtid-mode=ON

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -24,7 +24,7 @@ Maxwell can only operate if row-based replication is on.
 $ vi my.cnf
 
 [mysqld]
-server-id=1
+server_id=1
 log-bin=master
 binlog_format=row
 ```


### PR DESCRIPTION
In [mysqld],  it is server_id and not server-id.

It can be tested from mysql,

```
mysql> SHOW VARIABLES LIKE 'server%id';
+---------------+--------------------------------------+
| Variable_name | Value                                |
+---------------+--------------------------------------+
| server_id     | 1                                    |
| server_uuid   | 9f6ef86a-e632-11e7-b679-45de8b1dee56 |
+---------------+--------------------------------------+
2 rows in set (0.00 sec)
```