### PR TITLE
make enum_values a utf8 field.

### DIFF
--- a/src/main/resources/sql/maxwell_schema.sql
+++ b/src/main/resources/sql/maxwell_schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS `columns` (
   charset     varchar(255),
   coltype     varchar(255),
   is_signed   tinyint(1) unsigned,
-  enum_values text,
+  enum_values text charset 'utf8',
   column_length tinyint unsigned,
   index (schema_id),
   index (table_id)


### PR DESCRIPTION
I can't properly reproduce #1126 exactly, but I can get maxwell to lose enum values with a server that's set to latin1 encoding.