### PR TITLE
Added possibility to do not declare the rabbitmq exchange.

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -195,6 +195,7 @@ sqs_queue_uri=aws_sqs_queue_uri
 #rabbitmq_exchange_autodelete=false
 #rabbitmq_routing_key_template=%db%.%table%
 #rabbitmq_message_persistent=false
+#rabbitmq_declare_exchange=true
 
 ######### redis ######################
 # Valid values for redis_type = pubsub|lpush. Defaults to pubsub

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -195,6 +195,7 @@ The remaining configurable properties are:
 - `rabbitmq_routing_key_template` - defaults to **%db%.%table%**
     - This config controls the routing key, where `%db%` and `%table%` are placeholders that will be substituted at runtime
 - `rabbitmq_message_persistent` - defaults to **false**
+- `rabbitmq_declare_exchange` - defaults to **true**
 
 For more details on these options, you are encouraged to the read official RabbitMQ documentation here: https://www.rabbitmq.com/documentation.html
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -111,6 +111,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public boolean rabbitMqExchangeAutoDelete;
 	public String rabbitmqRoutingKeyTemplate;
 	public boolean rabbitmqMessagePersistent;
+	public boolean rabbitmqDeclareExchange;
 
 	public String redisHost;
 	public int redisPort;
@@ -255,6 +256,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "rabbitmq_exchange_autodelete", "If set, the exchange is deleted when all queues have finished using it. Defaults to false" ).withOptionalArg();
 		parser.accepts( "rabbitmq_routing_key_template", "A string template for the routing key, '%db%' and '%table%' will be substituted. Default is '%db%.%table%'." ).withRequiredArg();
 		parser.accepts( "rabbitmq_message_persistent", "Message persistence. Defaults to false" ).withOptionalArg();
+		parser.accepts( "rabbitmq_declare_exchange", "Should declare the exchange for rabbitmq publisher. Defaults to true" ).withOptionalArg();
 
 		parser.accepts( "__separator_9" );
 
@@ -368,6 +370,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.rabbitMqExchangeAutoDelete 	= fetchBooleanOption("rabbitmq_exchange_autodelete", options, properties, false);
 		this.rabbitmqRoutingKeyTemplate   	= fetchOption("rabbitmq_routing_key_template", options, properties, "%db%.%table%");
 		this.rabbitmqMessagePersistent    	= fetchBooleanOption("rabbitmq_message_persistent", options, properties, false);
+		this.rabbitmqDeclareExchange		= fetchBooleanOption("rabbitmq_declare_exchange", options, properties, true);
 
 		this.redisHost			= fetchOption("redis_host", options, properties, "localhost");
 		this.redisPort			= Integer.parseInt(fetchOption("redis_port", options, properties, "6379"));

--- a/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
@@ -31,7 +31,9 @@ public class RabbitmqProducer extends AbstractProducer {
 		factory.setVirtualHost(context.getConfig().rabbitmqVirtualHost);
 		try {
 			this.channel = factory.newConnection().createChannel();
-			this.channel.exchangeDeclare(exchangeName, context.getConfig().rabbitmqExchangeType, context.getConfig().rabbitMqExchangeDurable, context.getConfig().rabbitMqExchangeAutoDelete, null);
+			if(context.getConfig().rabbitmqDeclareExchange) {
+				this.channel.exchangeDeclare(exchangeName, context.getConfig().rabbitmqExchangeType, context.getConfig().rabbitMqExchangeDurable, context.getConfig().rabbitMqExchangeAutoDelete, null);
+			}
 		} catch (IOException | TimeoutException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
When you have a RabbitMQ user that can write to an exchange but cannot configure (in this case exchange already exists), the exchange declaration throws an exception and Maxwell exit.

For this case, I add the possibility to skip the exchange declaration.

The default behaviour is kept as before, the exchange declaration is done by default.

I added a new boolean property : rabbitmq_declare_exchange

To skip the exchange declaration, you have to set rabbitmq_declare_exchange to false.

If rabbitmq_declare_exchange is not present or is set to true, the exchange declaration is done as before.