### PR TITLE
fix bootstrapping for JSON columns

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
@@ -14,13 +14,19 @@ public class JsonColumnDef extends ColumnDef {
 
 	@Override
 	public Object asJSON(Object value) {
-		try {
-			byte[] bytes = (byte[]) value;
-			String jsonString = bytes.length > 0 ? JsonBinary.parseAsString(bytes) : "null";
-			return new RawJSONString(jsonString);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
+		String jsonString;
+
+		if ( value instanceof String ) {
+			jsonString = (String) value;
+		} else {
+			try {
+				byte[] bytes = (byte[]) value;
+				jsonString = bytes.length > 0 ? JsonBinary.parseAsString(bytes) : "null";
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
 		}
+		return new RawJSONString(jsonString);
 	}
 
 	@Override

--- a/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
@@ -40,6 +40,12 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
+	public void testJSONType() throws Exception {
+		requireMinimumVersion(server.VERSION_5_7);
+		runJSON("json/bootstrap-json-type");
+	}
+
+	@Test
 	public void testBootstrapIsWhitelisted() throws Exception {
 		MaxwellFilter filter = new MaxwellFilter();
 		filter.includeDatabase("shard_1");


### PR DESCRIPTION
bootstrap values come back as strings from JDBC vs byte[] from binlog-connector.

fixes #1017 

