### PR TITLE
stop invalidating pre-millenia-one dates

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateFormatter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateFormatter.java
@@ -36,15 +36,9 @@ public class DateFormatter {
 			throw new RuntimeException("couldn't extract date/time out of " + value);
 	}
 
-	private static Timestamp MIN_DATE = Timestamp.valueOf("1000-01-01 00:00:00");
-
 	private static String format(SimpleDateFormat formatter, Timestamp ts) {
-		if ( ts.before(MIN_DATE) ) {
-			return null;
-		} else {
-			synchronized(formatter) {
-					return formatter.format(ts);
-			}
+		synchronized(formatter) {
+			return formatter.format(ts);
 		}
 	}
 

--- a/src/test/resources/sql/json/test_time
+++ b/src/test/resources/sql/json/test_time
@@ -5,6 +5,9 @@ set global time_zone = '-0:00';
 
 CREATE TABLE tt ( t time(6), small_t time(3), dt datetime(6), small_dt datetime(3), ts timestamp(4) NULL );
 
+insert into tt set dt = '0001-01-01 00-00-00';
+-> { "database": "timedb", "table": "tt", "type": "insert", "data": {"t": null, "small_t": null, "dt": "0001-01-01 00:00:00.000000", "small_dt": null, "ts": null } }
+
 insert into tt set t = '12:23:33.123456', small_t = '12:23:33.345', dt = '2012-01-01 22:32:34.222222', small_dt = '2012-01-01 22:32:34.123', ts = '2012-01-01 22:32:34.1234';
 -> { "database": "timedb", "table": "tt", "type": "insert", "data": {"t": "12:23:33.123456", "small_t": "12:23:33.345", "dt": "2012-01-01 22:32:34.222222", "small_dt": "2012-01-01 22:32:34.123", "ts": "2012-01-01 22:32:34.1234" } }
 


### PR DESCRIPTION
binlog-connector used to null these out for us, but that was incorrect behavior.

Addresses the second issue on #928 