### PR TITLE
revert alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM openjdk:8u151-jdk-alpine
+FROM maven:3.5-jdk-8
 ENV MAXWELL_VERSION=1.14.6 KAFKA_VERSION=0.11.0.1
 
-RUN apk --no-cache add --virtual .build-dependencies make maven
-RUN apk --no-cache add java-snappy-native bash
-
 COPY . /workspace
-RUN cd /workspace \
+
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install -y make \
+    && cd /workspace \
     && KAFKA_VERSION=$KAFKA_VERSION make package MAXWELL_VERSION=$MAXWELL_VERSION \
     && mkdir /app \
     && mv /workspace/target/maxwell-$MAXWELL_VERSION/maxwell-$MAXWELL_VERSION/* /app/ \
-    && apk del .build-dependencies \
-    && rm -rf /tmp/* /var/tmp/* /usr/share/doc/* /workspace/ /root/.m2/ \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* /workspace/ /root/.m2/ \
     && echo "$MAXWELL_VERSION" > /REVISION
 
 WORKDIR /app

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -53,14 +53,6 @@ kafka.retries = 5 # or some larger number
 
 And you will also want to set `min.insync.replicas` on Maxwell's output topic.
 
-#### Snappy compression
-
-If Maxwell is run in a container and snappy compression is enabled,
-```
--Dorg.xerial.snappy.use.systemlib=true
-```
-should be added to the `$JAVA_OPTS`.
-
 #### Keys
 
 Maxwell generates keys for its Kafka messages based upon a mysql row's primary key in JSON format:


### PR DESCRIPTION
This broke snappy at first, and then it broke the kinesis producer.  Two
strikes is plenty.