### PR TITLE
Enable jvm metrics

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -273,6 +273,9 @@ sqs_queue_uri=aws_sqs_queue_uri
 # The prefix maxwell will apply to all metrics
 #metrics_prefix=MaxwellMetrics # default MaxwellMetrics
 
+# Enable (dropwizard) JVM metrics, default false
+#metrics_jvm=true
+
 # When metrics_type includes slf4j this is the frequency metrics are emitted to the log, in seconds
 #metrics_slf4j_interval=60
 

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -214,6 +214,7 @@ secret_key                     | STRING                              | specify t
 **monitoring**
 metrics_prefix | STRING | the prefix maxwell will apply to all metrics | MaxwellMetrics
 metrics_type         | [slf4j &#124; jmx &#124; http &#124; datadog]      | how maxwell metrics will be reported, at least one of slf4j &#124; jmx &#124; http &#124; datadog|
+metrics_jvm          | BOOLEAN                                            | enable jvm metrics, e.g. memory usage, GC stats, etc.| false
 metrics_slf4j_interval     | INT                                 | the frequency metrics are emitted to the log, in seconds, when slf4j reporting is configured | 60
 metrics_http_port         | INT                                 | the port the server will bind to when http reporting is configured (deprecated: use http_port) | 8080
 http_port                 | INT                                 | the port the server will bind to when http reporting is configured | 8080

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -87,6 +87,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public String metricsDatadogHost;
 	public int metricsDatadogPort;
 	public Long metricsDatadogInterval;
+	public boolean metricsJvm;
 
 	public MaxwellDiagnosticContext.Config diagnosticConfig;
 
@@ -285,6 +286,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "metrics_datadog_port", "the port to publish metrics to when metrics_datadog_type = udp" ).withRequiredArg();
 		parser.accepts( "http_diagnostic", "enable http diagnostic endpoint: true|false. default: false" ).withOptionalArg();
 		parser.accepts( "http_diagnostic_timeout", "the http diagnostic response timeout in ms when http_diagnostic=true. default: 10000" ).withRequiredArg();
+		parser.accepts( "metrics_jvm", "enable jvm metrics: true|false. default: false" ).withRequiredArg();
 
 		parser.accepts( "__separator_11" );
 
@@ -442,6 +444,8 @@ public class MaxwellConfig extends AbstractConfig {
 		this.metricsDatadogHost = fetchOption("metrics_datadog_host", options, properties, "localhost");
 		this.metricsDatadogPort = Integer.parseInt(fetchOption("metrics_datadog_port", options, properties, "8125"));
 		this.metricsDatadogInterval = fetchLongOption("metrics_datadog_interval", options, properties, 60L);
+
+		this.metricsJvm = fetchBooleanOption("metrics_jvm", options, properties, false);
 
 		this.diagnosticConfig = new MaxwellDiagnosticContext.Config();
 		this.diagnosticConfig.enable = fetchBooleanOption("http_diagnostic", options, properties, false);

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.codahale.metrics.jvm.*;
 import com.zendesk.maxwell.MaxwellConfig;
 import org.apache.commons.lang.StringUtils;
 import org.coursera.metrics.datadog.DatadogReporter;
@@ -43,6 +44,14 @@ public class MaxwellMetrics implements Metrics {
 		}
 
 		metricsPrefix = config.metricsPrefix;
+
+		if (config.metricsJvm) {
+			config.metricRegistry.register(metricName("jvm", "memory_usage"), new MemoryUsageGaugeSet());
+			config.metricRegistry.register(metricName("jvm", "gc"), new GarbageCollectorMetricSet());
+			config.metricRegistry.register(metricName("jvm", "class_loading"), new ClassLoadingGaugeSet());
+			config.metricRegistry.register(metricName("jvm", "file_descriptor_ratio"), new FileDescriptorRatioGauge());
+			config.metricRegistry.register(metricName("jvm", "thread_states"), new CachedThreadStatesGaugeSet(60, TimeUnit.SECONDS));
+		}
 
 		if (config.metricsReportingType.contains(reportingTypeSlf4j)) {
 			final Slf4jReporter reporter = Slf4jReporter.forRegistry(config.metricRegistry)


### PR DESCRIPTION
/cc @zendesk/goanna 

It's handy to use dropwizard jvm metrics. It's particularly useful when jmx fetch isn't the best option.