### PR TITLE
support predefined database name to partition mapping for kafka producer

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -118,6 +118,9 @@ password=maxwell
 # hash function to use.  "default" is just the JVM's 'hashCode' function.
 #kafka_partition_hash=default # [default, murmur3]
 
+# for predefined database name to partition mapping
+#kafka_partition_config_file=./maxwell-partitions.properties.example
+
 # how maxwell writes its kafka key.
 #
 # 'hash' looks like:

--- a/maxwell-partitions.properties.example
+++ b/maxwell-partitions.properties.example
@@ -1,0 +1,4 @@
+#database name to partition mapping
+db1=1
+db2=2
+db3=3

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -50,6 +50,8 @@ public class MaxwellConfig extends AbstractConfig {
 	public String kafkaPartitionKey;
 	public String kafkaPartitionColumns;
 	public String kafkaPartitionFallback;
+	public String kafkaPartitionConfigFile;
+	public Map<String, Integer> kafkaPartitionMap;
 	public String bootstrapperType;
 	public int bufferedProducerSize;
 
@@ -363,6 +365,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.kafkaPartitionKey  	= fetchOption("kafka_partition_by", options, properties, null);
 		this.kafkaPartitionColumns  = fetchOption("kafka_partition_columns", options, properties, null);
 		this.kafkaPartitionFallback = fetchOption("kafka_partition_by_fallback", options, properties, null);
+		this.kafkaPartitionConfigFile = fetchOption("kafka_partition_config_file", options, properties, null);
 
 		this.kafkaPartitionHash 	= fetchOption("kafka_partition_hash", options, properties, "default");
 		this.ddlKafkaTopic 		    = fetchOption("ddl_kafka_topic", options, properties, this.kafkaTopic);
@@ -517,6 +520,15 @@ public class MaxwellConfig extends AbstractConfig {
 		if (outputConfig.encryptionEnabled()) {
 			outputConfig.secretKey = fetchOption("secret_key", options, properties, null);
 		}
+
+		if (this.kafkaPartitionConfigFile != null) {
+			kafkaPartitionMap = new HashMap<>();
+			Properties partitionProps = readPropertiesFile(this.kafkaPartitionConfigFile, true);
+
+			for (String databaseName: partitionProps.stringPropertyNames()) {
+				kafkaPartitionMap.put(databaseName, Integer.parseInt(partitionProps.getProperty(databaseName)));
+			}
+		}
 	}
 
 	private Properties parseFile(String filename, Boolean abortOnMissing) {
@@ -554,7 +566,6 @@ public class MaxwellConfig extends AbstractConfig {
 		} else if ( this.producerPartitionKey.equals("column") && StringUtils.isEmpty(this.producerPartitionFallback) ) {
 			usageForOptions("please specify --producer_partition_by_fallback=[database, table, primary_key] when using producer_partition_by=column", "producer_partition_by_fallback");
 		}
-
 	}
 
 	public void validate() {

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/AbstractMaxwellKafkaPartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/AbstractMaxwellKafkaPartitioner.java
@@ -1,0 +1,12 @@
+package com.zendesk.maxwell.producer.partitioners;
+
+import com.zendesk.maxwell.row.RowMap;
+
+public abstract class AbstractMaxwellKafkaPartitioner extends AbstractMaxwellPartitioner {
+
+	public AbstractMaxwellKafkaPartitioner(String partitionKey, String csvPartitionColumns, String partitionKeyFallback) {
+		super(partitionKey, csvPartitionColumns, partitionKeyFallback);
+	}
+
+	public abstract int kafkaPartition(RowMap r, int numPartitions);
+}

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaDBNamePartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaDBNamePartitioner.java
@@ -1,0 +1,20 @@
+package com.zendesk.maxwell.producer.partitioners;
+
+import com.zendesk.maxwell.row.RowMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MaxwellKafkaDBNamePartitioner extends AbstractMaxwellKafkaPartitioner {
+	private Map<String, Integer> kafkaPartitionMap;
+
+	public MaxwellKafkaDBNamePartitioner(Map<String, Integer> kafkaPartitionMap) {
+		super(null, null, null);
+		this.kafkaPartitionMap = kafkaPartitionMap;
+	}
+
+	@Override
+	public int kafkaPartition(RowMap r, int numPartitions) {
+		return kafkaPartitionMap.get(r.getDatabase());
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaPartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaPartitioner.java
@@ -2,7 +2,7 @@ package com.zendesk.maxwell.producer.partitioners;
 
 import com.zendesk.maxwell.row.RowMap;
 
-public class MaxwellKafkaPartitioner extends AbstractMaxwellPartitioner {
+public class MaxwellKafkaPartitioner extends AbstractMaxwellKafkaPartitioner {
 	HashFunction hashFunc;
 
 	public MaxwellKafkaPartitioner(String hashFunction, String partitionKey, String csvPartitionColumns, String partitionKeyFallback) {
@@ -19,6 +19,7 @@ public class MaxwellKafkaPartitioner extends AbstractMaxwellPartitioner {
 		}
 	}
 
+	@Override
 	public int kafkaPartition(RowMap r, int numPartitions) {
 		return Math.abs(hashFunc.hashCode(this.getHashString(r)) % numPartitions);
 	}

--- a/src/test/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaDBNamePartitionerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/partitioners/MaxwellKafkaDBNamePartitionerTest.java
@@ -1,0 +1,22 @@
+package com.zendesk.maxwell.producer.partitioners;
+
+import com.zendesk.maxwell.row.RowMap;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaxwellKafkaDBNamePartitionerTest {
+	@Test
+	public void testKafkaPartitionBasedOnPartionMap() {
+		Map<String, Integer> partitionMap = new HashMap<>();
+		partitionMap.put("db1", 1);
+		partitionMap.put("db2", 2);
+		MaxwellKafkaDBNamePartitioner p = new MaxwellKafkaDBNamePartitioner(partitionMap);
+		int partition = p.kafkaPartition(new RowMap("insert", "db1", "table", 1234L, null, null, null), 1);
+
+		assertEquals(1, partition);
+	}
+}


### PR DESCRIPTION
When using the default kafka partitioner, the partition is computed as 
```
Math.abs(hashFunc.hashCode(databaseName) % numPartitions);
```
Which is hard to control which partition for the events from one database to land on. Using a property file we can define the partition for each database explicitly. 

/cc @osheroff @zendesk/goanna 