### PR TITLE
Optimize in-memory schema storage

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -463,7 +463,7 @@ public class MysqlSavedSchema {
 
 		Database currentDatabase = null;
 		Table currentTable = null;
-		int columnIndex = 0;
+		short columnIndex = 0;
 
 		while (rs.next()) {
 			// Database

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -161,7 +161,7 @@ public class SchemaCapturer {
 				String colName = r.getString("COLUMN_NAME");
 				String colType = r.getString("DATA_TYPE");
 				String colEnc = r.getString("CHARACTER_SET_NAME");
-				int colPos = r.getInt("ORDINAL_POSITION") - 1;
+				short colPos = (short) (r.getInt("ORDINAL_POSITION") - 1);
 				boolean colSigned = !r.getString("COLUMN_TYPE").matches(".* unsigned$");
 				Long columnLength = null;
 

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.schema;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 import com.zendesk.maxwell.schema.ddl.ColumnPosition;
@@ -25,15 +26,17 @@ public class Table {
 	private List<String> pkColumnNames;
 	private List<String> normalizedPKColumnNames;
 
-	private HashMap<String, Integer> columnOffsetMap;
 	@JsonIgnore
 	public int pkIndex;
 
 	public Table() { }
 	public Table(String database, String name, String charset, List<ColumnDef> list, List<String> pks) {
-		this.database = database;
-		this.name = name;
+		this.database = database.intern();
+		this.name = name.intern();
 		this.charset = charset;
+		if ( this.charset != null )
+			this.charset = this.charset.intern();
+
 		this.setColumnList(list);
 
 		if ( pks == null )
@@ -265,7 +268,7 @@ public class Table {
 
 	@JsonProperty("primary-key")
 	public synchronized void setPKList(List<String> pkColumnNames) {
-		this.pkColumnNames = pkColumnNames;
+		this.pkColumnNames = pkColumnNames.stream().map((n) -> n.intern()).collect(Collectors.toList());
 		this.normalizedPKColumnNames = null;
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -45,6 +45,11 @@ public class Table {
 		this.setPKList(pks);
 	}
 
+	@JsonProperty("table")
+	public void setTable(String name) {
+		this.name = name.intern();
+	}
+
 	@JsonProperty("columns")
 	public List<ColumnDef> getColumnList() {
 		return columns.getList();
@@ -246,11 +251,17 @@ public class Table {
 	}
 
 	public void setDatabase(String database) {
-		this.database = database;
+		this.database = database.intern();
 	}
 
 	public String getCharset() {
 		return charset;
+	}
+
+	public void setCharset(String charset) {
+		this.charset = charset;
+		if ( this.charset != null )
+			this.charset = charset.intern();
 	}
 
 	@JsonProperty("primary-key")

--- a/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
+++ b/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
@@ -7,11 +7,10 @@ import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
 public class TableColumnList implements Iterable<ColumnDef> {
 	private final List<ColumnDef> columns;
-	private HashMap<String, Integer> columnOffsetMap;
+	private Set<String> columnNames;
 
 	public TableColumnList(List<ColumnDef> columns) {
 		this.columns = columns;
-		initColumnOffsetMap();
 		renumberColumns();
 	}
 
@@ -23,18 +22,23 @@ public class TableColumnList implements Iterable<ColumnDef> {
 		return columns;
 	}
 
-	public Set<String> columnNames() {
-		return columnOffsetMap.keySet();
+	public synchronized Set<String> columnNames() {
+		if ( columnNames == null ) {
+			columnNames = new HashSet<>();
+			for ( ColumnDef cf : columns )
+				columnNames.add(cf.getName().toLowerCase().intern());
+		}
+		return columnNames;
 	}
 
 	public synchronized int indexOf(String name) {
 		String lcName = name.toLowerCase();
 
-		if ( this.columnOffsetMap.containsKey(lcName) ) {
-			return this.columnOffsetMap.get(lcName);
-		} else {
-			return -1;
+		for ( int i = 0 ; i < columns.size(); i++ ) {
+			if ( columns.get(i).getName().toLowerCase().equals(lcName) )
+				return i;
 		}
+		return -1;
 	}
 
 	public ColumnDef findByName(String name) {
@@ -47,13 +51,18 @@ public class TableColumnList implements Iterable<ColumnDef> {
 
 	public synchronized void add(int index, ColumnDef definition) {
 		columns.add(index, definition);
-		initColumnOffsetMap();
+
+		if ( columnNames != null )
+			columnNames.add(definition.getName().toLowerCase());
+
 		renumberColumns();
 	}
 
 	public synchronized ColumnDef remove(int index) {
 		ColumnDef c = columns.remove(index);
-		initColumnOffsetMap();
+
+		if ( columnNames != null )
+			columnNames.remove(c.getName().toLowerCase());
 		renumberColumns();
 		return c;
 	}
@@ -64,15 +73,6 @@ public class TableColumnList implements Iterable<ColumnDef> {
 
 	public int size() {
 		return columns.size();
-	}
-
-	private void initColumnOffsetMap() {
-		this.columnOffsetMap = new HashMap<>();
-		int i = 0;
-
-		for(ColumnDef c : columns) {
-			this.columnOffsetMap.put(c.getName().toLowerCase(), i++);
-		}
 	}
 
 	private void renumberColumns() {

--- a/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
+++ b/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
@@ -76,7 +76,7 @@ public class TableColumnList implements Iterable<ColumnDef> {
 	}
 
 	private void renumberColumns() {
-		int i = 0 ;
+		short i = 0 ;
 		for ( ColumnDef c : columns ) {
 			c.setPos(i++);
 		}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
@@ -7,7 +7,7 @@ public class BigIntColumnDef extends ColumnDef {
 
 	protected boolean signed;
 
-	public BigIntColumnDef(String name, String type, int pos, boolean signed) {
+	public BigIntColumnDef(String name, String type, short pos, boolean signed) {
 		super(name, type, pos);
 		this.signed = signed;
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
@@ -4,7 +4,7 @@ import java.math.BigInteger;
 import java.util.BitSet;
 
 public class BitColumnDef extends ColumnDef {
-	public BitColumnDef(String name, String type, int pos) {
+	public BitColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -2,21 +2,22 @@ package com.zendesk.maxwell.schema.columndef;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.zendesk.maxwell.util.DynamicEnum;
 
 @JsonSerialize(using=ColumnDefSerializer.class)
 @JsonDeserialize(using=ColumnDefDeserializer.class)
 
 public abstract class ColumnDef {
+	private static DynamicEnum dynamicEnum = new DynamicEnum(Byte.MAX_VALUE);
 	protected String name;
-	protected String type;
-
+	protected byte type;
 	protected short pos;
 
 	public ColumnDef() { }
 	public ColumnDef(String name, String type, short pos) {
 		this.name = name;
-		this.type = type;
 		this.pos = pos;
+		this.type = (byte) dynamicEnum.get(type);
 	}
 
 	public abstract String toSQL(Object value);
@@ -29,9 +30,6 @@ public abstract class ColumnDef {
 		name = name.intern();
 		if ( charset != null )
 			charset = charset.intern();
-
-		if ( type != null )
-			type = type.intern();
 
 		switch(type) {
 		case "tinyint":
@@ -189,7 +187,7 @@ public abstract class ColumnDef {
 	}
 
 	public String getType() {
-		return type;
+		return dynamicEnum.get(type);
 	}
 
 	public int getPos() {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -26,6 +26,13 @@ public abstract class ColumnDef {
 	}
 
 	public static ColumnDef build(String name, String charset, String type, int pos, boolean signed, String enumValues[], Long columnLength) {
+		name = name.intern();
+		if ( charset != null )
+			charset = charset.intern();
+
+		if ( type != null )
+			type = type.intern();
+
 		switch(type) {
 		case "tinyint":
 		case "smallint":

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -10,10 +10,10 @@ public abstract class ColumnDef {
 	protected String name;
 	protected String type;
 
-	protected int pos;
+	protected short pos;
 
 	public ColumnDef() { }
-	public ColumnDef(String name, String type, int pos) {
+	public ColumnDef(String name, String type, short pos) {
 		this.name = name;
 		this.type = type;
 		this.pos = pos;
@@ -25,7 +25,7 @@ public abstract class ColumnDef {
 		return value;
 	}
 
-	public static ColumnDef build(String name, String charset, String type, int pos, boolean signed, String enumValues[], Long columnLength) {
+	public static ColumnDef build(String name, String charset, String type, short pos, boolean signed, String enumValues[], Long columnLength) {
 		name = name.intern();
 		if ( charset != null )
 			charset = charset.intern();
@@ -196,7 +196,7 @@ public abstract class ColumnDef {
 		return pos;
 	}
 
-	public void setPos(int i) {
+	public void setPos(short i) {
 		this.pos = i;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefDeserializer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefDeserializer.java
@@ -36,6 +36,6 @@ public class ColumnDefDeserializer extends JsonDeserializer<ColumnDef> {
 		if ( columnLengthNode != null ) {
 			columnLength = columnLengthNode.asLong();
 		}
-		return ColumnDef.build(name, charset, type, 0, signed, enumValues, columnLength);
+		return ColumnDef.build(name, charset, type, (short) 0, signed, enumValues, columnLength);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefSerializer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefSerializer.java
@@ -11,11 +11,11 @@ public class ColumnDefSerializer extends JsonSerializer<ColumnDef> {
 	@Override
 	public void serialize(ColumnDef def, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
 		jgen.writeStartObject();
-		jgen.writeStringField("type", def.type);
+		jgen.writeStringField("type", def.getType());
 		jgen.writeStringField("name", def.name);
 
 		if ( def instanceof StringColumnDef ) {
-			jgen.writeStringField("charset", ((StringColumnDef) def).charset);
+			jgen.writeStringField("charset", ((StringColumnDef) def).getCharset());
 		} else if ( def instanceof IntColumnDef ) {
 			jgen.writeBooleanField("signed", ((IntColumnDef) def).isSigned());
 		} else if ( def instanceof BigIntColumnDef ) {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefWithLength.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefWithLength.java
@@ -17,7 +17,7 @@ public abstract class ColumnDefWithLength extends ColumnDef {
 		}
 	};
 
-	public ColumnDefWithLength(String name, String type, int pos, Long columnLength) {
+	public ColumnDefWithLength(String name, String type, short pos, Long columnLength) {
 		super(name, type, pos);
 		if ( columnLength == null )
 			this.columnLength = 0L;

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -1,7 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
 public class DateColumnDef extends ColumnDef {
-	public DateColumnDef(String name, String type, int pos) {
+	public DateColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -3,7 +3,7 @@ package com.zendesk.maxwell.schema.columndef;
 import java.sql.Timestamp;
 
 public class DateTimeColumnDef extends ColumnDefWithLength {
-	public DateTimeColumnDef(String name, String type, int pos, Long columnLength) {
+	public DateTimeColumnDef(String name, String type, short pos, Long columnLength) {
 		super(name, type, pos, columnLength);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DecimalColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DecimalColumnDef.java
@@ -3,7 +3,7 @@ package com.zendesk.maxwell.schema.columndef;
 import java.math.BigDecimal;
 
 public class DecimalColumnDef extends ColumnDef {
-	public DecimalColumnDef(String name, String type, int pos) {
+	public DecimalColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/EnumColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/EnumColumnDef.java
@@ -1,7 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
 public class EnumColumnDef extends EnumeratedColumnDef {
-	public EnumColumnDef(String name, String type, int pos, String[] enumValues) {
+	public EnumColumnDef(String name, String type, short pos, String[] enumValues) {
 		super(name, type, pos, enumValues);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/EnumeratedColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/EnumeratedColumnDef.java
@@ -8,7 +8,9 @@ abstract public class EnumeratedColumnDef extends ColumnDef  {
 
 	public EnumeratedColumnDef(String name, String type, short pos, String [] enumValues) {
 		super(name, type, pos);
-		this.enumValues = enumValues;
+		this.enumValues = new String[enumValues.length];
+		for ( int i = 0; i < enumValues.length; i++)
+			this.enumValues[i] = enumValues[i].intern();
 	}
 
 	public String[] getEnumValues() {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/EnumeratedColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/EnumeratedColumnDef.java
@@ -6,7 +6,7 @@ abstract public class EnumeratedColumnDef extends ColumnDef  {
 	@JsonProperty("enum-values")
 	protected String[] enumValues;
 
-	public EnumeratedColumnDef(String name, String type, int pos, String [] enumValues) {
+	public EnumeratedColumnDef(String name, String type, short pos, String [] enumValues) {
 		super(name, type, pos);
 		this.enumValues = enumValues;
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/FloatColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/FloatColumnDef.java
@@ -2,7 +2,7 @@ package com.zendesk.maxwell.schema.columndef;
 
 public class FloatColumnDef extends ColumnDef {
 	public FloatColumnDef() { }
-	public FloatColumnDef(String name, String type, int pos) {
+	public FloatColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/GeometryColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/GeometryColumnDef.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
  * Created by ben on 12/30/15.
  */
 public class GeometryColumnDef extends ColumnDef {
-	public GeometryColumnDef(String name, String type, int pos) {
+	public GeometryColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
@@ -5,7 +5,7 @@ public class IntColumnDef extends ColumnDef {
 
 	protected boolean signed;
 
-	public IntColumnDef(String name, String type, int pos, boolean signed) {
+	public IntColumnDef(String name, String type, short pos, boolean signed) {
 		super(name, type, pos);
 		this.signed = signed;
 		this.bits = bitsFromType(type);

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import static com.github.shyiko.mysql.binlog.event.deserialization.ColumnType.*;
 
 public class JsonColumnDef extends ColumnDef {
-	public JsonColumnDef(String name, String type, int pos) {
+	public JsonColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 
 public class SetColumnDef extends EnumeratedColumnDef {
-	public SetColumnDef(String name, String type, int pos, String[] enumValues) {
+	public SetColumnDef(String name, String type, short pos, String[] enumValues) {
 		super(name, type, pos, enumValues);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -14,7 +14,7 @@ public class StringColumnDef extends ColumnDef {
 	public String charset;
 
 	static final Logger LOGGER = LoggerFactory.getLogger(StringColumnDef.class);
-	public StringColumnDef(String name, String type, int pos, String charset) {
+	public StringColumnDef(String name, String type, short pos, String charset) {
 		super(name, type, pos);
 		this.charset = charset;
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
@@ -4,7 +4,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class TimeColumnDef extends ColumnDefWithLength {
-	public TimeColumnDef(String name, String type, int pos, Long columnLength) {
+	public TimeColumnDef(String name, String type, short pos, Long columnLength) {
 		super(name, type, pos, columnLength);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/YearColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/YearColumnDef.java
@@ -4,7 +4,7 @@ import java.sql.Date;
 import java.util.Calendar;
 
 public class YearColumnDef extends ColumnDef {
-	public YearColumnDef(String name, String type, int pos) {
+	public YearColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
@@ -381,7 +381,7 @@ public class MysqlParserListener extends mysqlBaseListener {
 		  name,
 		  colCharset,
 		  colType.toLowerCase(),
-		  -1,
+		  (short) -1,
 		  signed,
 		  enumValues,
 		  columnLength

--- a/src/main/java/com/zendesk/maxwell/util/DynamicEnum.java
+++ b/src/main/java/com/zendesk/maxwell/util/DynamicEnum.java
@@ -1,0 +1,45 @@
+package com.zendesk.maxwell.util;
+
+import java.util.HashMap;
+
+public class DynamicEnum {
+	private long counter = 0;
+	private final long maxLength;
+	private final HashMap<Long, String> forwardMap = new HashMap<>();
+	private final HashMap<String, Long> backwardsMap = new HashMap<>();
+
+	public DynamicEnum(long maxLength) {
+		this.maxLength = maxLength;
+	}
+
+	public String get(byte byID) {
+		return get((long) byID);
+	}
+
+	public String get(short byID) {
+		return get((long) byID);
+	}
+
+	public String get(int byID) {
+		return get((long) byID);
+	}
+
+	public String get(long byID) {
+		return forwardMap.get(byID);
+	}
+
+	public synchronized long get(String byString) {
+		if ( byString == null )
+			return -1;
+
+		Long id = backwardsMap.get(byString);
+		if ( id == null ) {
+			forwardMap.put(counter, byString);
+			backwardsMap.put(byString, counter);
+			id = counter;
+			if ( ++counter >= maxLength )
+				throw new RuntimeException("Overflowed DynamicEnum!");
+		}
+		return id;
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -54,7 +54,7 @@ public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 		});
 	}
 
-	final int HUGE_NUM_DBS = 100;
+	final int HUGE_NUM_DBS = 1000;
 	final int HUGE_NUM_TABLES = 200;
 
 	protected void generateHugeSchema() throws Exception {

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -55,19 +55,22 @@ public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 	}
 
 	final int HUGE_NUM_DBS = 100;
-	final int HUGE_NUM_TABLES = 2000;
+	final int HUGE_NUM_TABLES = 200;
 
 	protected void generateHugeSchema() throws Exception {
 		for ( int i = 0 ; i < HUGE_NUM_DBS; i++ ) {
 			String dbName = "huge_test_" + i;
 			server.execute("create database " + dbName);
 			for ( int j = 0; j < HUGE_NUM_TABLES; j++) {
-				server.execute("create table " + dbName + ".huge_tbl_" + j + "("
+				server.executeCached("create table " + dbName + ".huge_tbl_" + j + "("
 					+ "intcol" + j + " int NOT NULL PRIMARY KEY AUTO_INCREMENT, "
 					+ "strcol" + j + " varchar(255), "
 					+ "othercol" + j + " text"
 					+ ")");
+
 			}
+			long nGenerated = (i + 1) * HUGE_NUM_TABLES;
+			System.out.println("generated " + nGenerated + " of " + (HUGE_NUM_DBS * HUGE_NUM_TABLES) + " tables");
 		}
 	}
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -54,6 +54,23 @@ public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 		});
 	}
 
+	final int HUGE_NUM_DBS = 100;
+	final int HUGE_NUM_TABLES = 2000;
+
+	protected void generateHugeSchema() throws Exception {
+		for ( int i = 0 ; i < HUGE_NUM_DBS; i++ ) {
+			String dbName = "huge_test_" + i;
+			server.execute("create database " + dbName);
+			for ( int j = 0; j < HUGE_NUM_TABLES; j++) {
+				server.execute("create table " + dbName + ".huge_tbl_" + j + "("
+					+ "intcol" + j + " int NOT NULL PRIMARY KEY AUTO_INCREMENT, "
+					+ "strcol" + j + " varchar(255), "
+					+ "othercol" + j + " text"
+					+ ")");
+			}
+		}
+	}
+
 
 	private class MaxwellTestSupportTXCallback extends MaxwellTestSupportCallback {
 		private final String[] input;

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -10,10 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -164,7 +161,19 @@ public class MysqlIsolatedServer {
 	}
 
 	public void execute(String query) throws SQLException {
-		getConnection().createStatement().executeUpdate(query);
+		Statement s = getConnection().createStatement();
+		s.executeUpdate(query);
+		s.close();
+	}
+
+	private Connection cachedCX;
+	public void executeCached(String query) throws SQLException {
+		if ( cachedCX == null )
+			cachedCX = getConnection();
+
+		Statement s = cachedCX.createStatement();
+		s.executeUpdate(query);
+		s.close();
 	}
 
 	public void executeList(List<String> queries) throws SQLException {

--- a/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
@@ -193,9 +193,8 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 		generateHugeSchema();
 		Schema s = capturer.capture();
 		Runtime.getRuntime().gc();
+		Runtime.getRuntime().gc();
 		System.out.println("usage after: " + getUsedMem());
 		System.out.println(s.getCharset());
-
-
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
@@ -16,6 +16,7 @@ import com.zendesk.maxwell.MaxwellTestWithIsolatedServer;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -186,6 +187,8 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 		Runtime r = Runtime.getRuntime();
 		return r.totalMemory() - r.freeMemory();
 	}
+
+	@Ignore
 	@Test
 	public void testHugeCaptureMemUsage() throws Exception {
 		Runtime.getRuntime().gc();

--- a/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
@@ -181,4 +181,21 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 		assertEquals(",'", result[6]);
 		assertEquals("b", result[7]);
 	}
+
+	private long getUsedMem() {
+		Runtime r = Runtime.getRuntime();
+		return r.totalMemory() - r.freeMemory();
+	}
+	@Test
+	public void testHugeCaptureMemUsage() throws Exception {
+		Runtime.getRuntime().gc();
+		System.out.println("usage before: " + getUsedMem());
+		generateHugeSchema();
+		Schema s = capturer.capture();
+		Runtime.getRuntime().gc();
+		System.out.println("usage after: " + getUsedMem());
+		System.out.println(s.getCharset());
+
+
+	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
@@ -21,11 +21,11 @@ import org.junit.Test;
 
 public class ColumnDefTest extends TestWithNameLogging {
 	private ColumnDef build(String type, boolean signed) {
-		return ColumnDef.build("bar", "", type, 1, signed, null, null);
+		return ColumnDef.build("bar", "", type, (short) 1, signed, null, null);
 	}
 
 	private ColumnDef build(String type, boolean signed, Long columnLength) {
-		return ColumnDef.build("bar", "", type, 1, signed, null, columnLength);
+		return ColumnDef.build("bar", "", type, (short) 1, signed, null, columnLength);
 	}
 
 	@Before
@@ -100,7 +100,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 
 	@Test
 	public void testUTF8String() {
-		ColumnDef d = ColumnDef.build("bar", "utf8", "varchar", 1, false, null, null);
+		ColumnDef d = ColumnDef.build("bar", "utf8", "varchar", (short) 1, false, null, null);
 
 		assertThat(d, instanceOf(StringColumnDef.class));
 		byte input[] = "He∆˚ß∆".getBytes();
@@ -111,7 +111,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 	public void TestUTF8MB4String() {
 		String utf8_4 = "😁";
 
-		ColumnDef d = ColumnDef.build("bar", "utf8mb4", "varchar", 1, false, null, null);
+		ColumnDef d = ColumnDef.build("bar", "utf8mb4", "varchar", (short) 1, false, null, null);
 		byte input[] = utf8_4.getBytes();
 		assertThat(d.toSQL(input), is("'😁'"));
 	}
@@ -120,7 +120,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 	public void TestAsciiString() {
 		byte input[] = new byte[] { (byte) 126, (byte) 126, (byte) 126, (byte) 126 };
 
-		ColumnDef d = ColumnDef.build("bar", "ascii", "varchar", 1, false, null, null);
+		ColumnDef d = ColumnDef.build("bar", "ascii", "varchar", (short) 1, false, null, null);
 		assertThat((String) d.asJSON(input), is("~~~~"));
 	}
 
@@ -128,7 +128,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 	public void TestStringAsJSON() {
 		byte input[] = new byte[] { (byte) 169, (byte) 169, (byte) 169, (byte) 169 };
 
-		ColumnDef d = ColumnDef.build("bar", "latin1", "varchar", 1, false, null, null);
+		ColumnDef d = ColumnDef.build("bar", "latin1", "varchar", (short) 1, false, null, null);
 
 		assertThat((String) d.asJSON(input), is("©©©©"));
 	}
@@ -138,7 +138,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 		byte input[] = new byte[] { (byte) 0, (byte) 1, (byte) 0, (byte) 13, (byte) 0, (byte) 11,
 				(byte) 0, (byte) 2, (byte) 0, (byte) 5, (byte) 3, (byte) 0, (byte) 105, (byte) 100 };
 
-		ColumnDef d = ColumnDef.build("bar", "ascii", "json", 1, false, null, null);
+		ColumnDef d = ColumnDef.build("bar", "ascii", "json", (short) 1, false, null, null);
 
 		RawJSONString result = (RawJSONString) d.asJSON(input);
 		assertThat(result.json, is("{\"id\":3}"));
@@ -148,7 +148,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 	public void TestEmptyJSON() {
 		byte input[] = new byte[0];
 
-		ColumnDef d = ColumnDef.build("bar", "ascii", "json", 1, false, null, null);
+		ColumnDef d = ColumnDef.build("bar", "ascii", "json", (short) 1, false, null, null);
 
 		RawJSONString result = (RawJSONString) d.asJSON(input);
 		assertThat(result.json, is("null"));

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLResolverTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLResolverTest.java
@@ -78,8 +78,8 @@ public class DDLResolverTest extends MaxwellTestWithIsolatedServer {
 		ResolvedTableCreate rc = c.resolve(getSchema());
 
 		assertThat(rc.def.charset, is("latin2"));
-		assertThat(((StringColumnDef) rc.def.getColumnList().get(0)).charset, is("latin2"));
-		assertThat(((StringColumnDef) rc.def.getColumnList().get(1)).charset, is("utf8"));
+		assertThat(((StringColumnDef) rc.def.getColumnList().get(0)).getCharset(), is("latin2"));
+		assertThat(((StringColumnDef) rc.def.getColumnList().get(1)).getCharset(), is("utf8"));
 
 	}
 
@@ -91,7 +91,7 @@ public class DDLResolverTest extends MaxwellTestWithIsolatedServer {
 		ResolvedTableCreate rc = c.resolve(getSchema());
 		assertThat(rc.def.getColumnList().size(), is(2));
 		assertThat(rc.def.getPKList().get(0), is("ii"));
-		assertThat(((StringColumnDef) rc.def.getColumnList().get(1)).charset, is("utf8"));
+		assertThat(((StringColumnDef) rc.def.getColumnList().get(1)).getCharset(), is("utf8"));
 	}
 
 	@Test


### PR DESCRIPTION
With an eye towards #1066, I'm `intern()`ing a lot of strings that we use for our in-memory representation of maxwell schema.  Some of these are trivial and will benefit all our memory usage, some of these only get wins when the user has lots of duplicate schemas.

There's other pretty straightforward memory optimizations that could be done (why on earth are we storing a string pointer for column-type?  or character set?  could easily boil these down to shorts), but I think this is a good start, in my synthetic tests it reduced memory usage on a large schema scenario by about 50%. 

@kimbc I'd be interested to know if you could try this patch out.