### PR TITLE
Fix jdbc option parsing for cases when value contains =

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -66,7 +66,7 @@ public class MaxwellMysqlConfig {
 			return;
 
 		for ( String opt : opts.split("&") ) {
-			String[] valueKeySplit = opt.trim().split("=");
+			String[] valueKeySplit = opt.trim().split("=", 2);
 			if (valueKeySplit.length == 2) {
 				this.jdbcOptions.put(valueKeySplit[0], valueKeySplit[1]);
 			}


### PR DESCRIPTION
Currently, `jdbc_options=sessionVariables=wait_timeout=12` does not get set properly. This change should fix it.