### PR TITLE
Add schema_id as an optional field in output

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -80,7 +80,7 @@ password=maxwell
 #output_gtid_position=true
 
 # records include fields with null values (default true).  If this is false,
-# fiels where the value is null will be omitted entirely from output.
+# fields where the value is null will be omitted entirely from output.
 #output_nulls=true
 
 # records include server_id (default false)
@@ -88,6 +88,9 @@ password=maxwell
 
 # records include thread_id (default false)
 #output_thread_id=true
+
+# records include schema_id (default false)
+#output_schema_id=true
 
 # records include row query, binlog option "binlog_rows_query_log_events" must be enabled" (default false)
 #output_row_query=true

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -101,6 +101,7 @@ output_xoffset                 | BOOLEAN  | records include virtual tx-row offse
 output_nulls                   | BOOLEAN  | records include fields with NULL values    | true
 output_server_id               | BOOLEAN  | records include server_id                  | false
 output_thread_id               | BOOLEAN  | records include thread_id                  | false
+output_schema_id               | BOOLEAN  | records include schema_id, schema_id is the id of the latest schema tracked by maxwell and doesn't relate to any mysql tracked value                  | false
 output_row_query               | BOOLEAN  | records include INSERT/UPDATE/DELETE statement. Mysql option "binlog_rows_query_log_events" must be enabled | false
 output_ddl                     | BOOLEAN  | output DDL (table-alter, table-create, etc) events  | false
 &nbsp;

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -220,6 +220,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "output_nulls", "produced records include fields with NULL values [true|false]. default: true" ).withOptionalArg();
 		parser.accepts( "output_server_id", "produced records include server_id; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_thread_id", "produced records include thread_id; [true|false]. default: false" ).withOptionalArg();
