### PR TITLE
Fix maxwell process DDL twice 

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -575,7 +575,7 @@ public class MysqlSavedSchema {
 			PreparedStatement s = connection.prepareStatement(
 				"SELECT id from `schemas` "
 				+ "WHERE deleted = 0 "
-				+ "AND last_heartbeat_read <= ? AND ((binlog_file < ?) OR (binlog_file = ? and binlog_position <= ?)) AND server_id = ? "
+				+ "AND last_heartbeat_read <= ? AND ((binlog_file < ?) OR (binlog_file = ? and binlog_position < ?)) AND server_id = ? "
 				+ "ORDER BY last_heartbeat_read DESC, binlog_file DESC, binlog_position DESC limit 1");
 
 			s.setLong(1, targetPosition.getLastHeartbeatRead());

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -57,9 +57,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 		this.position = MaxwellTestSupport.capture(server.getConnection());
 		this.context = buildContext(position);
 		this.schema = new SchemaCapturer(server.getConnection(), context.getCaseSensitivity()).capture();
-		this.savedSchema = new MysqlSavedSchema(this.context.getServerID(), this.context.getCaseSensitivity(),
-				this.schema, makePosition(position.getBinlogPosition().getOffset() - 1L,
-				position.getBinlogPosition().getFile(), position.getLastHeartbeatRead()));
+		this.savedSchema = SavedSchemaSupport.getSavedSchema(this.context, this.schema, this.position);
 	}
 
 	@Test
@@ -198,10 +196,7 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 
 		server.executeList(sql);
 		this.schema = new SchemaCapturer(server.getConnection(), context.getCaseSensitivity()).capture();
-		this.savedSchema = new MysqlSavedSchema(this.context.getServerID(), this.context.getCaseSensitivity(),
-				this.schema, makePosition(position.getBinlogPosition().getOffset() - 1L,
-				position.getBinlogPosition().getFile(), position.getLastHeartbeatRead()));
-
+		this.savedSchema = SavedSchemaSupport.getSavedSchema(this.context, this.schema, this.position);
 		Connection c = context.getMaxwellConnection();
 		this.savedSchema.save(c);
 

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import com.google.common.collect.Lists;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 import org.apache.commons.lang3.StringUtils;
@@ -56,7 +57,9 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 		this.position = MaxwellTestSupport.capture(server.getConnection());
 		this.context = buildContext(position);
 		this.schema = new SchemaCapturer(server.getConnection(), context.getCaseSensitivity()).capture();
-		this.savedSchema = new MysqlSavedSchema(this.context, this.schema, position);
+		this.savedSchema = new MysqlSavedSchema(this.context.getServerID(), this.context.getCaseSensitivity(),
+				this.schema, makePosition(position.getBinlogPosition().getOffset() - 1L,
+				position.getBinlogPosition().getFile(), position.getLastHeartbeatRead()));
 	}
 
 	@Test
@@ -195,7 +198,9 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 
 		server.executeList(sql);
 		this.schema = new SchemaCapturer(server.getConnection(), context.getCaseSensitivity()).capture();
-		this.savedSchema = new MysqlSavedSchema(this.context, this.schema, position);
+		this.savedSchema = new MysqlSavedSchema(this.context.getServerID(), this.context.getCaseSensitivity(),
+				this.schema, makePosition(position.getBinlogPosition().getOffset() - 1L,
+				position.getBinlogPosition().getFile(), position.getLastHeartbeatRead()));
 
 		Connection c = context.getMaxwellConnection();
 		this.savedSchema.save(c);
@@ -299,6 +304,40 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 			serverId, caseSensitivity, targetBinlogPosition);
 		assertThat(foundSchema.getBinlogPosition(), equalTo(expectedSchema.getBinlogPosition()));
 		assertThat(foundSchema.getSchemaID(), equalTo(expectedSchema.getSchemaID()));
