### PR TITLE
Adding missing ``break'' in SQS producer.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -340,6 +340,7 @@ public class MaxwellContext {
 				break;
 			case "sqs":
 				this.producer = new MaxwellSQSProducer(this, this.config.sqsQueueUri);
+				break;
 			case "pubsub":
 				this.producer = new MaxwellPubsubProducer(this, this.config.pubsubProjectId, this.config.pubsubTopic, this.config.ddlPubsubTopic);
 				break;


### PR DESCRIPTION
Without this SQS producer will fallback to pubsub producer.  
I suppose this crept in during  [58b910](https://github.com/ashashwat/maxwell/commit/58b910677cae2303a31d9a68343fe5d4f3238c31).