### PR TITLE
Hoist column-level filters into `--filter` system

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -272,23 +272,43 @@ should be unique across all mysql and maxwell instances.
 ### Filtering
 ***
 
+#### Example 1
 Maxwell can be configured to filter out updates from specific tables.  This is controlled
 by the `--filter` command line flag.  Here's how that flag looks:
 
 ```
-bin/maxwell --filter = "exclude: foodb.*, include: foodb.tbl, include: foodb./table_\d+/"
+--filter = "exclude: foodb.*, include: foodb.tbl, include: foodb./table_\d+/"
 ```
 
 This example tells Maxwell to suppress all updates that happen on `foodb`, except for updates
 to `tbl` and any table in foodb matching the regexp `/table_\d+/`.
-
-
-```
-bin/maxwell --filter = "exclude: *.*, include: db1.*"
-```
+#### Example 2
 
 Filter options are evaluated in the order specified, so in this example we
 suppress everything except updates in the `db1` database.
+
+```
+--filter = "exclude: *.*, include: db1.*"
+```
+
+
+#### Column Filters
+Maxwell can also include/exclude based on column values:
+
+```
+--filter = "exclude: db.tbl.col = reject"
+```
+
+will reject any row in `db.tbl` that contains `col` and where the stringified value of "col" is "reject".
+
+#### Column Filters / Missing Columns
+Column filters are ignored if the specified column is not present, so:
+
+```
+--filter = "exclude: *.*.col_a = *"
+```
+
+will exclude updates to any table that contains `col_a`, but include every other table.
 
 
 #### Blacklisting tables
@@ -297,7 +317,7 @@ In rare cases, you may wish to tell Maxwell to completely ignore a database or
 table, including schema changes.  In general, don't use this.  If you must use this:
 
 ```
-bin/maxwell --filter = "blacklist: bad_db.*"
+--filter = "blacklist: bad_db.*"
 ```
 
 Note that once Maxwell has been running with a table or database marked as
@@ -310,7 +330,4 @@ blacklisting a table or database, you will have to drop the maxwell schema first
 If you wish to suppress columns from Maxwell's output (for instance, a password field),
 you can use `exclude_columns` to filter out columns by name.
 
-#### Filtering on column values
-Maxwell can filter rows to only match when a column contains a specific value.  The `include_column_values` option takes a comma-separated
-list of column/value pairs: "bar=x,foo=y".  Note that if a column does not exist in a table, it will ignore the value-filter.
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -245,8 +245,8 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "exclude_tables", "[deprecated]" ).withRequiredArg();
 		parser.accepts( "blacklist_dbs", "[deprecated]" ).withRequiredArg();
 		parser.accepts( "blacklist_tables", "[deprecated]" ).withRequiredArg();
-		parser.accepts( "filter", "filter specs.  specify like \"include:db.*, exclude:*.tbl, include: foo./.*bar$/\"");
-		parser.accepts( "include_column_values", "include only rows with these values formatted as include_column_values=C=x,D=y" ).withRequiredArg();
+		parser.accepts( "filter", "filter specs.  specify like \"include:db.*, exclude:*.tbl, include: foo./.*bar$/, exclude:foo.bar.baz=reject\"").withRequiredArg();
+		parser.accepts( "include_column_values", "[deprecated]" ).withRequiredArg();
 
 		parser.accepts( "__separator_8" );
 
