### PR TITLE
fixes for detecting replication-hosts and maxwell-hosts as the same

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -595,11 +595,6 @@ public class MaxwellConfig extends AbstractConfig {
 			this.maxwellMysql.host = "localhost";
 		}
 
-		if ( !Objects.equals(replicationMysql, maxwellMysql) && !this.bootstrapperType.equals("none") ) {
-			LOGGER.warn("disabling bootstrapping; not available when using a separate replication host.");
-			this.bootstrapperType = "none";
-		}
-
 		if ( this.replicationMysql.host == null
 				|| this.replicationMysql.user == null ) {
 
@@ -679,6 +674,12 @@ public class MaxwellConfig extends AbstractConfig {
 
 		if (outputConfig.encryptionEnabled() && outputConfig.secretKey == null)
 			usage("--secret_key required");
+
+		if ( !maxwellMysql.sameServerAs(replicationMysql) && !this.bootstrapperType.equals("none") ) {
+			LOGGER.warn("disabling bootstrapping; not available when using a separate replication host.");
+			this.bootstrapperType = "none";
+		}
+
 	}
 
 	public Properties getKafkaProperties() {

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -131,6 +131,11 @@ public class MaxwellMysqlConfig {
 				Objects.equals(connectTimeoutMS, that.connectTimeoutMS);
 	}
 
+	public boolean sameServerAs(MaxwellMysqlConfig other) {
+		return Objects.equals(host, other.host) &&
+			Objects.equals(port, other.port);
+	}
+
 	@Override
 	public int hashCode() {
 		return Objects


### PR DESCRIPTION
pr #958 introduced a regression that disabled bootstrapping due to a bad equivalence check.
