### PR TITLE
Add logging for binlog errors to make them easier to skip

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -89,7 +89,14 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 
 
 	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Position position) throws SchemaStoreException, InvalidSchemaError {
-		List<ResolvedSchemaChange> resolvedSchemaChanges = resolveSQL(getSchema(), sql, currentDatabase);
+		List<ResolvedSchemaChange> resolvedSchemaChanges;
+		try {
+			resolvedSchemaChanges = resolveSQL(getSchema(), sql, currentDatabase);
+		} catch (Exception e) {
+			LOGGER.error("Error on bin log position " + position.toString());
+			e.printStackTrace();
+			throw e;
+		}
 
 		if ( resolvedSchemaChanges.size() > 0 ) {
 			try {


### PR DESCRIPTION
This is related to the problem I had in the last PR. I am trying to figure out how to skip a bad binlog entry.

With this change, this is the process I followed to skip over a log entry:
- This error message was printed: `Error on bin log position Position[BinlogPosition[mysql-bin.000010:238759], lastHeartbeat=0]`
- `mysqlbinlog mysql-bin.000010 --verbose --base64-output=decode-rows | grep -C 100 "at 238759"` gave:
```
# at 238759
#180303  0:08:57 server id 1  end_log_pos 238900 	Query	thread_id=5	exec_time=0	error_code=0
SET TIMESTAMP=1520035737/*!*/;
SET @@session.sql_mode=0/*!*/;
CREATE SCHEMA IF NOT EXISTS my_sqhema CHARACTER SET = DEFAULT
/*!*/;
# at 238900
#180303  0:08:58 server id 1  end_log_pos 238971 	Query	thread_id=5	exec_time=0	error_code=0
SET TIMESTAMP=1520035738/*!*/;
BEGIN
/*!*/;
# at 238971
# at 239053
#180303  0:08:58 server id 1  end_log_pos 239053 	Table_map: `db1`.`table1` mapped to number 884
#180303  0:08:58 server id 1  end_log_pos 239109 	Write_rows: table id 884 flags: STMT_END_F
### INSERT INTO table1.db1
```
- I ran maxwell with `--init_position=mysql-bin.000010:238900:1520035738`

I am wondering:
- Is using the timestamp as a heartbeat the intended way?
- Since maxwell doesn't shut down properly, what can I do to ensure that every bin log entry before the bad one was processed properly and written to kafka at least once? How does this affect schema changes?

Thanks for being so responsive and helpful!