### PR TITLE
Maven warning fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
Missing maven-jar-plugin version throw this warning during build.

```
[WARNING] Some problems were encountered while building the effective model for com.zendesk:maxwell:jar:1.13.2
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 370, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

Adding the version fixes it.