+		parser.accepts( "output_schema_id", "produced records include schema_id; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_row_query", "produced records include query, binlog option \"binlog_rows_query_log_events\" must be enabled; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_ddl", "produce DDL records to ddl_kafka_topic [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "exclude_columns", "suppress these comma-separated columns from output" ).withRequiredArg();
@@ -510,6 +511,7 @@ public class MaxwellConfig extends AbstractConfig {
 		outputConfig.includesNulls = fetchBooleanOption("output_nulls", options, properties, true);
 		outputConfig.includesServerId = fetchBooleanOption("output_server_id", options, properties, false);
 		outputConfig.includesThreadId = fetchBooleanOption("output_thread_id", options, properties, false);
+		outputConfig.includesSchemaId = fetchBooleanOption("output_schema_id", options, properties, false);
 		outputConfig.includesRowQuery = fetchBooleanOption("output_row_query", options, properties, false);
 		outputConfig.outputDDL	= fetchBooleanOption("output_ddl", options, properties, false);
 		this.excludeColumns     = fetchOption("exclude_columns", options, properties, null);

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
@@ -13,6 +13,7 @@ public class MaxwellOutputConfig {
 	public boolean includesNulls;
 	public boolean includesServerId;
 	public boolean includesThreadId;
+	public boolean includesSchemaId;
 	public boolean includesRowQuery;
 	public boolean outputDDL;
 	public List<Pattern> excludeColumns;
@@ -26,6 +27,7 @@ public class MaxwellOutputConfig {
 		this.includesNulls = true;
 		this.includesServerId = false;
 		this.includesThreadId = false;
+		this.includesSchemaId = false;
 		this.includesRowQuery = false;
 		this.outputDDL = false;
 		this.excludeColumns = new ArrayList<>();

--- a/src/main/java/com/zendesk/maxwell/recovery/RecoverySchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/RecoverySchemaStore.java
@@ -51,4 +51,9 @@ public class RecoverySchemaStore implements SchemaStore {
 	public List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Position position) throws SchemaStoreException, InvalidSchemaError {
 		return new ArrayList<>();
 	}
+
+	@Override
+	public Long getSchemaID() throws SchemaStoreException {
+		return new Long(0);
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -241,9 +241,10 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 	 */
 	private void processQueryEvent(String dbName, String sql, SchemaStore schemaStore, Position position, Position nextPosition, Long timestamp) throws Exception {
 		List<ResolvedSchemaChange> changes = schemaStore.processSQL(sql, dbName, position);
+		Long schemaId = this.schemaStore.getSchemaID();
 		for (ResolvedSchemaChange change : changes) {
 			if (change.shouldOutput(filter)) {
-				DDLMap ddl = new DDLMap(change, timestamp, sql, position, nextPosition);
+				DDLMap ddl = new DDLMap(change, timestamp, sql, position, nextPosition, schemaId);
 
 				if ( scripting != null )
 					scripting.invoke(ddl);
@@ -490,6 +491,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 						rowBuffer = getTransactionRows(event);
 						rowBuffer.setServerId(event.getEvent().getHeader().getServerId());
 						rowBuffer.setThreadId(qe.getThreadId());
+						rowBuffer.setSchemaId(this.schemaStore.getSchemaID());
 					} else {
 						processQueryEvent(event);
 					}

--- a/src/main/java/com/zendesk/maxwell/row/FieldNames.java
+++ b/src/main/java/com/zendesk/maxwell/row/FieldNames.java
@@ -19,6 +19,7 @@ public class FieldNames {
 	public static final String SERVER_ID = "server_id";
 	public static final String TABLE = "table";
 	public static final String THREAD_ID = "thread_id";
+	public static final String SCHEMA_ID = "schema_id";
 	public static final String TIMESTAMP = "ts";
 	public static final String TRANSACTION_ID = "xid";
 	public static final String TRANSACTION_OFFSET = "xoffset";

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -46,6 +46,7 @@ public class RowMap implements Serializable {
 	private boolean txCommit;
 	private Long serverId;
 	private Long threadId;
+	private Long schemaId;
 
 	private final LinkedHashMap<String, Object> data;
 	private final LinkedHashMap<String, Object> oldData;
@@ -294,7 +295,6 @@ public class RowMap implements Serializable {
 		if ( outputConfig.includesBinlogPosition )
 			g.writeStringField(FieldNames.POSITION, binlogPosition.getFile() + ":" + binlogPosition.getOffset());
 
-
 		if ( outputConfig.includesGtidPosition)
 			g.writeStringField(FieldNames.GTID, binlogPosition.getGtid());
 
@@ -304,6 +304,10 @@ public class RowMap implements Serializable {
 
 		if ( outputConfig.includesThreadId && this.threadId != null ) {
 			g.writeNumberField(FieldNames.THREAD_ID, this.threadId);
+		}
+
+		if ( outputConfig.includesSchemaId && this.schemaId != null ) {
+			 g.writeNumberField(FieldNames.SCHEMA_ID, this.schemaId);
 		}
 
 		for ( Map.Entry<String, Object> entry : this.extraAttributes.entrySet() ) {
@@ -455,6 +459,14 @@ public class RowMap implements Serializable {
 
 	public void setThreadId(Long threadId) {
 		this.threadId = threadId;
+	}
+
+	public Long getSchemaId() {
+		return schemaId;
+	}
+
+	public void setSchemaId(Long schemaId) {
+		this.schemaId = schemaId;
 	}
 
 	public String getDatabase() {

--- a/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
@@ -10,6 +10,7 @@ public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 	private Long xoffset = 0L;
 	private Long serverId;
 	private Long threadId;
+	private Long schemaId;
 	private long memorySize = 0;
 	private long outputStreamCacheSize = 0;
 	private final long maxMemory;
@@ -58,6 +59,7 @@ public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 		r.setXoffset(this.xoffset++);
 		r.setServerId(this.serverId);
 		r.setThreadId(this.threadId);
+		r.setSchemaId(this.schemaId);
 
 		return r;
 	}
@@ -72,5 +74,9 @@ public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 
 	public void setThreadId(Long threadId) {
 		this.threadId = threadId;
+	}
+
+	public void setSchemaId(Long schemaId) {
+		this.schemaId = schemaId;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -59,6 +59,11 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 		return savedSchema.getSchema();
 	}
 
+	public Long getSchemaID() throws SchemaStoreException {
+		getSchema();
+		return savedSchema.getSchemaID();
+	}
+
 	private MysqlSavedSchema restoreOrCaptureSchema() throws SchemaStoreException {
 		try {
 			MysqlSavedSchema savedSchema =

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStore.java
@@ -27,4 +27,13 @@ public interface SchemaStore {
 	 * @return A list of the schema changes parsed from the SQL.
 	 */
 	List<ResolvedSchemaChange> processSQL(String sql, String currentDatabase, Position position) throws SchemaStoreException, InvalidSchemaError;
+
+	/**
+	 * Retrieve current schema id
+	 *
+	 * Schema id should be an always increasing integer, not current intended for use
+	 * to refernce the schema, simply as a schema generation indicator.
+	 * @return The current schema id
+	 */
+	Long getSchemaID() throws SchemaStoreException;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DDLMap.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DDLMap.java
@@ -6,6 +6,7 @@ import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.row.FieldNames;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,13 +18,15 @@ public class DDLMap extends RowMap {
 	private final Long timestamp;
 	private final String sql;
 	private Position position;
+	private final Long schemaId;
 
-	public DDLMap(ResolvedSchemaChange change, Long timestamp, String sql, Position position, Position nextPosition) {
+	public DDLMap(ResolvedSchemaChange change, Long timestamp, String sql, Position position, Position nextPosition, Long schemaId) {
 		super("ddl", change.databaseName(), change.tableName(), timestamp, new ArrayList<>(0), position, nextPosition, sql);
 		this.change = change;
 		this.timestamp = timestamp;
 		this.sql = sql;
 		this.position = position;
+		this.schemaId = schemaId;
 	}
 
 	public String pkToJson(KeyFormat keyFormat) throws IOException {
@@ -56,10 +59,13 @@ public class DDLMap extends RowMap {
 
 		BinlogPosition binlogPosition = position.getBinlogPosition();
 		if ( outputConfig.includesBinlogPosition ) {
-			map.put("position", binlogPosition.getFile() + ":" + binlogPosition.getOffset());
+			map.put(FieldNames.POSITION, binlogPosition.getFile() + ":" + binlogPosition.getOffset());
 		}
 		if ( outputConfig.includesGtidPosition) {
-			map.put("gtid", binlogPosition.getGtid());
+			map.put(FieldNames.GTID, binlogPosition.getGtid());
+		}
+		if ( outputConfig.includesSchemaId) {
+			map.put(FieldNames.SCHEMA_ID, this.schemaId);
 		}
 		return new ObjectMapper().writeValueAsString(map);
 	}


### PR DESCRIPTION
**Motivation:**
I want to have an id that can be used by consumers to know whether or not they're ok to consume a message. If they know they're ok to consume all schema_id 5 and they see schema_id 6, they can stop consuming and check against another service what schema is ok to consume, not continuing until they get the ok to consume schema_id 6.

**Uncertainties:**

- There's some differing conventions  in the code regarding capitilization of id, SchemaStore users `ID`, other places like RowMap, it's `Id`. So, BinlogConnectorReplicator has the boundary `Long schemaId = this.schemaStore.getSchemaID();`
- Wasn't really sure what schema_id to return from RecoverySchemaStore, I put 0, I didn't ponder it too long.
- DDL output currently has the new schema_id, should be the very first instance of it, it could instead have the previous schema_id, the very last instance of it. I thought this way made more sense.