### PR TITLE
update to kafka 1.0, muck with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM maven:3.5-jdk-8
-ENV MAXWELL_VERSION=1.14.7 KAFKA_VERSION=0.11.0.1
-
-COPY . /workspace
+ENV MAXWELL_VERSION=1.14.7 KAFKA_VERSION=1.0.0
 
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y make \
-    && cd /workspace \
+    && apt-get install -y make
+
+# prime so we can have a cached image of the maven deps
+COPY pom.xml /tmp
+RUN cd /tmp && mvn dependency:resolve
+
+COPY . /workspace
+RUN cd /workspace \
     && KAFKA_VERSION=$KAFKA_VERSION make package MAXWELL_VERSION=$MAXWELL_VERSION \
     && mkdir /app \
     && mv /workspace/target/maxwell-$MAXWELL_VERSION/maxwell-$MAXWELL_VERSION/* /app/ \
@@ -16,4 +20,4 @@ RUN apt-get update \
 
 WORKDIR /app
 
-CMD [ "/bin/bash", "-c", "bin/maxwell --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=kafka --kafka.bootstrap.servers=$KAFKA_HOST:$KAFKA_PORT $MAXWELL_OPTIONS" ]
+CMD [ "/bin/bash", "-c", "bin/maxwell-docker" ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KAFKA_VERSION ?= 0.11.0.1
+KAFKA_VERSION ?= 1.0.0
 KAFKA_PROFILE = kafka-${KAFKA_VERSION}
 export JAVA_TOOL_OPTIONS = -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
@@ -16,7 +16,7 @@ clean:
 depclean: clean
 	rm -f $(CLASSPATH)
 
-package: depclean kafka-0.8.2.2 kafka-0.9.0.1 kafka-0.10.0.1 kafka-0.10.2.1 kafka-0.11.0.1
+package: depclean kafka-0.8.2.2 kafka-0.9.0.1 kafka-0.10.0.1 kafka-0.10.2.1 kafka-0.11.0.1 kafka-1.0.0
 	@# TODO: this is inefficient, we really just want to copy the jars...
 	mvn package -DskipTests=true
 

--- a/bin/maxwell
+++ b/bin/maxwell
@@ -12,7 +12,7 @@ fi
 
 CLASSPATH="$CLASSPATH:$lib_dir/*"
 
-KAFKA_VERSION="0.11.0.1"
+KAFKA_VERSION="1.0.0"
 
 function use_kafka() {
 	wanted="$1"

--- a/bin/maxwell-docker
+++ b/bin/maxwell-docker
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+MAXWELL_PRODUCER=${MAXWELL_PRODUCER:-kafka}
+
+if [ "$MAXWELL_PRODUCER" == "kafka" ]
+then
+  if [ -z "$KAFKA_BROKERS" ]
+  then
+    KAFKA_BROKERS="$KAFKA_HOST:$KAFKA_PORT"
+  fi
+  MAXWELL_OPTIONS="$MAXWELL_OPTIONS --kafka.bootstrap.servers=$KAFKA_BROKERS"
+fi
+
+exec `dirname $0`/maxwell  --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD --host=$MYSQL_HOST --producer=$MAXWELL_PRODUCER $MAXWELL_OPTIONS

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -8,9 +8,9 @@ latter case 'database' and 'table' will be replaced with the values for the row
 being processed. This can be changed with the `kafka_topic` option.
 
 #### Client version
-By default, maxwell uses the kafka 0.11.0.1 library. The `--kafka_version` flag
+By default, maxwell uses the kafka 1.0.0 library. The `--kafka_version` flag
 lets you choose an alternate library version: 0.8.2.2, 0.9.0.1, 0.10.0.1, 0.10.2.1 or
-0.11.0.1.  This flag is only available on the command line.
+0.11.0.1, 1.0.0.  This flag is only available on the command line.
 
 
 - The 0.8.2.2 client is only compatible with brokers running kafka 0.8.

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,16 @@
     </profile>
     <profile>
       <id>kafka-0.11.0.1</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+          <version>0.11.0.1</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>kafka-1.0.0</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
@@ -93,7 +103,7 @@
         <dependency>
           <groupId>org.apache.kafka</groupId>
           <artifactId>kafka-clients</artifactId>
-          <version>0.11.0.1</version>
+          <version>1.0.0</version>
         </dependency>
       </dependencies>
     </profile>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -186,7 +186,7 @@ public class MaxwellConfig extends AbstractConfig {
 			+ "comma separated.").withRequiredArg();
 		parser.accepts( "producer_partition_by_fallback", "database|table|primary_key, fallback to this value when using 'column' partitioning and the columns are not present in the row").withRequiredArg();
 
-		parser.accepts( "kafka_version", "kafka client library version: 0.8.2.2|0.9.0.1|0.10.0.1|0.10.2.1|0.11.0.1").withRequiredArg();
+		parser.accepts( "kafka_version", "kafka client library version: 0.8.2.2|0.9.0.1|0.10.0.1|0.10.2.1|0.11.0.1|1.0.0").withRequiredArg();
 		parser.accepts( "kafka_partition_by", "[deprecated]").withRequiredArg();
 		parser.accepts( "kafka_partition_columns", "[deprecated]").withRequiredArg();
 		parser.accepts( "kafka_partition_by_fallback", "[deprecated]").withRequiredArg();


### PR DESCRIPTION
we add an intermediate maxwell-docker shell script in order to support both KAFKA_HOST:KAFKA_PORT and KAFKA_BROKERS style args.  

I also mucked with the Dockerfile a bit to support faster rebuilds.