### PR TITLE
Running maxwell as daemon.

### DIFF
--- a/bin/maxwell
+++ b/bin/maxwell
@@ -45,8 +45,26 @@ do
 		use_kafka "${key#*=}"
 		;;
 
+        --daemon)
+        DAEMON_MODE="true"
+        DAEMON_NAME="MaxwellDaemon"
+        ;;
+
 	esac
 done
+
+if [ "x$DAEMON_MODE" = "xtrue" ]; then
+    # Log directory to use
+    if [ "x$LOG_DIR" = "x" ]; then
+        LOG_DIR="$base_dir/logs"
+    fi
+    # Create logs directory
+    if [ ! -d "$LOG_DIR" ]; then
+        mkdir -p "$LOG_DIR"
+    fi
+    # Console output file when daemonized
+    CONSOLE_OUTPUT_FILE=$LOG_DIR/$DAEMON_NAME.out
+fi
 
 kafka_client_dir="$lib_dir/kafka-clients"
 kafka_client_jar="$(ls -1 "$kafka_client_dir/kafka-clients-$KAFKA_VERSION"*.jar 2>/dev/null || true)"
@@ -71,4 +89,9 @@ else
 	JAVA="$JAVA_HOME/bin/java"
 fi
 
-exec $JAVA $JAVA_OPTS -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
+# Launch mode
+if [ "x$DAEMON_MODE" = "xtrue" ]; then
+    nohup $JAVA $JAVA_OPTS -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
+else
+    exec $JAVA $JAVA_OPTS -Dfile.encoding=UTF-8 -Dlog4j.shutdownCallbackRegistry=com.djdch.log4j.StaticShutdownCallbackRegistry -cp $CLASSPATH com.zendesk.maxwell.Maxwell "$@"
+fi

--- a/bin/maxwell
+++ b/bin/maxwell
@@ -62,7 +62,7 @@ if [ "x$DAEMON_MODE" = "xtrue" ]; then
     if [ ! -d "$LOG_DIR" ]; then
         mkdir -p "$LOG_DIR"
     fi
-    # Console output file when daemonized
+    # Console output file when maxwell runs as a daemon
     CONSOLE_OUTPUT_FILE=$LOG_DIR/$DAEMON_NAME.out
 fi
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -143,6 +143,7 @@ public class MaxwellConfig extends AbstractConfig {
 		final OptionParser parser = new OptionParser();
 		parser.accepts( "config", "location of config file" ).withRequiredArg();
 		parser.accepts( "log_level", "log level, one of DEBUG|INFO|WARN|ERROR" ).withRequiredArg();
+		parser.accepts( "daemon", "daemon, running maxwell as a daemon" ).withOptionalArg();
 
 		parser.accepts("__separator_1");
 


### PR DESCRIPTION
With `--daemon `as an optional argument, maxwell now runs as a daemon.

This is with reference to issue [875](https://github.com/zendesk/maxwell/issues/875).