### PR TITLE
[BUG] Schema id missing in bootstrapped rows

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -53,6 +53,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		Database database = findDatabase(schema, databaseName);
 		Table table = findTable(tableName, database);
 
+		Long schemaId = replicator.getSchemaId();
 		Position position = startBootstrapRow.getPosition();
 		producer.push(startBootstrapRow);
 		producer.push(bootstrapStartRowMap(table, position));
@@ -66,6 +67,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 			while ( resultSet.next() ) {
 				RowMap row = bootstrapEventRowMap("bootstrap-insert", table, position);
 				setRowValues(row, resultSet, table);
+				row.setSchemaId(schemaId);
 
 				Scripting scripting = context.getConfig().scripting;
 				if ( scripting != null )

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -242,7 +242,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 	 */
 	private void processQueryEvent(String dbName, String sql, SchemaStore schemaStore, Position position, Position nextPosition, Long timestamp) throws Exception {
 		List<ResolvedSchemaChange> changes = schemaStore.processSQL(sql, dbName, position);
-		Long schemaId = this.schemaStore.getSchemaID();
+		Long schemaId = getSchemaId();
 		for (ResolvedSchemaChange change : changes) {
 			if (change.shouldOutput(filter)) {
 				DDLMap ddl = new DDLMap(change, timestamp, sql, position, nextPosition, schemaId);
@@ -487,7 +487,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 						rowBuffer = getTransactionRows(event);
 						rowBuffer.setServerId(event.getEvent().getHeader().getServerId());
 						rowBuffer.setThreadId(qe.getThreadId());
-						rowBuffer.setSchemaId(this.schemaStore.getSchemaID());
+						rowBuffer.setSchemaId(getSchemaId());
 					} else {
 						processQueryEvent(event);
 					}
@@ -520,5 +520,8 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		return this.schemaStore.getSchema();
 	}
 
+	public Long getSchemaId() throws SchemaStoreException {
+		return this.schemaStore.getSchemaID();
+	}
 
 }

--- a/src/main/java/com/zendesk/maxwell/replication/Replicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/Replicator.java
@@ -15,6 +15,7 @@ public interface Replicator extends StoppableTask {
 	RowMap getRow() throws Exception;
 	Long getLastHeartbeatRead();
 	Schema getSchema() throws SchemaStoreException;
+	Long getSchemaId() throws SchemaStoreException;
 
 	void stopAtHeartbeat(long heartbeat);
 	void runLoop() throws Exception;


### PR DESCRIPTION
**Problem**
Schema id not appearing in rows with type `'bootstrap_insert'` even when `outputConfig.includesSchemaId` is set to true.

**Solution**
Grabbed the schema id from the replicator at the start of the bootstrap and added it every bootstrapped row. This assumes that the schema is constant throughout the bootstrap, which I believe is reasonable.

**Note**
Purposely did not add/modify any tests because output configs like binlog position are also not tested in the bootstrapped rows, even though they do appear where configured to do so. Also, considering the current bootstrap tests, it seems that it is not possible to modify the output config fo a single test, so every test would have to be modified (since they use the `runJSON` function).