### PR TITLE
Non-english characters support for db, table, column names

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -107,6 +107,9 @@ public class MaxwellMysqlConfig {
 			uriBuilder.addParameter(jdbcOption.getKey(), jdbcOption.getValue());
 		}
 
+		// added by d8888 2018/09/10, force JDBC to use UTF-8 to support using non-english db, table & column names
+		uriBuilder.addParameter("characterEncoding", "UTF-8");
+		
 		return uriBuilder.build().toString();
 	}
 

--- a/src/main/resources/sql/maxwell_schema.sql
+++ b/src/main/resources/sql/maxwell_schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS `schemas` (
 CREATE TABLE IF NOT EXISTS `databases` (
   id        int unsigned auto_increment NOT NULL primary key,
   schema_id int unsigned,
-  name      varchar(255),
+  name      varchar(255) charset 'utf8',
   charset   varchar(255),
   index (schema_id)
 );
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS `tables` (
   id          int unsigned auto_increment NOT NULL primary key,
   schema_id   int unsigned,
   database_id int unsigned,
-  name      varchar(255),
+  name      varchar(255) charset 'utf8',
   charset   varchar(255),
   pk        varchar(1024) charset 'utf8',
   index (schema_id),
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS `columns` (
   id          int unsigned auto_increment NOT NULL primary key,
   schema_id   int unsigned,
   table_id    int unsigned,
-  name        varchar(255),
+  name        varchar(255) charset 'utf8',
   charset     varchar(255),
   coltype     varchar(255),
   is_signed   tinyint(1) unsigned,

--- a/src/main/resources/sql/maxwell_schema_bootstrap.sql
+++ b/src/main/resources/sql/maxwell_schema_bootstrap.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `bootstrap` (
   id              int unsigned auto_increment NOT NULL primary key,
-  database_name   varchar(255) NOT NULL,
-  table_name      varchar(255) NOT NULL,
+  database_name   varchar(255) charset 'utf8' NOT NULL,
+  table_name      varchar(255) charset 'utf8' NOT NULL,
   where_clause    varchar(255),
   is_complete     tinyint(1) unsigned NOT NULL default 0,
   inserted_rows   bigint(20) unsigned NOT NULL DEFAULT 0,

--- a/src/test/java/com/zendesk/maxwell/MaxwellMysqlConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellMysqlConfigTest.java
@@ -26,7 +26,7 @@ public class MaxwellMysqlConfigTest {
 
 		try {
 			final String uri = config.getConnectionURI();
-			assertThat(uri, is(equalTo("jdbc:mysql://localhost:3306/maxwell?connectTimeout=5000&zeroDateTimeBehavior=convertToNull&initialTimeout=2&autoReconnect=true&maxReconnects=10&useSSL=false")));
+			assertThat(uri, is(equalTo("jdbc:mysql://localhost:3306/maxwell?connectTimeout=5000&zeroDateTimeBehavior=convertToNull&initialTimeout=2&autoReconnect=true&maxReconnects=10&useSSL=false&characterEncoding=UTF-8")));
 		}
 		catch (URISyntaxException e) {
 			fail();

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -528,5 +528,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertEquals(2, rows.size());
 		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"database-create\",\"database\":\"測試資料庫三\""));
 		assertTrue(rows.get(1).toJSON(ddlOutputConfig()).contains("\"type\":\"table-create\",\"database\":\"測試資料庫三\",\"table\":\"表格二\""));
+		// test if non-Latin column name outputs correctly
+		assertTrue(rows.get(1).toJSON(ddlOutputConfig()).contains("\"type\":\"int\",\"name\":\"中文欄位\""));
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -419,11 +419,26 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertEquals(1, rows.size());
 		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"table-create\",\"database\":\"mysql\",\"table\":\"TestTableCreate1\""));
 	}
+	
+	@Test
+	public void testNonLatinTableCreate() throws Exception {
+		String[] sql = {"create table 測試表格 ( 測試欄位一 int, 測試欄位二 text )"};
+		List<RowMap> rows = getRowsForDDLTransaction(sql, null);
+		assertEquals(1, rows.size());
+		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"table-create\",\"database\":\"mysql\",\"table\":\"測試表格\""));
+	}
 
 	@Test
 	public void testTableCreateFilter() throws Exception {
 		String[] sql = {"create table TestTableCreate2 ( account_id int, text_field text )"};
 		List<RowMap> rows = getRowsForDDLTransaction(sql, excludeTable("TestTableCreate2"));
+		assertEquals(0, rows.size());
+	}
+	
+	@Test
+	public void testNonLatinTableCreateFilter() throws Exception {
+		String[] sql = {"create table 測試表格二 ( 測試欄位一 int, 測試欄位二 text )"};
+		List<RowMap> rows = getRowsForDDLTransaction(sql, excludeTable("測試表格二"));
 		assertEquals(0, rows.size());
 	}
 
