### PR TITLE
Back pressure

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -162,6 +162,8 @@ kafka.acks=1
 #            *** kinesis ***
 
 #kinesis_stream=maxwell
+#kinesis_throttle_limit=10000
+#kinesis_throttle_sleep=1000
 
 # AWS places a 256 unicode character limit on the max key length of a record
 # http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.zendesk</groupId>
   <artifactId>maxwell</artifactId>
-  <version>1.17.1</version>
+  <version>1.19.0</version>
   <packaging>jar</packaging>
 
   <name>maxwell</name>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -63,6 +63,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public String kinesisStream;
 	public boolean kinesisMd5Keys;
+	public Long kinesisThrottleLimit;
+	public Long kinesisThrottleSleep;
 
 	public String sqsQueueUri;
 
@@ -205,6 +207,9 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "kafka_key_format", "how to format the kafka key; array|hash" ).withRequiredArg();
 
 		parser.accepts( "kinesis_stream", "kinesis stream name" ).withOptionalArg();
+		parser.accepts( "kinesis_throttle_limit", "Something default: 10000" ).withRequiredArg();
+		parser.accepts( "kinesis_throttle_sleep", "Something default: 1000" ).withRequiredArg();
+	    
 		parser.accepts( "sqs_queue_uri", "SQS Queue uri" ).withRequiredArg();
 
 		parser.accepts( "pubsub_project_id", "provide a google cloud platform project id associated with the pubsub topic" ).withRequiredArg();
@@ -427,6 +432,10 @@ public class MaxwellConfig extends AbstractConfig {
 		this.producerPartitionFallback = fetchOption("producer_partition_by_fallback", options, properties, null);
 
 		this.kinesisStream  = fetchOption("kinesis_stream", options, properties, null);
+		this.kinesisThrottleLimit = fetchLongOption("kinesis_throttle_limit", options, properties, 10000L);
+		this.kinesisThrottleSleep = fetchLongOption("kinesis_throttle_sleep", options, properties, 1000L);
+	    
+
 		this.kinesisMd5Keys = fetchBooleanOption("kinesis_md5_keys", options, properties, false);
 
 		this.sqsQueueUri = fetchOption("sqs_queue_uri", options, properties, null);


### PR DESCRIPTION
#### What
Solves memory issue in case of high DB updates and during bootstrap.
Since, KPL stores records in memory as FutureCallback. In case of large records it pushes all records in memory leading to memory spike.

For Throttling we can configure Kinesis Ingestion with fields
```
kinesis_throttle_limit
kinesis_throttle_sleep
```

#### Fixes
- https://github.com/zendesk/maxwell/issues/816
- https://github.com/zendesk/maxwell/issues/1100

#### References
Aws [blog](https://aws.amazon.com/blogs/big-data/implementing-efficient-and-reliable-producers-with-the-amazon-kinesis-producer-library/)

##### Metrics
For High ingestion you can set throttle to high number like 10000000 and sleep of 1

Tested with 
```
kinesis_throttle_limit=50000
kinesis_throttle_sleep=2000
```
Stable at 900mb ram. We can change the numbers for high throughput.

cc: @osheroff @thomasdziedzic