+	}
+
+	@Test
+	public void testFindBaseSchemaIdIfTheLatestSchemaPositionIsTheCurrentPosition() throws Exception {
+		if (context.getConfig().gtidMode) {
+			return;
+		}
+		Connection c = context.getMaxwellConnection();
+		long serverId = 100;
+		long targetPosition = 500;
+		long lastHeartbeat = 9000L;
+		String targetFile = "binlog01";
+		Position targetBinlogPosition = makePosition(targetPosition, targetFile, lastHeartbeat + 10L);
+
+		//base binlog position
+		MysqlSavedSchema baseSchema = new MysqlSavedSchema(
+				serverId, caseSensitivity,
+				buildSchema(),
+				makePosition(targetPosition - 200L, targetFile, lastHeartbeat)
+		);
+		baseSchema.save(c);
+
+		MysqlSavedSchema newSchema = new MysqlSavedSchema(serverId, caseSensitivity,
+				buildSchema(),
+				makePosition(targetPosition, targetFile, lastHeartbeat),
+				baseSchema.getSchemaID(),
+				Lists.newArrayList()
+		);
+		newSchema.save(c);
+
+		MysqlSavedSchema foundSchema = MysqlSavedSchema.restore(context.getMaxwellConnectionPool(),
+				serverId, caseSensitivity, targetBinlogPosition);
+
+		assertThat(foundSchema.getSchemaID(), equalTo(baseSchema.getSchemaID()));
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/SavedSchemaSupport.java
+++ b/src/test/java/com/zendesk/maxwell/SavedSchemaSupport.java
@@ -1,0 +1,20 @@
+package com.zendesk.maxwell;
+
+import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
+import com.zendesk.maxwell.schema.MysqlSavedSchema;
+import com.zendesk.maxwell.schema.Schema;
+
+final public class SavedSchemaSupport {
+	private SavedSchemaSupport() { }
+
+	public static MysqlSavedSchema getSavedSchema(MaxwellContext context, Schema schema, Position position) throws Exception {
+		if (context.getConfig().gtidMode) {
+			return new MysqlSavedSchema(context, schema, position);
+		}
+
+		return new MysqlSavedSchema(context.getServerID(), context.getCaseSensitivity(),
+				schema, new Position(new BinlogPosition(position.getBinlogPosition().getOffset() - 1L,
+				position.getBinlogPosition().getFile()), position.getLastHeartbeatRead()));
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
+++ b/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
@@ -361,10 +361,8 @@ public class RecoveryTest extends TestWithNameLogging {
 		MysqlSavedSchema savedSchema = MysqlSavedSchema.restore(context, oldlogPosition);
 		if (savedSchema == null) {
 			Connection c = context.getMaxwellConnection();
-			Position schemaPosition = new Position(new BinlogPosition(oldlogPosition.getBinlogPosition().getOffset() - 1L,
-					oldlogPosition.getBinlogPosition().getFile()), oldlogPosition.getLastHeartbeatRead());
 			Schema newSchema = new SchemaCapturer(c, context.getCaseSensitivity()).capture();
-			savedSchema = new MysqlSavedSchema(context, newSchema, schemaPosition);
+			savedSchema = SavedSchemaSupport.getSavedSchema(context, newSchema, context.getInitialPosition());
 			savedSchema.save(c);
 		}
 		Long oldSchemaId = savedSchema.getSchemaID();

--- a/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
+++ b/src/test/java/com/zendesk/maxwell/recovery/RecoveryTest.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell.recovery;
 
 import com.github.shyiko.mysql.binlog.network.SSLMode;
 import com.zendesk.maxwell.*;
+import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
@@ -360,8 +361,10 @@ public class RecoveryTest extends TestWithNameLogging {
 		MysqlSavedSchema savedSchema = MysqlSavedSchema.restore(context, oldlogPosition);
 		if (savedSchema == null) {
 			Connection c = context.getMaxwellConnection();
+			Position schemaPosition = new Position(new BinlogPosition(oldlogPosition.getBinlogPosition().getOffset() - 1L,
+					oldlogPosition.getBinlogPosition().getFile()), oldlogPosition.getLastHeartbeatRead());
 			Schema newSchema = new SchemaCapturer(c, context.getCaseSensitivity()).capture();
-			savedSchema = new MysqlSavedSchema(context, newSchema, context.getInitialPosition());
+			savedSchema = new MysqlSavedSchema(context, newSchema, schemaPosition);
 			savedSchema.save(c);
 		}
 		Long oldSchemaId = savedSchema.getSchemaID();


### PR DESCRIPTION
Related to issue https://github.com/zendesk/maxwell/issues/780

Schema chain building conflicts with message processing on DDL.

In more details: 

What happen is that when Maxwell starts, it will compare the current position with schema binlog position and then build the schema linked list. This behaviour is correct and helps maxwell to reproduce all the db changes at any point of time. 

If the binlog position is DML, it is working fine. However, there is an edge case, if the binlog position is pointing to a DDL statement, maxwell would include this DDL statement into the schema chain. After that, maxwell will be unable to reprocess this statement again in `BinlogConnectorReplicator.processQueryEvent`. i.e. it couldn't create same table twice, it couldn't alter the same table twice and etc.

Solution: Use the parent schema from the latest if `binlog_position` and `target_position` are same.

Here are other solutions I can think of, but I feel like the drawback of it are pretty clear.
- Fix it in the `BinlogConnectorReplicator.processQueryEvent`: I don't think we should leave it at processing stage, it is very late and error prone.
- Point to previous binlog position: If it is DML, the same message would be reprocessing twice.

Any other ideas @zendesk/goanna  ?

@osheroff I am sorry to ask you review it, it is little abrupt, but this is my first code change to maxwell, I hope it won't break anything :) 
