### PR TITLE
fix schema resolver issue for master failover

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -576,7 +576,7 @@ public class MysqlSavedSchema {
 				"SELECT id from `schemas` " +
 				"WHERE deleted = 0 AND " +
 				"last_heartbeat_read <= ? AND " +
-			    "((binlog_file < ?) OR " +
+				"((binlog_file < ?) OR " +
 				"(binlog_file = ? AND binlog_position < ?) OR " +
 				"(binlog_file = ? AND binlog_position = ? AND deltas = '[]')) AND " + // master failover
 				"server_id = ? " +


### PR DESCRIPTION
When master fails over, we write a record in `schemas` table with the recovered position from the new master and `[]` as `deltas`. We'd use the this schema change as the latest schema during schema resolving. 

/cc @zendesk/goanna @osheroff 