### PR TITLE
Add support for Prometheus metrics

### DIFF
--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -33,6 +33,7 @@ When the HTTP server is enabled the following endpoints are exposed:
 | endpoint       | description                                                                    |
 |:---------------|:-------------------------------------------------------------------------------|
 | `/metrics`     | return all metrics as JSON                                                     |
+| `/prometheus`  | return all metrics as Prometheus format                                        |
 | `/healthcheck` | run Maxwell's healthchecks.  Considered unhealthy if &gt;0 messages have failed in the last 15 minutes. |
 | `/ping`        | a simple ping test, responds with `pong`                                       |
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,16 @@
       <artifactId>progressbar</artifactId>
       <version>0.6.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_dropwizard</artifactId>
+      <version>0.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <version>0.5.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
@@ -96,6 +96,7 @@ class MaxwellHTTPServerWorker implements StoppableTask, Runnable {
 		if (metricsRegistries != null) {
 			// TODO: there is a way to wire these up automagically via the AdminServlet, but it escapes me right now
 			handler.addServlet(new ServletHolder(new MetricsServlet(metricsRegistries.metricRegistry)), "/metrics");
+			handler.addServlet(new ServletHolder(new io.prometheus.client.exporter.MetricsServlet()), "/prometheus");
 			handler.addServlet(new ServletHolder(new HealthCheckServlet(metricsRegistries.healthCheckRegistry)), "/healthcheck");
 			handler.addServlet(new ServletHolder(new PingServlet()), "/ping");
 		}

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
@@ -7,6 +7,8 @@ import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.jvm.*;
 import com.zendesk.maxwell.MaxwellConfig;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
 import org.apache.commons.lang.StringUtils;
 import org.coursera.metrics.datadog.DatadogReporter;
 import org.coursera.metrics.datadog.transport.HttpTransport;
@@ -106,6 +108,10 @@ public class MaxwellMetrics implements Metrics {
 
 			reporter.start(config.metricsDatadogInterval, TimeUnit.SECONDS);
 			LOGGER.info("Datadog reporting enabled");
+		}
+
+		if (config.metricsReportingType.contains(reportingTypeHttp)) {
+			CollectorRegistry.defaultRegistry.register(new DropwizardExports(config.metricRegistry));
 		}
 	}
 


### PR DESCRIPTION
I was trying to deploy Maxwell to production, but I noticed that its missing metrics in Prometheus (Prometheus.io) format. I made a implementation based out suggestions on https://github.com/zendesk/maxwell/issues/974

Could you guys check it. I was struggling with the configuration options, so I could use an second opinion.
1) Use following solution. Add another metric_type ```prometheus``` and enable the endpoint when needed.
2) Enable Prometheus automatically when ```http``` is provided.
3) Starting different http server on separate port (too much resources in my opinion)

I'm looking forward to your ideas. Basically its my first PR :D 