@@ -437,6 +452,18 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertEquals(1, rows.size());
 		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"table-create\",\"database\":\"mysql\",\"table\":\"TestTableCreate3\""));
 	}
+	
+	@Test
+	public void testNonLatinTableRenameFilter() throws Exception {
+		String[] sql = {
+			"create table 測試表格三 ( 測試欄位一 int, 測試欄位二 text )",
+			"rename table 測試表格三 to 測試表格四"
+		};
+		List<RowMap> rows = getRowsForDDLTransaction(sql, excludeTable("測試表格四"));
+		assertEquals(1, rows.size());
+		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"table-create\",\"database\":\"mysql\",\"table\":\"測試表格三\""));
+	}
+	
 
 	@Test
 	public void testDatabaseCreate() throws Exception {
@@ -449,6 +476,18 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"database-create\",\"database\":\"TestDatabaseCreate1\""));
 		assertTrue(rows.get(1).toJSON(ddlOutputConfig()).contains("\"type\":\"database-alter\",\"database\":\"TestDatabaseCreate1\""));
 	}
+	
+	@Test
+	public void testNonLatinDatabaseCreate() throws Exception {
+		String[] sql = {
+			"create database 測試資料庫一",
+			"alter database 測試資料庫一 character set latin2"
+		};
+		List<RowMap> rows = getRowsForDDLTransaction(sql, null);
+		assertEquals(2, rows.size());
+		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"database-create\",\"database\":\"測試資料庫一\""));
+		assertTrue(rows.get(1).toJSON(ddlOutputConfig()).contains("\"type\":\"database-alter\",\"database\":\"測試資料庫一\""));
+	}
 
 	@Test
 	public void testDatabaseFilter() throws Exception {
@@ -456,6 +495,14 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		List<RowMap> rows = getRowsForDDLTransaction(sql, excludeDb("TestDatabaseCreate2"));
 		assertEquals(0, rows.size());
 	}
+	
+	@Test
+	public void testNonLatinDatabaseFilter() throws Exception {
+		String[] sql = {"create database 測試資料庫二"};
+		List<RowMap> rows = getRowsForDDLTransaction(sql, excludeDb("測試資料庫二"));
+		assertEquals(0, rows.size());
+	}
+	
 
 	@Test
 	public void testDatabaseChangeWithTableFilter() throws Exception {
@@ -468,5 +515,18 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		assertEquals(2, rows.size());
 		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"database-create\",\"database\":\"TestDatabaseCreate3\""));
 		assertTrue(rows.get(1).toJSON(ddlOutputConfig()).contains("\"type\":\"table-create\",\"database\":\"TestDatabaseCreate3\",\"table\":\"burger\""));
+	}
+	
+	@Test
+	public void testNonLatinDatabaseChangeWithTableFilter() throws Exception {
+		String[] sql = {
+				"create database 測試資料庫三",
+				"create table `測試資料庫三`.`表格一` ( 中文欄位 int )",
+				"create table `測試資料庫三`.`表格二` ( 中文欄位 int )"
+		};
+		List<RowMap> rows = getRowsForDDLTransaction(sql, excludeTable("表格一"));
+		assertEquals(2, rows.size());
+		assertTrue(rows.get(0).toJSON(ddlOutputConfig()).contains("\"type\":\"database-create\",\"database\":\"測試資料庫三\""));
+		assertTrue(rows.get(1).toJSON(ddlOutputConfig()).contains("\"type\":\"table-create\",\"database\":\"測試資料庫三\",\"table\":\"表格二\""));
 	}
 }


### PR DESCRIPTION
An attempted fix for this issue: https://github.com/zendesk/maxwell/issues/1075
Problem: When using Maxwell Daemon to stream data from table containing Chinese column name (such as "你好"), key in JSON message corresponding to column name became question marks, that is:
expected outcome: {..., "data": {"你好":"123"}}
actual outcome: {..., "data": {"????":"123"}} 

This PR changed Maxwell to use UTF8 in JDBC connection. Corresponding test is also changed. 
Charset of db, table, column names are changed to UTF-8 in .sql files
