### PR TITLE
Version fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,19 @@
         </configuration>
       </plugin>
       <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+    <configuration>
+        <archive>                   
+            <manifest>
+                <mainClass>com.zendesk.maxwell.Maxwell</mainClass>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
+        </archive>
+    </configuration>
+</plugin>
+      <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
         <version>4.5</version>
@@ -397,5 +410,40 @@
       </plugin>
 
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[2.8,)</versionRange>
+                    <goals>
+                      <goal>copy-dependencies</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <resources>
+        <resource>
+            <directory>src/main/resources</directory>
+            <filtering>true</filtering>
+        </resource>
+    </resources>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -333,19 +333,6 @@
         </configuration>
       </plugin>
       <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-jar-plugin</artifactId>
-    <configuration>
-        <archive>                   
-            <manifest>
-                <mainClass>com.zendesk.maxwell.Maxwell</mainClass>
-                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-            </manifest>
-        </archive>
-    </configuration>
-</plugin>
-      <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
         <version>4.5</version>
@@ -410,40 +397,11 @@
       </plugin>
 
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <versionRange>[2.8,)</versionRange>
-                    <goals>
-                      <goal>copy-dependencies</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore></ignore>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <resources>
-        <resource>
-            <directory>src/main/resources</directory>
-            <filtering>true</filtering>
-        </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
     </resources>
   </build>
 </project>

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -124,13 +124,13 @@ public class Maxwell implements Runnable {
 	public String getMaxwellVersion() {
 		String packageVersion = getClass().getPackage().getImplementationVersion();
 		if ( packageVersion == null ) {
-		    final Properties properties = new Properties();
-	        try {
-	            properties.load(getClass().getClassLoader().getResourceAsStream("maxwell.properties"));
-                packageVersion = properties.getProperty("version");
-	        } catch (IOException e) {
-                LOGGER.info ("Maxwell version not found.");
-	        }
+			final Properties properties = new Properties();
+			try {
+				properties.load(getClass().getClassLoader().getResourceAsStream("maxwell.properties"));
+				packageVersion = properties.getProperty("version");
+			} catch (IOException e) {
+				LOGGER.info ("Maxwell version not found.");
+			}
 		}
 		if ( packageVersion == null )
 			return "??";

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -15,9 +15,11 @@ import com.zendesk.maxwell.util.Logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 public class Maxwell implements Runnable {
 	protected MaxwellConfig config;
@@ -121,6 +123,15 @@ public class Maxwell implements Runnable {
 
 	public String getMaxwellVersion() {
 		String packageVersion = getClass().getPackage().getImplementationVersion();
+		if ( packageVersion == null ) {
+		    final Properties properties = new Properties();
+	        try {
+	            properties.load(getClass().getClassLoader().getResourceAsStream("maxwell.properties"));
+                packageVersion = properties.getProperty("version");
+	        } catch (IOException e) {
+                LOGGER.info ("Maxwell version not found.");
+	        }
+		}
 		if ( packageVersion == null )
 			return "??";
 		else

--- a/src/main/resources/maxwell.properties
+++ b/src/main/resources/maxwell.properties
@@ -1,0 +1,2 @@
+version=${project.version}
+artifactId=${project.artifactId}


### PR DESCRIPTION
This PR fixes the issue [#889](https://github.com/zendesk/maxwell/issues/889) .  

To summarize, currently, Maxwell version is always missing.  A property file `src/main/resources/maxwell.property` can be used to pull the version information from pom.xml.  