### PR TITLE
Open access to row-query for javascript filters

### DIFF
--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -30,7 +30,7 @@ public class RowMap implements Serializable {
 
 	static final Logger LOGGER = LoggerFactory.getLogger(RowMap.class);
 
-	private final String rowQuery;
+	private String rowQuery;
 	private final String rowType;
 	private final String database;
 	private final String table;
@@ -491,6 +491,10 @@ public class RowMap implements Serializable {
 
 	public String getRowQuery() {
 		return rowQuery;
+	}
+
+	public void setRowQuery(String query) {
+		this.rowQuery = query;
 	}
 
 	public String getRowType() {

--- a/src/main/java/com/zendesk/maxwell/scripting/WrappedRowMap.java
+++ b/src/main/java/com/zendesk/maxwell/scripting/WrappedRowMap.java
@@ -67,6 +67,13 @@ public class WrappedRowMap {
 		return row.getTimestamp();
 	}
 
+	public String getQuery() {
+		return row.getRowQuery();
+	}
+
+	public void setQuery(String query) {
+	}
+
 	public void suppress() {
 		row.suppress();
 	}

--- a/src/main/java/com/zendesk/maxwell/scripting/WrappedRowMap.java
+++ b/src/main/java/com/zendesk/maxwell/scripting/WrappedRowMap.java
@@ -72,6 +72,7 @@ public class WrappedRowMap {
 	}
 
 	public void setQuery(String query) {
+		row.setRowQuery(query);
 	}
 
 	public void suppress() {

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -589,6 +589,8 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 
 	@Test
 	public void testJavascriptFilters() throws Exception {
+		requireMinimumVersion(server.VERSION_5_6);
+
 		String dir = MaxwellTestSupport.getSQLDir();
 		runJSON("/json/test_javascript_filters", (c) -> {
 			c.javascriptFile = dir + "/json/filter.javascript";

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -590,7 +590,10 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testJavascriptFilters() throws Exception {
 		String dir = MaxwellTestSupport.getSQLDir();
-		runJSON("/json/test_javascript_filters", (c) -> c.javascriptFile = dir + "/json/filter.javascript");
+		runJSON("/json/test_javascript_filters", (c) -> {
+			c.javascriptFile = dir + "/json/filter.javascript";
+			c.outputConfig.includesRowQuery = true;
+		});
 	}
 
 	static String[] createDBSql = {

--- a/src/test/resources/sql/json/filter.javascript
+++ b/src/test/resources/sql/json/filter.javascript
@@ -5,4 +5,8 @@ function process_row(rowmap) {
 
 		rowmap.data.a = rowmap.data.a.toUpperCase();
 	}
+
+	if ( rowmap.query && rowmap.query.match(/mangle/) ) {
+		rowmap.query = "mangled";
+	}
 }

--- a/src/test/resources/sql/json/test_javascript_filters
+++ b/src/test/resources/sql/json/test_javascript_filters
@@ -11,3 +11,7 @@ insert into test_table set a='big big words', b='bvalue2'
 
 ->  {"database": "test", "table": "test_table", "type": "insert", "data": {"id": 2, "a": "BIG BIG WORDS", "b": "bvalue2"} }
 
+SET binlog_rows_query_log_events=true
+insert into test_table set a='mangle'
+
+->  {"database": "test", "table": "test_table", "type": "insert", "query": "mangled", "data": {"id": 3, "a": "MANGLE", "b": null} }


### PR DESCRIPTION
this addresses the desire in #1074, which is to be able to read and/or mangle the query from javascript filters.  

