### PR TITLE
allow for injection of hashes/arrayes from js-filters

### DIFF
--- a/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
+++ b/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
@@ -11,6 +11,7 @@ import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.ddl.DDLMap;
 import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import jdk.nashorn.api.scripting.ScriptUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,5 +55,16 @@ public class Scripting {
 			processDDLFunc.call(null, new WrappedDDLMap((DDLMap) row));
 		else if ( row instanceof RowMap && processRowFunc != null )
 			processRowFunc.call(null, new WrappedRowMap(row));
+	}
+
+	private static ThreadLocal<ScriptEngine> stringifyEngineThreadLocal = ThreadLocal.withInitial(() -> {
+		ScriptEngineManager manager = new ScriptEngineManager();
+		return manager.getEngineByName("nashorn");
+
+	});
+
+	public static String stringify(ScriptObjectMirror mirror) throws ScriptException {
+		ScriptObjectMirror json = (ScriptObjectMirror) stringifyEngineThreadLocal.get().eval("JSON");
+		return (String) json.callMember("stringify", ScriptUtils.unwrap(mirror));
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
+++ b/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
@@ -60,11 +60,10 @@ public class Scripting {
 	private static ThreadLocal<ScriptEngine> stringifyEngineThreadLocal = ThreadLocal.withInitial(() -> {
 		ScriptEngineManager manager = new ScriptEngineManager();
 		return manager.getEngineByName("nashorn");
-
 	});
 
 	public static String stringify(ScriptObjectMirror mirror) throws ScriptException {
 		ScriptObjectMirror json = (ScriptObjectMirror) stringifyEngineThreadLocal.get().eval("JSON");
-		return (String) json.callMember("stringify", ScriptUtils.unwrap(mirror));
+		return (String) json.callMember("stringify", mirror);
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellIntegrationTest.java
@@ -613,6 +613,14 @@ public class MaxwellIntegrationTest extends MaxwellTestWithIsolatedServer {
 		});
 	}
 
+	@Test
+	public void testJavascriptFiltersInjectRichValues() throws Exception {
+		String dir = MaxwellTestSupport.getSQLDir();
+		runJSON("/json/test_javascript_filters_rich_values", (c) -> {
+			c.javascriptFile = dir + "/json/filter_rich.javascript";
+		});
+	}
+
 	static String[] createDBSql = {
 			"CREATE database if not exists `foo`",
 			"CREATE TABLE if not exists `foo`.`ordered_output` ( id int, account_id int, user_id int )"

--- a/src/test/resources/sql/json/filter_rich.javascript
+++ b/src/test/resources/sql/json/filter_rich.javascript
@@ -1,0 +1,4 @@
+function process_row(rowmap) {
+	rowmap.data.a = [1,2,3,"b", {"a": "b"}];
+  rowmap.data.b = {a: "b"};
+}

--- a/src/test/resources/sql/json/test_javascript_filters_rich_values
+++ b/src/test/resources/sql/json/test_javascript_filters_rich_values
@@ -1,0 +1,12 @@
+use test
+DROP TABLE if exists `test_table_z`
+CREATE TABLE `test_table_z` ( id int auto_increment primary key, a text, b text )
+
+# our javascript filter:
+# 1.  exclude everything that matches "xyzzy"
+# 2.  upper case everything else
+
+insert into test_table_z set a='xyzzy'
+
+->  {"database": "test", "table": "test_table_z", "type": "insert", "data": {"id": 1, "a":  [1,2,3,"b", {"a": "b"}], "b": {"a": "b"}} }
+


### PR DESCRIPTION
It's a bit ugly, but there doesn't *seem* to be a way to do this without
calling nashorn's JSON.stringify.  One could reach into the .internals
package, but, yuck.

Note that the tests fail prior to JDK8 .171, not quite sure what up
witht that.

addresses #1168 