### PR TITLE
[MELINF-692] Bump dependencies due to security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,12 +202,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.3</version>
+      <version>2.8.11</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.3</version>
+      <version>2.8.11.2</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>
@@ -222,7 +222,7 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>4.0.0</version>
+      <version>4.8.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -252,12 +252,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.2.21.v20170120</version>
+      <version>9.3.25.v20180904</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.2.21.v20170120</version>
+      <version>9.3.25.v20180904</version>
     </dependency>
     <dependency>
       <groupId>org.coursera</groupId>


### PR DESCRIPTION
@zendesk/goanna @osheroff 

Bump jackson, amqp-client, and jetty due to known security vulnerabilities.