### PR TITLE
Add --skip_positions option

### DIFF
--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -66,6 +66,7 @@ public class Recovery {
 					maxwellDatabaseName,
 					metrics,
 					position,
+					null,
 					true,
 					recoveryInfo.clientID,
 					new HeartbeatNotifier()

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MaxwellSQLSyntaxError.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MaxwellSQLSyntaxError.java
@@ -1,6 +1,6 @@
 package com.zendesk.maxwell.schema.ddl;
 
-class MaxwellSQLSyntaxError extends RuntimeException {
+public class MaxwellSQLSyntaxError extends RuntimeException {
 	private static final long serialVersionUID = 140545518818187219L;
 
 	public MaxwellSQLSyntaxError(String message) {

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -175,9 +175,8 @@ public class MaxwellTestSupport {
 		config.filter = filter;
 		config.bootstrapperType = "sync";
 
-		callback.beforeReplicatorStart(mysql);
+		callback.beforeReplicatorStart(mysql, config);
 
-		config.initPosition = capture(mysql.getConnection());
 		final String waitObject = new String("");
 		final BufferedMaxwell maxwell = new BufferedMaxwell(config) {
 			@Override

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupportCallback.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupportCallback.java
@@ -1,9 +1,19 @@
 package com.zendesk.maxwell;
 
+import com.zendesk.maxwell.replication.Position;
+
 import java.sql.SQLException;
+
+import static com.zendesk.maxwell.MaxwellTestSupport.inGtidMode;
 
 public class MaxwellTestSupportCallback {
 	public void beforeReplicatorStart(MysqlIsolatedServer mysql) throws SQLException {}
+
+	public void beforeReplicatorStart(MysqlIsolatedServer mysql, MaxwellConfig mutableConfig) throws SQLException {
+		beforeReplicatorStart(mysql);
+		mutableConfig.initPosition = Position.capture(mysql.getConnection(), inGtidMode());
+	}
+
 	public void afterReplicatorStart(MysqlIsolatedServer mysql) throws SQLException {}
 	public void beforeTerminate(MysqlIsolatedServer mysql) { }
 }


### PR DESCRIPTION
This PR adds a --skip_positions=file1:123-456,file2:111-111 option. The intent behind this option is to allow maxwell to safely skip over a log entry in the event of a bug.

Question for reviewer: Currently, `testThatSkipPositionsDoesNotParseCrashes` does not work as intended. The intent here is to make sure that maxwell does not try to parse the binlog. The test is not strictly necessary, but if you can think of a way to test this, please let me know. I manually tested this by reverting https://github.com/zendesk/maxwell/pull/907/files, to give you an idea of the case that I am worrying about. If there was some way of injecting an invalid binlog into the stream that maxwell reads, that would be great.

Let me know if you want any changes. Thanks!