### PR TITLE
Fix CREATE SCHEMA x CHARACTER SET = DEFAULT parsing bug

### DIFF
--- a/src/main/antlr4/imports/mysql_idents.g4
+++ b/src/main/antlr4/imports/mysql_idents.g4
@@ -25,7 +25,7 @@ string_literal: (STRING_LITERAL | DBL_STRING_LITERAL);
 
 string: (IDENT | STRING_LITERAL);
 integer: INTEGER_LITERAL;
-charset_name: (IDENT | string_literal | QUOTED_IDENT | BINARY | ASCII);
+charset_name: (IDENT | string_literal | QUOTED_IDENT | BINARY | ASCII | DEFAULT);
 
 default_character_set: DEFAULT? charset_token '='? charset_name collation?;
 default_collation: DEFAULT? collation;

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -466,6 +466,12 @@ public class DDLParserTest {
 	}
 
 	@Test
+	public void testCreateSchemaCharSet() {
+		List<SchemaChange> changes = parse("CREATE SCHEMA IF NOT EXISTS `tblname` CHARACTER SET = default");
+		assertThat(changes.size(), is(1));
+	}
+
+	@Test
 	public void testMysqlTestFixedSQL() throws Exception {
 		int i = 1;
 		List<String> lines = Files.readAllLines(Paths.get(getSQLDir() + "/ddl/mysql-test-fixed.sql"), Charset.defaultCharset());


### PR DESCRIPTION
This test case came up while running maxwell. It is valid sql, so this change should allow it to be parsed correctly

Thanks!