### PR TITLE
Update the maxwell install doc.

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -14,7 +14,13 @@ or get the docker image:
 
 ```
 docker pull zendesk/maxwell
+```  
+
+or on Mac OS X with homebrew installed:
+
 ```
+brew install maxwell
+```  
 
 ### Row based replication
 ***


### PR DESCRIPTION
On Mac OS X with homebrew installed, maxwell can now be installed with:

```brew install maxwell```

The information regarding maxwell can be checked via info,  
```
➜  brew info maxwell
maxwell: stable 1.13.1
Maxwell's daemon, a mysql-to-json kafka producer
http://maxwells-daemon.io/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/maxwell.rb
==> Requirements
Required: java = 1.8 ✔
``` 

Right now it will install maxwell version 1.13.1.  
Updating the docs with the instruction.