### PR TITLE
add backpressure on a per-row basis

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -24,6 +24,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 		}
 
 		public void markCompleted() {
+			inflightMessages.freeSlot();
 			if(isTXCommit) {
 				InflightMessageList.InflightMessage message = inflightMessages.completeMessage(position);
 
@@ -65,6 +66,9 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 			}
 			return;
 		}
+
+		// back-pressure from slow producers
+		inflightMessages.waitForSlot();
 
 		if(r.isTXCommit()) {
 			inflightMessages.addMessage(position, r.getTimestampMillis());

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -15,16 +15,18 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 		private final MaxwellContext context;
 		private final Position position;
 		private final boolean isTXCommit;
+		private final long messageID;
 
-		public CallbackCompleter(InflightMessageList inflightMessages, Position position, boolean isTXCommit, MaxwellContext context) {
+		public CallbackCompleter(InflightMessageList inflightMessages, Position position, boolean isTXCommit, MaxwellContext context, long messageID) {
 			this.inflightMessages = inflightMessages;
 			this.context = context;
 			this.position = position;
 			this.isTXCommit = isTXCommit;
+			this.messageID = messageID;
 		}
 
 		public void markCompleted() {
-			inflightMessages.freeSlot();
+			inflightMessages.freeSlot(messageID);
 			if(isTXCommit) {
 				InflightMessageList.InflightMessage message = inflightMessages.completeMessage(position);
 
@@ -58,7 +60,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 		// Rows that do not get sent to a target will be automatically marked as complete.
 		// We will attempt to commit a checkpoint up to the current row.
 		if(!r.shouldOutput(outputConfig)) {
-			inflightMessages.addMessage(position, r.getTimestampMillis());
+			inflightMessages.addMessage(position, r.getTimestampMillis(), 0L);
 
 			InflightMessageList.InflightMessage completed = inflightMessages.completeMessage(position);
 			if(completed != null) {
@@ -68,13 +70,14 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 		}
 
 		// back-pressure from slow producers
-		inflightMessages.waitForSlot();
+
+		long messageID = inflightMessages.waitForSlot();
 
 		if(r.isTXCommit()) {
-			inflightMessages.addMessage(position, r.getTimestampMillis());
+			inflightMessages.addMessage(position, r.getTimestampMillis(), messageID);
 		}
 
-		CallbackCompleter cc = new CallbackCompleter(inflightMessages, position, r.isTXCommit(), context);
+		CallbackCompleter cc = new CallbackCompleter(inflightMessages, position, r.isTXCommit(), context, messageID);
 
 		sendAsync(r, cc);
 	}

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -8,12 +8,12 @@ package com.zendesk.maxwell.producer;
 
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.Position;
-import com.zendesk.maxwell.row.RowMap;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 
 public class InflightMessageList {
+
 
 	class InflightMessage {
 		public final Position position;
@@ -33,18 +33,18 @@ public class InflightMessageList {
 		}
 	}
 
-	private static final long INIT_CAPACITY = 1000;
+	private static final long DEFAULT_CAPACITY = 10000;
 	private static final double COMPLETE_PERCENTAGE_THRESHOLD = 0.9;
 
 	private final LinkedHashMap<Position, InflightMessage> linkedMap;
 	private final MaxwellContext context;
 	private final long capacity;
+	private long outstanding;
 	private final long producerAckTimeoutMS;
 	private final double completePercentageThreshold;
-	private volatile boolean isFull;
 
 	public InflightMessageList(MaxwellContext context) {
-		this(context, INIT_CAPACITY, COMPLETE_PERCENTAGE_THRESHOLD);
+		this(context, DEFAULT_CAPACITY, COMPLETE_PERCENTAGE_THRESHOLD);
 	}
 
 	public InflightMessageList(MaxwellContext context, long capacity, double completePercentageThreshold) {
@@ -53,63 +53,60 @@ public class InflightMessageList {
 		this.completePercentageThreshold = completePercentageThreshold;
 		this.linkedMap = new LinkedHashMap<>();
 		this.capacity = capacity;
+		this.outstanding = 0;
+	}
+
+
+	public synchronized void waitForSlot() throws InterruptedException {
+		while ( this.outstanding >= this.capacity )
+			this.wait();
+
+		this.outstanding++;
+	}
+
+	public synchronized void freeSlot() {
+		this.outstanding--;
+		this.notify();
 	}
 
 	public void addMessage(Position p, long eventTimestampMillis) throws InterruptedException {
-		synchronized (this.linkedMap) {
-			while (isFull) {
-				this.linkedMap.wait();
-			}
-
-			InflightMessage m = new InflightMessage(p, eventTimestampMillis);
-			this.linkedMap.put(p, m);
-
-			if (linkedMap.size() >= capacity) {
-				isFull = true;
-			}
-		}
+		InflightMessage m = new InflightMessage(p, eventTimestampMillis);
+		this.linkedMap.put(p, m);
 	}
 
 	/* returns the position that stuff is complete up to, or null if there were no changes */
 	public InflightMessage completeMessage(Position p) {
-		synchronized (this.linkedMap) {
-			InflightMessage m = this.linkedMap.get(p);
-			assert(m != null);
+		InflightMessage m = this.linkedMap.get(p);
+		assert(m != null);
 
-			m.isComplete = true;
+		m.isComplete = true;
 
-			InflightMessage completeUntil = null;
-			Iterator<InflightMessage> iterator = iterator();
+		InflightMessage completeUntil = null;
+		Iterator<InflightMessage> iterator = iterator();
 
-			while ( iterator.hasNext() ) {
-				InflightMessage msg = iterator.next();
-				if ( !msg.isComplete ) {
-					break;
-				}
-
-				completeUntil = msg;
-				iterator.remove();
+		while ( iterator.hasNext() ) {
+			InflightMessage msg = iterator.next();
+			if ( !msg.isComplete ) {
+				break;
 			}
 
-			if (isFull && linkedMap.size() < capacity) {
-				isFull = false;
-				this.linkedMap.notify();
-			}
-
-			// If the head is stuck for the length of time (configurable) and majority of the messages have completed,
-			// we assume the head will unlikely get acknowledged, hence terminate Maxwell.
-			// This gatekeeper is the last resort since if anything goes wrong,
-			// producer should have raised exceptions earlier than this point when all below conditions are met.
-			if (producerAckTimeoutMS > 0 && isFull) {
-				Iterator<InflightMessage> it = iterator();
-				if (it.hasNext() && it.next().timeSinceSendMS() > producerAckTimeoutMS && completePercentage() >= completePercentageThreshold) {
-					context.terminate(new IllegalStateException(
-							"Did not receive acknowledgement for the head of the inflight message list for " + producerAckTimeoutMS + " ms"));
-				}
-			}
-
-			return completeUntil;
+			completeUntil = msg;
+			iterator.remove();
 		}
+
+		// If the head is stuck for the length of time (configurable) and majority of the messages have completed,
+		// we assume the head will unlikely get acknowledged, hence terminate Maxwell.
+		// This gatekeeper is the last resort since if anything goes wrong,
+		// producer should have raised exceptions earlier than this point when all below conditions are met.
+		if (producerAckTimeoutMS > 0 && linkedMap.size() >= capacity) {
+			Iterator<InflightMessage> it = iterator();
+			if (it.hasNext() && it.next().timeSinceSendMS() > producerAckTimeoutMS && completePercentage() >= completePercentageThreshold) {
+				context.terminate(new IllegalStateException(
+					"Did not receive acknowledgement for the head of the inflight message list for " + producerAckTimeoutMS + " ms"));
+			}
+		}
+
+		return completeUntil;
 	}
 
 	public int size() {

--- a/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
+++ b/src/main/java/com/zendesk/maxwell/producer/InflightMessageList.java
@@ -68,7 +68,7 @@ public class InflightMessageList {
 		// we assume the head will unlikely get acknowledged, hence terminate Maxwell.
 		// This gatekeeper is the last resort since if anything goes wrong,
 		// producer should have raised exceptions earlier than this point when all below conditions are met.
-		if (producerAckTimeoutMS > 0 && outstanding >= capacity) {
+		if (producerAckTimeoutMS > 0) {
 			Iterator<InflightMessage> it = iterator();
 			if (it.hasNext() && it.next().timeSinceSendMS() > producerAckTimeoutMS && completePercentage() >= completePercentageThreshold) {
 				context.terminate(new IllegalStateException(

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -35,7 +35,7 @@ public class InflightMessageListTest {
 
 	@Test
 	public void testInOrderCompletion() throws InterruptedException {
-		setupWithInflightRequestTimeout(0, 0.1);
+		setupWithInflightRequestTimeout(0);
 
 		Position ret;
 
@@ -53,7 +53,7 @@ public class InflightMessageListTest {
 
 	@Test
 	public void testOutOfOrderComplete() throws InterruptedException {
-		setupWithInflightRequestTimeout(0, 0.1);
+		setupWithInflightRequestTimeout(0);
 
 		Position ret;
 		InflightMessageList.InflightMessage m;
@@ -72,7 +72,7 @@ public class InflightMessageListTest {
 	public void testMaxwellWillTerminateWhenHeadOfInflightMsgListIsStuckAndListFullAndMostCompletedAndCheckTurnedOn() throws InterruptedException {
 		// Given
 		long inflightRequestTimeout = 100;
-		setupWithInflightRequestTimeout(inflightRequestTimeout, 0.1);
+		setupWithInflightRequestTimeout(inflightRequestTimeout);
 		list.completeMessage(p2);
 		list.freeSlot(2);
 		Thread.sleep(inflightRequestTimeout + 5);
@@ -89,7 +89,7 @@ public class InflightMessageListTest {
 	@Test
 	public void testMaxwellWillNotTerminateWhenHeadOfInflightMsgListIsStuckAndCheckTurnedOff() throws InterruptedException {
 		// Given
-		setupWithInflightRequestTimeout(0, 0.1);
+		setupWithInflightRequestTimeout(0);
 		list.completeMessage(p2);
 		list.freeSlot(2);
 
@@ -103,7 +103,7 @@ public class InflightMessageListTest {
 
 	@Test
 	public void testWaitForSlotWillWaitWhenCapacityIsFull() throws InterruptedException {
-		setupWithInflightRequestTimeout(0, 0.1);
+		setupWithInflightRequestTimeout(0);
 
 		AddMessage addMessage = new AddMessage();
 		Thread add = new Thread(addMessage);
@@ -136,7 +136,7 @@ public class InflightMessageListTest {
 		}
 	}
 
-	private void setupWithInflightRequestTimeout(long timeout, double completePercentageThreshold) throws InterruptedException {
+	private void setupWithInflightRequestTimeout(long timeout) throws InterruptedException {
 		context = mock(MaxwellContext.class);
 		MaxwellConfig config = new MaxwellConfig();
 		config.producerAckTimeout = timeout;

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -4,6 +4,7 @@ import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -127,6 +128,7 @@ public class InflightMessageListTest {
 	}
 
 	@Test
+	@Ignore
 	public void testAddMessageWillWaitWhenCapacityIsFull() throws InterruptedException {
 		setupWithInflightRequestTimeout(0, 0.1);
 

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -69,7 +69,7 @@ public class InflightMessageListTest {
 	}
 
 	@Test
-	public void testMaxwellWillTerminateWhenHeadOfInflightMsgListIsStuckAndListFullAndMostCompletedAndCheckTurnedOn() throws InterruptedException {
+	public void testMaxwellWillTerminateWhenHeadOfInflightMsgListIsStuckAndCheckTurnedOn() throws InterruptedException {
 		// Given
 		long inflightRequestTimeout = 100;
 		setupWithInflightRequestTimeout(inflightRequestTimeout);
@@ -141,7 +141,7 @@ public class InflightMessageListTest {
 		MaxwellConfig config = new MaxwellConfig();
 		config.producerAckTimeout = timeout;
 		when(context.getConfig()).thenReturn(config);
-		list = new InflightMessageList(context, capacity, 1);
+		list = new InflightMessageList(context, capacity);
 		list.waitForSlot();
 		list.addMessage(p1, 0L, 1);
 		list.waitForSlot();

--- a/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/InflightMessageListTest.java
@@ -74,12 +74,12 @@ public class InflightMessageListTest {
 		long inflightRequestTimeout = 100;
 		setupWithInflightRequestTimeout(inflightRequestTimeout, 0.1);
 		list.completeMessage(p2);
-		list.freeSlot();
+		list.freeSlot(2);
 		Thread.sleep(inflightRequestTimeout + 5);
 
 		// When
 		list.completeMessage(p3);
-		list.freeSlot();
+		list.freeSlot(3);
 
 		// Then
 		verify(context).terminate(captor.capture());
@@ -91,52 +91,17 @@ public class InflightMessageListTest {
 		// Given
 		setupWithInflightRequestTimeout(0, 0.1);
 		list.completeMessage(p2);
-		list.freeSlot();
+		list.freeSlot(2);
 
 		// When
 		list.completeMessage(p3);
-		list.freeSlot();
+		list.freeSlot(3);
 
 		// Then
 		verify(context, never()).terminate(any(RuntimeException.class));
 	}
 
 	@Test
-	public void testMaxwellWillNotTerminateWhenHeadOfInflightMsgListIsStuckAndListNotFullAndMostCompletedAndCheckTurnedOn() throws InterruptedException {
-		// Given
-		long inflightRequestTimeout = 100;
-		setupWithInflightRequestTimeout(inflightRequestTimeout, 0.1);
-		list.completeMessage(p1);
-		list.freeSlot();
-		Thread.sleep(inflightRequestTimeout + 5);
-
-		// When
-		list.completeMessage(p3);
-		list.freeSlot();
-
-		// Then
-		verify(context, never()).terminate(any(RuntimeException.class));
-	}
-
-	@Test
-	public void testMaxwellWillNotTerminateWhenHeadOfInflightMsgListIsStuckAndListFullAndMostCompletedAndCheckTurnedOn() throws InterruptedException {
-		// Given
-		long inflightRequestTimeout = 100;
-		setupWithInflightRequestTimeout(inflightRequestTimeout, 0.9);
-		list.completeMessage(p2);
-		list.freeSlot();
-		Thread.sleep(inflightRequestTimeout + 5);
-
-		// When
-		list.completeMessage(p3);
-		list.freeSlot();
-
-		// Then
-		verify(context, never()).terminate(any(RuntimeException.class));
-	}
-
-	@Test
-	@Ignore
 	public void testWaitForSlotWillWaitWhenCapacityIsFull() throws InterruptedException {
 		setupWithInflightRequestTimeout(0, 0.1);
 
@@ -148,10 +113,9 @@ public class InflightMessageListTest {
 		long wait = 500;
 		Thread.sleep(wait + 100);
 		list.completeMessage(p1);
-		list.freeSlot();
+		list.freeSlot(1);
 
 		add.join();
-		assertThat("Should never exceed capacity", list.size(), is(capacity));
 		long elapse = addMessage.end - addMessage.start;
 		assertThat("Should have waited message to be completed", elapse, greaterThanOrEqualTo(wait));
 	}
@@ -177,12 +141,12 @@ public class InflightMessageListTest {
 		MaxwellConfig config = new MaxwellConfig();
 		config.producerAckTimeout = timeout;
 		when(context.getConfig()).thenReturn(config);
-		list = new InflightMessageList(context, capacity, completePercentageThreshold);
+		list = new InflightMessageList(context, capacity, 1);
 		list.waitForSlot();
-		list.addMessage(p1, 0L);
+		list.addMessage(p1, 0L, 1);
 		list.waitForSlot();
-		list.addMessage(p2, 0L);
+		list.addMessage(p2, 0L, 2);
 		list.waitForSlot();
-		list.addMessage(p3, 0L);
+		list.addMessage(p3, 0L, 3);
 	}
 }


### PR DESCRIPTION
The first implementation of InflightMessageList's backpressure mechanism only dealt with rows that were actually tracked inside the list, meaning rows where txCommit is true.  Since no bootstrap rows satisfied this condition, there was no backpressure for producers in bootstrap.

Here we generalize backpressure to use a simple counter.  10k outstanding rows is a complete guess.

@ericwush I'm preserving the blocked-head check, would love your eyes to confirm I haven't messed stuff up here.