### PR TITLE
Add message.publish.age metric

### DIFF
--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -23,6 +23,7 @@ metric                         | description
 `inflightmessages.count`       | the number of messages that are currently in-flight (awaiting acknowledgement from the destination, or ahead of messages which are)
 **Timers**
 `message.publish.time`         | the time it took to send a given record to Kafka, in milliseconds
+`message.publish.age`          | the time between an event occurring on the DB and being published to kafka, in milliseconds. Note: since MySQL timestamps are accurate to the second, this overestimates the age by an average of 500ms.
 `replication.queue.time`       | the time it took to enqueue a given binlog event for processing, in milliseconds
 
 ### HTTP Endpoints

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -23,7 +23,7 @@ metric                         | description
 `inflightmessages.count`       | the number of messages that are currently in-flight (awaiting acknowledgement from the destination, or ahead of messages which are)
 **Timers**
 `message.publish.time`         | the time it took to send a given record to Kafka, in milliseconds
-`message.publish.age`          | the time between an event occurring on the DB and being published to kafka, in milliseconds. Note: since MySQL timestamps are accurate to the second, this overestimates the age by an average of 500ms.
+`message.publish.age`          | the time between an event occurring on the DB and being published to kafka, in milliseconds. Note: since MySQL timestamps are accurate to the second, this is only accurate to +/- 500ms.
 `replication.queue.time`       | the time it took to enqueue a given binlog event for processing, in milliseconds
 
 ### HTTP Endpoints

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -31,7 +31,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 					context.setPosition(message.position);
 					long currentTime = System.currentTimeMillis();
 					messagePublishTimer.update(currentTime - message.sendTimeMS, TimeUnit.MILLISECONDS);
-					messageLatencyTimer.update(Math.max(0L, currentTime - message.eventTimeMS), TimeUnit.MILLISECONDS);
+					messageLatencyTimer.update(Math.max(0L, currentTime - message.eventTimeMS - 500L), TimeUnit.MILLISECONDS);
 				}
 			}
 		}

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
@@ -17,7 +17,8 @@ public abstract class AbstractProducer {
 	protected final Meter succeededMessageMeter;
 	protected final Counter failedMessageCount;
 	protected final Meter failedMessageMeter;
-	protected final Timer metricsTimer;
+	protected final Timer messagePublishTimer;
+	protected final Timer messageLatencyTimer;
 
 	public AbstractProducer(MaxwellContext context) {
 		this.context = context;
@@ -30,7 +31,8 @@ public abstract class AbstractProducer {
 		this.succeededMessageMeter = metricRegistry.meter(metrics.metricName("messages", "succeeded", "meter"));
 		this.failedMessageCount = metricRegistry.counter(metrics.metricName("messages", "failed"));
 		this.failedMessageMeter = metricRegistry.meter(metrics.metricName("messages", "failed", "meter"));
-		this.metricsTimer = metrics.getRegistry().timer(metrics.metricName("message", "publish", "time"));
+		this.messagePublishTimer = metrics.getRegistry().timer(metrics.metricName("message", "publish", "time"));
+		this.messageLatencyTimer = metrics.getRegistry().timer(metrics.metricName("message", "publish", "age"));
 	}
 
 	abstract public void push(RowMap r) throws Exception;

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -153,7 +153,7 @@ public class InflightMessageListTest {
 		public void run() {
 			start = System.currentTimeMillis();
 			try {
-				list.addMessage(p4);
+				list.addMessage(p4, start);
 			} catch (InterruptedException e) {
 				e.printStackTrace();
 			}
@@ -167,8 +167,8 @@ public class InflightMessageListTest {
 		config.producerAckTimeout = timeout;
 		when(context.getConfig()).thenReturn(config);
 		list = new InflightMessageList(context, capacity, completePercentageThreshold);
-		list.addMessage(p1);
-		list.addMessage(p2);
-		list.addMessage(p3);
+		list.addMessage(p1, 0L);
+		list.addMessage(p2, 0L);
+		list.addMessage(p3, 0L);
 	}
 }


### PR DESCRIPTION
This tracks the age of the event _after_ it's been published (according to DB timestamp), i.e. end-to-end lag.

Since MySQL timestamp is only accurate to seconds, this is not accurate for subsecond lag. Negative values are clipped to 0.

/cc @zendesk/goanna 