### PR TITLE
Remove redundant log.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -213,7 +213,6 @@ public class Maxwell implements Runnable {
 		} catch ( SQLException e ) {
 			// catch SQLException explicitly because we likely don't care about the stacktrace
 			LOGGER.error("SQLException: " + e.getLocalizedMessage());
-			LOGGER.error(e.getLocalizedMessage());
 			System.exit(1);
 		} catch ( URISyntaxException e ) {
 			// catch URISyntaxException explicitly as well to provide more information to the user


### PR DESCRIPTION
If MySQL service is not running, maxwell when started will abort due to
Communication link failure.  However we see the logs printed twice.
```

➜  maxwell git:(master) ✗ bin/maxwell --user='maxwell' --password='maxwell' --host='127.0.0.1' --producer=kafka --kafka.bootstrap.servers=localhost:9092 --kafka_topic=test
Using kafka version: 0.11.0.1
11:29:13,725 WARN  MaxwellMetrics - Metrics will not be exposed: metricsReportingType not configured.
11:29:14,114 ERROR Maxwell - SQLException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
11:29:14,114 ERROR Maxwell - Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
```