### PR TITLE
Bump mysql-connector-java version for mysql 8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.39</version>
+      <version>5.1.47</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Current version 5.1.39 doesn't work with mysql 8.
If it worked, I'd bump it to 8.0.12 (latest) but I got a compilation error when I tried it.