### PR TITLE
Fix possible NPE in TableAlter

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -54,7 +54,7 @@ public class TableAlter extends SchemaChange {
 
 		if ( convertCharset != null ) {
 			for ( StringColumnDef sc : table.getStringColumns() ) {
-				if ( !sc.getCharset().toLowerCase().equals("binary") )
+				if (sc.getCharset() == null || !sc.getCharset().toLowerCase().equals("binary") )
 					sc.setCharset(convertCharset);
 			}
 		}

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -402,6 +402,19 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
+	public void testDatabaseAlterMySqlTableCharset() throws Exception {
+		testIntegration("ALTER TABLE mysql.columns_priv " +
+				"MODIFY Host char(60) NOT NULL default '', " +
+				"MODIFY Db char(64) NOT NULL default '', " +
+				"MODIFY User char(16) NOT NULL default '', " +
+				"MODIFY Table_name char(64) NOT NULL default '', " +
+				"MODIFY Column_name char(64) NOT NULL default '', " +
+				"ENGINE=MyISAM, " +
+				"CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin, " +
+				"COMMENT='Column privileges'");
+	}
+
+	@Test
 	@Category(Mysql57Tests.class)
 	public void testGeneratedColumns() throws Exception {
 		requireMinimumVersion(server.VERSION_5_7);


### PR DESCRIPTION
There's a possible NPE in TableAlter, which can be hit in MySQL security updates. 

A test was added with one of the problematic queries below. Running that without the `null` change will result in an NPE.