### PR TITLE
recapture the latest schema on start by recapture_schema flag

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -45,7 +45,7 @@ producer_partition_by          | [PARTITION_BY](#partition_by)       | input to 
 producer_partition_columns     | STRING                              | if partitioning by 'column', a comma separated list of columns |
 producer_partition_by_fallback | [PARTITION_BY_FALLBACK](#partition_by_fallback) | required when producer_partition_by=column.  Used when the column is missing |
 ignore_producer_error          | BOOLEAN              | Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. | true
-reset_schema_store             | BOOLEAN              | Clean out the existing schema store by truncating tables: `databases`, `tables`, `columns`, and `schemas` then recapture the latest schema. | false
+recapture_schema               | BOOLEAN              | recapture the latest schema. | false
 &nbsp;
 **"file" producer options**
 output_file                    | STRING                              | output file for `file` producer                     |

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -45,6 +45,7 @@ producer_partition_by          | [PARTITION_BY](#partition_by)       | input to 
 producer_partition_columns     | STRING                              | if partitioning by 'column', a comma separated list of columns |
 producer_partition_by_fallback | [PARTITION_BY_FALLBACK](#partition_by_fallback) | required when producer_partition_by=column.  Used when the column is missing |
 ignore_producer_error          | BOOLEAN              | Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. | true
+reset_schema_store             | BOOLEAN              | Clean out the existing schema store by truncating tables: `databases`, `tables`, `columns`, and `schemas` then recapture the latest schema. | false
 &nbsp;
 **"file" producer options**
 output_file                    | STRING                              | output file for `file` producer                     |

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -24,6 +24,7 @@ client_id                      | STRING               | unique text identifier f
 replica_server_id              | LONG                 | unique numeric identifier for this maxwell instance | 6379 (see [notes](#multiple-maxwell-instances))
 master_recovery                | BOOLEAN              | enable experimental master recovery code            | false
 gtid_mode                      | BOOLEAN              | enable GTID-based replication                       | false
+recapture_schema               | BOOLEAN              | recapture the latest schema. Not available in config.properties. | false
 &nbsp;
 replication_host               | STRING               | server to replicate from.  See [split server roles](#split-server-roles) | *schema-store host*
 replication_password           | STRING               | password on replication server                      | (none)
@@ -45,7 +46,6 @@ producer_partition_by          | [PARTITION_BY](#partition_by)       | input to 
 producer_partition_columns     | STRING                              | if partitioning by 'column', a comma separated list of columns |
 producer_partition_by_fallback | [PARTITION_BY_FALLBACK](#partition_by_fallback) | required when producer_partition_by=column.  Used when the column is missing |
 ignore_producer_error          | BOOLEAN              | Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. | true
-recapture_schema               | BOOLEAN              | recapture the latest schema. Not available in config.properties. | false
 &nbsp;
 **"file" producer options**
 output_file                    | STRING                              | output file for `file` producer                     |

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -45,7 +45,7 @@ producer_partition_by          | [PARTITION_BY](#partition_by)       | input to 
 producer_partition_columns     | STRING                              | if partitioning by 'column', a comma separated list of columns |
 producer_partition_by_fallback | [PARTITION_BY_FALLBACK](#partition_by_fallback) | required when producer_partition_by=column.  Used when the column is missing |
 ignore_producer_error          | BOOLEAN              | Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. | true
-recapture_schema               | BOOLEAN              | recapture the latest schema. | false
+recapture_schema               | BOOLEAN              | recapture the latest schema. Not available in config.properties. | false
 &nbsp;
 **"file" producer options**
 output_file                    | STRING                              | output file for `file` producer                     |

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -193,7 +193,7 @@ public class Maxwell implements Runnable {
 		MysqlSchemaStore mysqlSchemaStore = new MysqlSchemaStore(this.context, initPosition);
 
 		if (config.recaptureSchema) {
-			mysqlSchemaStore.recaptureSchema();
+			mysqlSchemaStore.captureAndSaveSchema();
 		}
 
 		mysqlSchemaStore.getSchema(); // trigger schema to load / capture before we start the replicator.

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -191,6 +191,11 @@ public class Maxwell implements Runnable {
 		this.context.setPosition(initPosition);
 
 		MysqlSchemaStore mysqlSchemaStore = new MysqlSchemaStore(this.context, initPosition);
+
+		if (config.resetSchemaStore) {
+			mysqlSchemaStore.destroy();
+		}
+
 		mysqlSchemaStore.getSchema(); // trigger schema to load / capture before we start the replicator.
 
 		this.replicator = new BinlogConnectorReplicator(mysqlSchemaStore, producer, bootstrapper, this.context, initPosition);

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -192,8 +192,8 @@ public class Maxwell implements Runnable {
 
 		MysqlSchemaStore mysqlSchemaStore = new MysqlSchemaStore(this.context, initPosition);
 
-		if (config.resetSchemaStore) {
-			mysqlSchemaStore.destroy();
+		if (config.recaptureSchema) {
+			mysqlSchemaStore.recaptureSchema();
 		}
 
 		mysqlSchemaStore.getSchema(); // trigger schema to load / capture before we start the replicator.

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -101,6 +101,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public boolean replayMode;
 	public boolean masterRecovery;
 	public boolean ignoreProducerError;
+	public boolean resetSchemaStore;
 
 	public String rabbitmqUser;
 	public String rabbitmqPass;
@@ -236,6 +237,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "master_recovery", "(experimental) enable master position recovery code" ).withOptionalArg();
 		parser.accepts( "gtid_mode", "(experimental) enable gtid mode" ).withOptionalArg();
 		parser.accepts( "ignore_producer_error", "Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. Default to true" ).withOptionalArg();
+		parser.accepts( "reset_schema_store", "Clean out the existing schema store by truncating tables: `databases`, `tables`, `columns`, and `schemas` then recapture the latest schema." ).withOptionalArg();
 
 		parser.accepts( "__separator_7" );
 
@@ -493,6 +495,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.replayMode =     fetchBooleanOption("replay", options, null, false);
 		this.masterRecovery = fetchBooleanOption("master_recovery", options, properties, false);
 		this.ignoreProducerError = fetchBooleanOption("ignore_producer_error", options, properties, true);
+		this.resetSchemaStore = fetchBooleanOption("reset_schema_store", options, properties, false);
 
 		outputConfig.includesBinlogPosition = fetchBooleanOption("output_binlog_position", options, properties, false);
 		outputConfig.includesGtidPosition = fetchBooleanOption("output_gtid_position", options, properties, false);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -495,7 +495,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.replayMode =     fetchBooleanOption("replay", options, null, false);
 		this.masterRecovery = fetchBooleanOption("master_recovery", options, properties, false);
 		this.ignoreProducerError = fetchBooleanOption("ignore_producer_error", options, properties, true);
-		this.recaptureSchema = fetchBooleanOption("recapture_schema", options, properties, false);
+		this.recaptureSchema = fetchBooleanOption("recapture_schema", options, null, false);
 
 		outputConfig.includesBinlogPosition = fetchBooleanOption("output_binlog_position", options, properties, false);
 		outputConfig.includesGtidPosition = fetchBooleanOption("output_gtid_position", options, properties, false);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -101,7 +101,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public boolean replayMode;
 	public boolean masterRecovery;
 	public boolean ignoreProducerError;
-	public boolean resetSchemaStore;
+	public boolean recaptureSchema;
 
 	public String rabbitmqUser;
 	public String rabbitmqPass;
@@ -237,7 +237,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "master_recovery", "(experimental) enable master position recovery code" ).withOptionalArg();
 		parser.accepts( "gtid_mode", "(experimental) enable gtid mode" ).withOptionalArg();
 		parser.accepts( "ignore_producer_error", "Maxwell will be terminated on kafka/kinesis errors when false. Otherwise, those producer errors are only logged. Default to true" ).withOptionalArg();
-		parser.accepts( "reset_schema_store", "Clean out the existing schema store by truncating tables: `databases`, `tables`, `columns`, and `schemas` then recapture the latest schema." ).withOptionalArg();
+		parser.accepts( "recapture_schema", "recapture the latest schema" ).withOptionalArg();
 
 		parser.accepts( "__separator_7" );
 
@@ -495,7 +495,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.replayMode =     fetchBooleanOption("replay", options, null, false);
 		this.masterRecovery = fetchBooleanOption("master_recovery", options, properties, false);
 		this.ignoreProducerError = fetchBooleanOption("ignore_producer_error", options, properties, true);
-		this.resetSchemaStore = fetchBooleanOption("reset_schema_store", options, properties, false);
+		this.recaptureSchema = fetchBooleanOption("recapture_schema", options, properties, false);
 
 		outputConfig.includesBinlogPosition = fetchBooleanOption("output_binlog_position", options, properties, false);
 		outputConfig.includesGtidPosition = fetchBooleanOption("output_gtid_position", options, properties, false);

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -606,35 +606,12 @@ public class MysqlSavedSchema {
 		this.schema = s;
 	}
 
-	private void ensureSchemaID() {
-		if ( this.schemaID == null ) {
-			throw new RuntimeException("Can't destroy uninitialized schema!");
-		}
-	}
-
 	private void setPosition(Position position) {
 		this.position = position;
 	}
 
 	public static void delete(Connection connection, long schema_id) throws SQLException {
 		connection.createStatement().execute("update `schemas` set deleted = 1 where id = " + schema_id);
-	}
-
-	public void destroy(Connection connection) throws SQLException {
-		ensureSchemaID();
-
-		String[] tables = { "databases", "tables", "columns" };
-		connection.createStatement().execute("delete from `schemas` where id = " + schemaID);
-		for ( String tName : tables ) {
-			connection.createStatement().execute("delete from `" + tName + "` where schema_id = " + schemaID);
-		}
-	}
-
-	public boolean schemaExists(Connection connection, long schema_id) throws SQLException {
-		if ( this.schemaID == null )
-			return false;
-		ResultSet rs = connection.createStatement().executeQuery("select id from `schemas` where id = " + schema_id);
-		return rs.next();
 	}
 
 	public BinlogPosition getBinlogPosition() {

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -86,6 +86,15 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 		}
 	}
 
+	public void destroy() throws SQLException {
+		try ( Connection conn = maxwellConnectionPool.getConnection() ) {
+			String[] tables = { "databases", "tables", "columns", "schemas" };
+			LOGGER.info("Maxwell is cleaning out existing schema store");
+			for ( String tName : tables ) {
+				conn.createStatement().execute("TRUNCATE TABLE `" + tName + "`");
+			}
+		}
+	}
 
 	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Position position) throws SchemaStoreException, InvalidSchemaError {
 		List<ResolvedSchemaChange> resolvedSchemaChanges;

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -65,7 +65,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 				restore(maxwellConnectionPool, serverID, caseSensitivity, initialPosition);
 
 			if ( savedSchema == null ) {
-				savedSchema = recaptureSchema();
+				savedSchema = captureAndSaveSchema();
 			}
 
 			return savedSchema;
@@ -76,7 +76,7 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 		}
 	}
 
-	public MysqlSavedSchema recaptureSchema() throws SQLException {
+	public MysqlSavedSchema captureAndSaveSchema() throws SQLException {
 		try ( Connection conn = maxwellConnectionPool.getConnection() ) {
 			MysqlSavedSchema savedSchema = new MysqlSavedSchema(serverID, caseSensitivity, captureSchema(), initialPosition);
 			if (!readOnly)


### PR DESCRIPTION
Provide a way to recapture the latest schema by `recapture_schema` config. 

**NOTE**: Only use this if there are no migrations between now and the current replicated position (from `positions` table). 

It can be used to fix schema issues.

/cc @zendesk/goanna @osheroff 