### PR TITLE
Fix one race in SchemaCapturer

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -192,10 +192,10 @@ public class SchemaCapturer {
 		pkPreparedStatement.setString(1, db.getName());
 		ResultSet rs = pkPreparedStatement.executeQuery();
 
-		HashMap<String, ArrayList<String>> l = new HashMap<>();
+		HashMap<String, ArrayList<String>> tablePKMap = new HashMap<>();
 
 		for (String tableName : tables.keySet()) {
-			l.put(tableName, new ArrayList<String>());
+			tablePKMap.put(tableName, new ArrayList<String>());
 		}
 
 		while (rs.next()) {
@@ -203,7 +203,9 @@ public class SchemaCapturer {
 			String tableName = rs.getString("TABLE_NAME");
 			String columnName = rs.getString("COLUMN_NAME");
 
-			l.get(tableName).add(ordinalPosition - 1, columnName);
+			ArrayList<String> pkList = tablePKMap.get(tableName);
+			if ( pkList != null )
+				pkList.add(ordinalPosition - 1, columnName);
 		}
 		rs.close();
 
@@ -211,7 +213,7 @@ public class SchemaCapturer {
 			String key = entry.getKey();
 			Table table = entry.getValue();
 
-			table.setPKList(l.get(key));
+			table.setPKList(tablePKMap.get(key));
 		}
 	}
 
@@ -240,5 +242,5 @@ public class SchemaCapturer {
 		}
 		return result.toArray(new String[0]);
 	}
-	
+
 }


### PR DESCRIPTION
In this race, a table is added between when we capture the tables and
when we capture the PKs.  This race, when encountered, will not cause a
future crash as we will simply process the `CREATE TABLE` after the
schema is captured.

Addresses #950.

Note that this is not the end of race conditions inside `SchemaCapturer`; other races will cause crashes after processing the racing DDL, or, in some cases, a corrupt view of the schema.