@@ -569,7 +569,7 @@ public class MaxwellConfig extends AbstractConfig {
 			return;
 		try {
 			if ( this.filterList != null ) {
-				this.filter = new Filter(filterList, includeColumnValues);
+				this.filter = new Filter(filterList);
 			} else {
 				boolean hasOldStyleFilters =
 					includeDatabases != null ||
@@ -577,7 +577,8 @@ public class MaxwellConfig extends AbstractConfig {
 						includeTables != null ||
 						excludeTables != null ||
 						blacklistDatabases != null ||
-						blacklistTables != null;
+						blacklistTables != null ||
+						includeColumnValues != null;
 
 				if ( hasOldStyleFilters ) {
 					this.filter = Filter.fromOldFormat(
@@ -594,7 +595,7 @@ public class MaxwellConfig extends AbstractConfig {
 				}
 			}
 		} catch (InvalidFilterException e) {
-			usage("Invalid filter options: " + e.getLocalizedMessage());
+			usageForOptions("Invalid filter options: " + e.getLocalizedMessage(), "filter");
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/filtering/Filter.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/Filter.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.filtering;
 
+import com.zendesk.maxwell.schema.Table;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,35 +38,21 @@ public class Filter {
 		return new ArrayList<>(this.patterns);
 	}
 
-	private boolean matchesValues(Map<String, Object> data) {
-		for (Map.Entry<String, String> entry : includeColumnValues.entrySet()) {
-			String column = entry.getKey();
-
-			if (data.containsKey(column)) {
-				String expectedColumnValue = entry.getValue();
-				Object value = data.get(column);
-
-				if ("NULL".equals(expectedColumnValue)) {
-					// null or "null" (string) or "NULL" (string) is expected
-					if (value != null && !"null".equals(value) && !"NULL".equals(value)) {
-						return false;
-					}
-				} else {
-					if (value == null || !expectedColumnValue.equals(value.toString())) {
-						return false;
-					}
-				}
-			}
-		}
-
-		return true;
-	}
 
 	public boolean includes(String database, String table) {
 		FilterResult match = new FilterResult();
 
 		for ( FilterPattern p : patterns )
 			p.match(database, table, match);
+
+		return match.include;
+	}
+
+	public boolean includes(String database, String table, Map<String, Object> values) {
+		FilterResult match = new FilterResult();
+
+		for ( FilterPattern p : patterns )
+			p.matchValue(database, table, values, match);
 
 		return match.include;
 	}
@@ -105,11 +92,11 @@ public class Filter {
 		}
 	}
 
-	public static boolean matchesValues(Filter filter, Map<String, Object> data) {
+	public static boolean includes(Filter filter, String database, String table, Map<String, Object> data) {
 		if (filter == null) {
 			return true;
 		} else {
-			return filter.matchesValues(data);
+			return filter.includes(database, table, data);
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
@@ -1,9 +1,15 @@
 package com.zendesk.maxwell.filtering;
 
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class FilterColumnPattern extends FilterPattern {
+	private static final Logger LOGGER = LoggerFactory.getLogger(FilterColumnPattern.class);
 	private final String columnName;
 	private final Pattern columnPattern;
 	private final boolean columnPatternIsNull;
@@ -40,6 +46,13 @@ public class FilterColumnPattern extends FilterPattern {
 				}
 			}
 		}
+	}
+
+	@Override
+	public boolean couldIncludeColumn(String database, String table, Set<String> columns) {
+		return type == FilterPatternType.INCLUDE
+			&& appliesTo(database, table)
+			&& columns.contains(columnName);
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
@@ -1,0 +1,50 @@
+package com.zendesk.maxwell.filtering;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class FilterColumnPattern extends FilterPattern {
+	private final String columnName;
+	private final Pattern columnPattern;
+	private final boolean columnPatternIsNull;
+
+	public FilterColumnPattern(
+		FilterPatternType type,
+		Pattern dbPattern,
+		Pattern tablePattern,
+		String columnName,
+		Pattern columnPattern
+	) {
+		super(type, dbPattern, tablePattern);
+		this.columnName = columnName;
+		this.columnPattern = columnPattern;
+		this.columnPatternIsNull = "^null$".equals(columnPattern.toString().toLowerCase());
+	}
+
+	@Override
+	public void match(String database, String table, FilterResult match) { }
+
+	@Override
+	public void matchValue(String database, String table, Map<String, Object> data, FilterResult match) {
+		if ( appliesTo(database, table) && data.containsKey(columnName) ) {
+			Object value = data.get(columnName);
+
+			if ( columnPatternIsNull ) {
+				// null or "null" (string) or "NULL" (string) is expected
+				if (value == null || "null".equals(value) || "NULL".equals(value)) {
+					match.include = (this.type == FilterPatternType.INCLUDE);
+				}
+			} else if ( value != null ) {
+				if ( columnPattern.matcher(value.toString()).find() ) {
+					match.include = (this.type == FilterPatternType.INCLUDE);
+				}
+			}
+		}
+	}
+
+	@Override
+	public String toString() {
+		String filterString = super.toString();
+		return filterString + "." + columnName + "=" + patternToString(columnPattern);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
@@ -32,20 +32,28 @@ public class FilterColumnPattern extends FilterPattern {
 
 	@Override
 	public void matchValue(String database, String table, Map<String, Object> data, FilterResult match) {
+		boolean applyFilter = false;
 		if ( appliesTo(database, table) && data.containsKey(columnName) ) {
 			Object value = data.get(columnName);
 
 			if ( columnPatternIsNull ) {
 				// null or "null" (string) or "NULL" (string) is expected
 				if (value == null || "null".equals(value) || "NULL".equals(value)) {
-					match.include = (this.type == FilterPatternType.INCLUDE);
+					applyFilter = true;
 				}
-			} else if ( value != null ) {
+			} else if ( value == null ) {
+				// wildcards match the null value
+				if ( columnPattern.pattern().length() == 0 )
+					applyFilter = true;
+			} else {
 				if ( columnPattern.matcher(value.toString()).find() ) {
 					match.include = (this.type == FilterPatternType.INCLUDE);
 				}
 			}
 		}
+
+		if ( applyFilter )
+			match.include = (this.type == FilterPatternType.INCLUDE);
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterColumnPattern.java
@@ -46,9 +46,8 @@ public class FilterColumnPattern extends FilterPattern {
 				if ( columnPattern.pattern().length() == 0 )
 					applyFilter = true;
 			} else {
-				if ( columnPattern.matcher(value.toString()).find() ) {
-					match.include = (this.type == FilterPatternType.INCLUDE);
-				}
+				if ( columnPattern.matcher(value.toString()).find() )
+					applyFilter = true;
 			}
 		}
 

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterParser.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterParser.java
@@ -110,7 +110,6 @@ public class FilterParser {
 			skipToken('=');
 			Pattern valuePattern = parsePattern();
 			ret = new FilterColumnPattern(type, dbPattern, tablePattern, columnName, valuePattern);
-			System.out.println("weird. " + ret.toString());
 		} else {
 			ret = new FilterPattern(type, dbPattern, tablePattern);
 		}

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterParser.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterParser.java
@@ -110,6 +110,7 @@ public class FilterParser {
 			skipToken('=');
 			Pattern valuePattern = parsePattern();
 			ret = new FilterColumnPattern(type, dbPattern, tablePattern, columnName, valuePattern);
+			System.out.println("weird. " + ret.toString());
 		} else {
 			ret = new FilterPattern(type, dbPattern, tablePattern);
 		}

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterPattern.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterPattern.java
@@ -1,9 +1,10 @@
 package com.zendesk.maxwell.filtering;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class FilterPattern {
-	private final FilterPatternType type;
+	protected final FilterPatternType type;
 	private final Pattern dbPattern, tablePattern;
 
 	public FilterPattern(FilterPatternType type, Pattern dbPattern, Pattern tablePattern) {
@@ -12,10 +13,17 @@ public class FilterPattern {
 		this.tablePattern = tablePattern;
 	}
 
+	protected boolean appliesTo(String database, String table) {
+		return (database == null || dbPattern.matcher(database).find())
+			&& (table == null || tablePattern.matcher(table).find());
+	}
 	public void match(String database, String table, FilterResult match) {
-		if ( (database == null || dbPattern.matcher(database).find())
-		  && (table == null || tablePattern.matcher(table).find()) )
+		if ( appliesTo(database, table) )
 			match.include = (this.type == FilterPatternType.INCLUDE);
+	}
+
+	public void matchValue(String database, String table, Map<String, Object> data, FilterResult match) {
+		match(database, table, match);
 	}
 
 	public FilterPatternType getType() {
@@ -30,7 +38,7 @@ public class FilterPattern {
 		return tablePattern;
 	}
 
-	private String patternToString(Pattern p) {
+	protected String patternToString(Pattern p) {
 		String s = p.pattern();
 
 		if ( s.equals("") ) {

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterPattern.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterPattern.java
@@ -1,6 +1,8 @@
 package com.zendesk.maxwell.filtering;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class FilterPattern {
@@ -66,5 +68,9 @@ public class FilterPattern {
 		}
 
 		return s + patternToString(dbPattern) + "." + patternToString(tablePattern);
+	}
+
+	public boolean couldIncludeColumn(String database, String table, Set<String> columns) {
+		return false;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/AbstractReplicator.java
@@ -129,7 +129,7 @@ public abstract class AbstractReplicator extends RunLoopProcess implements Repli
 
 
 	protected boolean shouldOutputRowMap(String database, String table, RowMap rowMap, Filter filter) {
-		return Filter.matchesValues(filter, rowMap.getData());
+		return Filter.includes(filter, database, table, rowMap.getData());
 	}
 
 	/**

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -8,6 +8,7 @@ import com.github.shyiko.mysql.binlog.network.SSLMode;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.MaxwellMysqlConfig;
 import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
+import com.zendesk.maxwell.filtering.Filter;
 import com.zendesk.maxwell.monitoring.Metrics;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.row.RowMap;
@@ -184,7 +185,7 @@ public class BinlogConnectorReplicator extends AbstractReplicator implements Rep
 				case EXT_DELETE_ROWS:
 					Table table = tableCache.getTable(event.getTableID());
 
-					if ( table != null && shouldOutputEvent(table.getDatabase(), table.getName(), filter) ) {
+					if ( table != null && shouldOutputEvent(table.getDatabase(), table.getName(), filter, table.getColumnNames()) ) {
 						for ( RowMap r : event.jsonMaps(table, lastHeartbeatPosition, currentQuery) )
 							if (shouldOutputRowMap(table.getDatabase(), table.getName(), r, filter)) {
 								buffer.add(r);

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -47,6 +47,11 @@ public class Table {
 		return columns.getList();
 	}
 
+	@JsonIgnore
+	public Set<String> getColumnNames() {
+		return columns.columnNames();
+	}
+
 	@JsonProperty("columns")
 	public void setColumnList(List<ColumnDef> list) {
 		this.columns = new TableColumnList(list);

--- a/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
+++ b/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
@@ -23,6 +23,10 @@ public class TableColumnList implements Iterable<ColumnDef> {
 		return columns;
 	}
 
+	public Set<String> columnNames() {
+		return columnOffsetMap.keySet();
+	}
+
 	public synchronized int indexOf(String name) {
 		String lcName = name.toLowerCase();
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -282,6 +282,59 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertTrue(Pattern.compile("\"account_id\":2").matcher(json).find());
 	}
 
+	static String insertColumnSQL[] = {
+		"INSERT into foo.bars set something = 'accept'",
+		"INSERT into foo.bars set something = 'reject'"
+	};
+
+	@Test
+	public void testExcludeColumnValues() throws Exception {
+		List<RowMap> list;
+
+		Filter filter = new Filter();
+		filter.addRule("exclude: foo.bars.something=reject");
+
+		list = getRowsForSQL(filter, insertColumnSQL, createDBs);
+
+		assertThat(list.size(), is(1));
+	}
+
+	@Test
+	public void testExcludeTableIncludeColumns() throws Exception {
+		List<RowMap> list;
+
+		Filter filter = new Filter();
+		filter.addRule("exclude: foo.bars, include: foo.bars.something=accept");
+
+		list = getRowsForSQL(filter, insertColumnSQL, createDBs);
+
+		assertThat(list.size(), is(1));
+	}
+
+	@Test
+	public void testExcludeIncludeColumns() throws Exception {
+		List<RowMap> list;
+
+		Filter filter = new Filter();
+		filter.addRule("exclude: foo.bars.something=*, include: foo.bars.something=accept");
+
+		list = getRowsForSQL(filter, insertColumnSQL, createDBs);
+
+		assertThat(list.size(), is(1));
+	}
+
+	@Test
+	public void testExcludeMissingColumns() throws Exception {
+		List<RowMap> list;
+
+		Filter filter = new Filter();
+		filter.addRule("exclude: foo.bars.notacolumn=*");
+
+		list = getRowsForSQL(filter, insertColumnSQL, createDBs);
+
+		assertThat(list.size(), is(2));
+	}
+
 	static String blacklistSQLDDL[] = {
 		"CREATE DATABASE nodatabase",
 		"CREATE TABLE nodatabase.noseeum (i int)",

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -335,6 +335,23 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertThat(list.size(), is(2));
 	}
 
+	@Test
+	public void testWildCardMatchesNull() throws Exception {
+		List<RowMap> list;
+
+		String nullInsert[] = {
+			"INSERT into foo.bars set something = NULL",
+			"INSERT into foo.bars set something = 'accept'"
+		};
+
+		Filter filter = new Filter();
+		filter.addRule("exclude: foo.bars.something=*");
+
+		list = getRowsForSQL(filter, nullInsert, createDBs);
+
+		assertThat(list.size(), is(0));
+	}
+
 	static String blacklistSQLDDL[] = {
 		"CREATE DATABASE nodatabase",
 		"CREATE TABLE nodatabase.noseeum (i int)",

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -91,12 +91,12 @@ public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 	}
 
 	protected Filter excludeTable(String name) throws InvalidFilterException {
-		Filter filter = new Filter("exclude: *." + name, "");
+		Filter filter = new Filter("exclude: *." + name);
 		return filter;
 	}
 
 	protected Filter excludeDb(String name) throws InvalidFilterException {
-		Filter filter = new Filter("exclude: " + name + ".*", "");
+		Filter filter = new Filter("exclude: " + name + ".*");
 		return filter;
 	}
 

--- a/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
+++ b/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
@@ -74,14 +74,14 @@ public class FilterTest {
 
 	@Test
 	public void TestExcludeAll() throws Exception {
-		Filter f = new Filter("exclude: *.*, include: foo.bar", "");
+		Filter f = new Filter("exclude: *.*, include: foo.bar");
 		assertTrue(f.includes("foo", "bar"));
 		assertFalse(f.includes("anything", "else"));
 	}
 
 	@Test
 	public void TestBlacklist() throws Exception {
-		Filter f = new Filter("blacklist: seria.*", "");
+		Filter f = new Filter("blacklist: seria.*");
 		assertTrue(f.includes("foo", "bar"));
 		assertFalse(f.includes("seria", "var"));
 		assertTrue(f.isDatabaseBlacklisted("seria"));
@@ -90,7 +90,7 @@ public class FilterTest {
 
 	@Test
 	public void TestColumnFiltersAreIgnoredByIncludes() throws Exception {
-		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val", "");
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val");
 		assertFalse(f.includes("foo", "bar"));
 	}
 
@@ -98,7 +98,7 @@ public class FilterTest {
 	public void TestColumnFilters() throws Exception {
 		Map<String, Object> map = new HashMap<>();
 		map.put("col", "val");
-		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val", "");
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val");
 		assertFalse(f.includes("foo", "bar"));
 		assertTrue(f.includes("foo", "bar", map));
 	}
@@ -107,7 +107,7 @@ public class FilterTest {
 	public void TestColumnFiltersFromOtherTables() throws Exception {
 		Map<String, Object> map = new HashMap<>();
 		map.put("col", "val");
-		Filter f = new Filter("exclude: *.*, include: no.go.col=val", "");
+		Filter f = new Filter("exclude: *.*, include: no.go.col=val");
 		assertFalse(f.includes("foo", "bar"));
 		assertFalse(f.includes("foo", "bar", map));
 	}
@@ -116,7 +116,7 @@ public class FilterTest {
 	public void TestNullValuesInData() throws Exception {
 		Map<String, Object> map = new HashMap<>();
 		map.put("col", null);
-		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null", "");
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
 		assertFalse(f.includes("foo", "bar"));
 		assertTrue(f.includes("foo", "bar", map));
 
@@ -163,5 +163,13 @@ public class FilterTest {
 		assertEquals("include: *./foo.*bar/", rules.get(1).toString());
 	}
 
+	@Test
+	public void TestOldFiltersIncludeColumnValues() throws Exception {
+		Filter f = Filter.fromOldFormat(null, null, null, null, null, null, "foo=bar");
+		List<FilterPattern> rules = f.getRules();
+		assertEquals(2, rules.size());
+		assertEquals("exclude: *.*.foo=*", rules.get(0).toString());
+		assertEquals("include: *.*.foo=bar", rules.get(1).toString());
+	}
 }
 

--- a/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
+++ b/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
@@ -3,7 +3,9 @@ package com.zendesk.maxwell.filtering;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
@@ -12,8 +14,7 @@ public class FilterTest {
 	private List<FilterPattern> filters;
 
 	private List<FilterPattern> runParserTest(String input) throws Exception {
-		FilterParser parser = new FilterParser(input);
-		return parser.parse();
+		return new FilterParser(input).parse();
 	}
 
 	@Test
@@ -64,6 +65,14 @@ public class FilterTest {
 	}
 
 	@Test
+	public void TestColumnFilterParse() throws Exception {
+		String input = "include: 1foo.bar.column=foo";
+		filters = runParserTest(input);
+		assertEquals(1, filters.size());
+		assertEquals(input, filters.get(0).toString());
+	}
+
+	@Test
 	public void TestExcludeAll() throws Exception {
 		Filter f = new Filter("exclude: *.*, include: foo.bar", "");
 		assertTrue(f.includes("foo", "bar"));
@@ -77,6 +86,46 @@ public class FilterTest {
 		assertFalse(f.includes("seria", "var"));
 		assertTrue(f.isDatabaseBlacklisted("seria"));
 		assertTrue(f.isTableBlacklisted("seria", "anything"));
+	}
+
+	@Test
+	public void TestColumnFiltersAreIgnoredByIncludes() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val", "");
+		assertFalse(f.includes("foo", "bar"));
+	}
+
+	@Test
+	public void TestColumnFilters() throws Exception {
+		Map<String, Object> map = new HashMap<>();
+		map.put("col", "val");
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val", "");
+		assertFalse(f.includes("foo", "bar"));
+		assertTrue(f.includes("foo", "bar", map));
+	}
+
+	@Test
+	public void TestColumnFiltersFromOtherTables() throws Exception {
+		Map<String, Object> map = new HashMap<>();
+		map.put("col", "val");
+		Filter f = new Filter("exclude: *.*, include: no.go.col=val", "");
+		assertFalse(f.includes("foo", "bar"));
+		assertFalse(f.includes("foo", "bar", map));
+	}
+
+	@Test
+	public void TestNullValuesInData() throws Exception {
+		Map<String, Object> map = new HashMap<>();
+		map.put("col", null);
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null", "");
+		assertFalse(f.includes("foo", "bar"));
+		assertTrue(f.includes("foo", "bar", map));
+
+		map.put("col", "null");
+		assertTrue(f.includes("foo", "bar", map));
+
+		map.remove("col");
+		assertFalse(f.includes("foo", "bar", map));
+
 	}
 
 	@Test
@@ -113,4 +162,6 @@ public class FilterTest {
 		assertEquals("exclude: *.*", rules.get(0).toString());
 		assertEquals("include: *./foo.*bar/", rules.get(1).toString());
 	}
+
 }
+


### PR DESCRIPTION
The only thing tricky here is that for efficiency's sake we do a two-pass filter:  first we check if the table for an event is included/excluded (based on database/table).  If we find that the table is excluded, we must make sure there's not a rule later that could bring a *row* out of the table in.

@ericwush 



