### PR TITLE
filter-case

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellFilter.java
@@ -50,32 +50,38 @@ public class MaxwellFilter {
 	) throws MaxwellInvalidFilterException {
 		if ( includeDatabases != null ) {
 			for ( String s : includeDatabases.split(",") )
-				includeDatabase(s);
+				//includeDatabase(s);
+			    includeDatabase(s.toUpperCase()); // toUpperCase
 		}
 
 		if ( excludeDatabases != null ) {
 			for ( String s : excludeDatabases.split(",") )
-				excludeDatabase(s);
+				//excludeDatabase(s);
+				excludeDatabase(s.toUpperCase()); // toUpperCase
 		}
 
 		if ( includeTables != null ) {
 			for ( String s : includeTables.split(",") )
-				includeTable(s);
+				//includeTable(s);
+				includeTable(s.toUpperCase()); // toUpperCase
 		}
 
 		if ( excludeTables != null ) {
 			for ( String s : excludeTables.split(",") )
-				excludeTable(s);
+				//excludeTable(s);
+				excludeTable(s.toUpperCase()); // toUpperCase
 		}
 
 		if ( blacklistDatabases != null ) {
 			for ( String s : blacklistDatabases.split(",") )
-				blacklistDatabases(s);
+				//blacklistDatabases(s);
+				blacklistDatabases(s.toUpperCase()); // toUpperCase
 		}
 
 		if ( blacklistTables != null ) {
 			for ( String s : blacklistTables.split(",") )
-				blacklistTable(s);
+				//blacklistTable(s);
+				blacklistTable(s.toUpperCase()); // toUpperCase
 		}
 	}
 
@@ -120,11 +126,12 @@ public class MaxwellFilter {
 	}
 
 	private boolean filterListsInclude(List<Pattern> includeList, List<Pattern> excludeList, String name) {
+		name = name.toUpperCase(); //toUpperCase
+
 		if ( includeList.size() > 0 ) {
 			boolean found = false;
 			for ( Pattern p : includeList ) {
-				found = p.matcher(name).find();
-
+				found = p.matcher(name).find(); //Case problems, so the values of p and name should be capitalized.
 				if ( found )
 					break;
 			}
@@ -210,3 +217,4 @@ public class MaxwellFilter {
 		}
 	}
 }
+


### PR DESCRIPTION
https://github.com/zendesk/maxwell/issues/904

Maxwell version: 1.10.5~1.13.1 (have tested)
Current Maxwell version: master

**MySQL(Linux) :**
default: 
lower_case_table_names = 0, is case sensitive.

but dba will set lower_case_table_names = 1 in product env, isn't case sensitive.
create db "test" and table "timezonetest".


1.DB Name is upper in Maxwell config.properties
include_dbs=TEST
include_tables=timezonetest

2.Table Name is upper in config.properties
include_dbs=test
include_tables=TIMEZONETEST

3.Test
MySQL SQL: insert into timezonetest(date_c,datetime_c,timestamp_c) values('2018-02-25','2018-02-25','2018-02-25 10:00:00');

4.Run Maxwell producer as stdout
The console will not print the sql json,is issue.

5.Modify MaxwellFilter.java
Maxwell-904.patch
https://github.com/zendesk/maxwell/files/1754225/Maxwell-904.patch.zip

6.Test is ok.
