### PR TITLE
use positions from other clients when starting up a new client

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -101,7 +101,18 @@ public class Maxwell implements Runnable {
 			if ( config.masterRecovery )
 				initial = attemptMasterRecovery();
 
-			/* third method: capture the current master position. */
+			/* third method: is there a previous client_id?
+			   if so we have to start at that position or else
+			   we could miss schema changes, see https://github.com/zendesk/maxwell/issues/782 */
+
+			if ( initial == null ) {
+				initial = this.context.getOtherClientPosition();
+				if ( initial != null ) {
+					LOGGER.info("Found previous client position: " + initial);
+				}
+			}
+
+			/* fourth method: capture the current master position. */
 			if ( initial == null ) {
 				try ( Connection c = context.getReplicationConnection() ) {
 					initial = Position.capture(c, config.gtidMode);

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -247,7 +247,7 @@ public class MaxwellContext {
 	}
 
 	public Position getOtherClientPosition() throws SQLException {
-		return this.positionStore.getAny();
+		return this.positionStore.getLatestFromAnyClient();
 	}
 
 	public RecoveryInfo getRecoveryInfo() throws SQLException {

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -246,6 +246,10 @@ public class MaxwellContext {
 		return this.initialPosition;
 	}
 
+	public Position getOtherClientPosition() throws SQLException {
+		return this.positionStore.getAny();
+	}
+
 	public RecoveryInfo getRecoveryInfo() throws SQLException {
 		return this.positionStore.getRecoveryInfo(config);
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -171,9 +171,9 @@ public class MysqlPositionStore {
 		return new Position(pos, rs.getLong("last_heartbeat_read"));
 	}
 
-	public Position getAny() throws SQLException {
+	public Position getLatestFromAnyClient() throws SQLException {
 		try ( Connection c = connectionPool.getConnection() ) {
-			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ?");
+			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? ORDER BY last_heartbeat_read desc limit 1");
 			s.setLong(1, serverID);
 
 			return positionFromResultSet(s.executeQuery());

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -156,24 +156,37 @@ public class MysqlPositionStore {
 		return lastHeartbeat;
 	}
 
+	private Position positionFromResultSet(ResultSet rs) throws SQLException {
+		if ( !rs.next() )
+			return null;
+
+		String gtid = gtidMode ? rs.getString("gtid_set") : null;
+		BinlogPosition pos = new BinlogPosition(
+			gtid,
+			null,
+			rs.getLong("binlog_position"),
+			rs.getString("binlog_file")
+		);
+
+		return new Position(pos, rs.getLong("last_heartbeat_read"));
+	}
+
+	public Position getAny() throws SQLException {
+		try ( Connection c = connectionPool.getConnection() ) {
+			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ?");
+			s.setLong(1, serverID);
+
+			return positionFromResultSet(s.executeQuery());
+		}
+	}
+
 	public Position get() throws SQLException {
 		try ( Connection c = connectionPool.getConnection() ) {
 			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? and client_id = ?");
 			s.setLong(1, serverID);
 			s.setString(2, clientID);
 
-			ResultSet rs = s.executeQuery();
-			if ( !rs.next() )
-				return null;
-
-			String gtid = gtidMode ? rs.getString("gtid_set") : null;
-			return new Position(
-				new BinlogPosition(gtid, null,
-					rs.getLong("binlog_position"),
-					rs.getString("binlog_file")
-				),
-				rs.getLong("last_heartbeat_read")
-			);
+			return positionFromResultSet(s.executeQuery());
 		}
 	}
 


### PR DESCRIPTION
since we're not re-capturing schemas, it's wrong to assume that we
should pick up from the master's current position: if there is another
(old, stopped) client, we'll end up corresponding the current position
to an older schema, which is no good.

Addresses #782 