### PR TITLE
Kinesis: fail records > 1MB instead of crashing

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -120,9 +120,9 @@ public class MaxwellKinesisProducer extends AbstractAsyncProducer {
 	public void sendAsync(RowMap r, AbstractAsyncProducer.CallbackCompleter cc) throws Exception {
 		String key = this.partitioner.getKinesisKey(r);
 		String value = r.toJSON(outputConfig);
+		int vsize = value.length();
 
 		ByteBuffer encodedValue = ByteBuffer.wrap(value.getBytes("UTF-8"));
-		ListenableFuture<UserRecordResult> future = kinesisProducer.addUserRecord(kinesisStream, key, encodedValue);
 
 		// release the reference to ease memory pressure
 		if(!KinesisCallback.logger.isDebugEnabled()) {
@@ -132,6 +132,12 @@ public class MaxwellKinesisProducer extends AbstractAsyncProducer {
 		FutureCallback<UserRecordResult> callback = new KinesisCallback(cc, r.getNextPosition(), key, value,
 				this.succeededMessageCount, this.failedMessageCount, this.succeededMessageMeter, this.failedMessageMeter, this.context);
 
-		Futures.addCallback(future, callback);
+		try {
+			ListenableFuture<UserRecordResult> future = kinesisProducer.addUserRecord(kinesisStream, key, encodedValue);
+			Futures.addCallback(future, callback);
+		} catch(IllegalArgumentException t) {
+			callback.onFailure(t);
+			logger.error("Database:" + r.getDatabase() + ", Table:" + r.getTable() + ", PK:" + r.pkAsConcatString() + ", Size:" + Integer.toString(vsize));
+		}
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellKinesisProducerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellKinesisProducerTest.java
@@ -1,0 +1,42 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.MaxwellConfig;
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.monitoring.NoOpMetrics;
+import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
+import com.zendesk.maxwell.row.RowMap;
+import org.junit.Test;
+
+import java.util.Properties;
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MaxwellKinesisProducerTest {
+
+	private static final long TIMESTAMP_MILLISECONDS = 1496712943447L;
+
+	private static final Position POSITION = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+
+	@Test
+	public void dealsWithTooLargeRecord() throws Exception {
+		MaxwellContext context = mock(MaxwellContext.class);
+		MaxwellConfig config = new MaxwellConfig();
+		when(context.getConfig()).thenReturn(config);
+		when(context.getMetrics()).thenReturn(new NoOpMetrics());
+		String kinesisStream = "test-stream";
+		MaxwellKinesisProducer producer = new MaxwellKinesisProducer(context, kinesisStream);
+
+		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", TIMESTAMP_MILLISECONDS, new ArrayList<String>(), POSITION);
+		StringBuilder r = new StringBuilder();
+		for (int i = 0; i < 100_000; i++) {
+			r.append("long string");
+		}
+		rowMap.putData("content", r.toString());
+
+		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
+		producer.sendAsync(rowMap, cc);
+	}
+}


### PR DESCRIPTION
The error caused Maxwell to crash until the end of the retention period,
at which point the binlog file with the change disappeared and Maxwell
failed with "Could not find first log file name in binary log index file"