### PR TITLE
move key-related serialization from RowMap info new RowIdentity class

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -14,7 +14,6 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.partitioners.MaxwellKinesisPartitioner;
-import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 
@@ -137,7 +136,7 @@ public class MaxwellKinesisProducer extends AbstractAsyncProducer {
 			Futures.addCallback(future, callback);
 		} catch(IllegalArgumentException t) {
 			callback.onFailure(t);
-			logger.error("Database:" + r.getDatabase() + ", Table:" + r.getTable() + ", PK:" + r.pkAsConcatString() + ", Size:" + Integer.toString(vsize));
+			logger.error("Database:" + r.getDatabase() + ", Table:" + r.getTable() + ", PK:" + r.getRowIdentity().toConcatString() + ", Size:" + Integer.toString(vsize));
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/AbstractMaxwellPartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/AbstractMaxwellPartitioner.java
@@ -5,7 +5,6 @@ import com.zendesk.maxwell.row.RowMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 public abstract class AbstractMaxwellPartitioner {
 	List<String> partitionColumns = new ArrayList<String>();
@@ -45,10 +44,6 @@ public abstract class AbstractMaxwellPartitioner {
 		return r.getTable();
 	}
 
-	static protected String getPrimaryKey(RowMap r) {
-		return r.pkAsConcatString();
-	}
-
 	public String getHashString(RowMap r, PartitionBy by) {
 		switch ( by ) {
 			case TABLE:
@@ -60,7 +55,7 @@ public abstract class AbstractMaxwellPartitioner {
 			case DATABASE:
 				return r.getDatabase();
 			case PRIMARY_KEY:
-				return r.pkAsConcatString();
+				return r.getRowIdentity().toConcatString();
 			case COLUMN:
 				String s = r.buildPartitionKey(partitionColumns);
 				if ( s.length() > 0 )

--- a/src/main/java/com/zendesk/maxwell/row/RowIdentity.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowIdentity.java
@@ -1,0 +1,107 @@
+package com.zendesk.maxwell.row;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.*;
+
+public class RowIdentity implements Serializable {
+	private String database;
+	private String table;
+	private final List<Map.Entry<String, Object>> primaryKeyColumns;
+
+	// slightly less verbose pair construction
+	public static Map.Entry<String, Object> pair(String key, Object value) {
+		return new AbstractMap.SimpleImmutableEntry<>(key, value);
+	}
+
+	public RowIdentity(String database, String table, List<Map.Entry<String, Object>> primaryKeyColumns) {
+		this.database = database;
+		this.table = table;
+		this.primaryKeyColumns = primaryKeyColumns;
+	}
+
+	public String getDatabase() {
+		return database;
+	}
+
+	public String getTable() {
+		return table;
+	}
+
+	public String toKeyJson(RowMap.KeyFormat keyFormat) throws IOException {
+		MaxwellJson json = MaxwellJson.getInstance();
+		JsonGenerator g = json.reset();
+		if ( keyFormat == RowMap.KeyFormat.HASH )
+			writeKeyJsonHash(g);
+		else
+			writeKeyJsonArray(g);
+		return json.consume();
+	}
+
+	private void writeKeyJsonHash(JsonGenerator g) throws IOException {
+		writeStartCommon(g);
+		if (primaryKeyColumns.isEmpty()) {
+			g.writeStringField(FieldNames.UUID, UUID.randomUUID().toString());
+		} else {
+			for (Map.Entry<String,Object> pk : primaryKeyColumns) {
+				writePrimaryKey(g, "pk." + pk.getKey().toLowerCase(), pk.getValue());
+			}
+		}
+		g.writeEndObject();
+	}
+
+	private void writeKeyJsonArray(JsonGenerator g) throws IOException {
+		g.writeStartArray();
+		g.writeString(database);
+		g.writeString(table);
+
+		g.writeStartArray();
+		for (Map.Entry<String,Object> pk : primaryKeyColumns) {
+			g.writeStartObject();
+			MaxwellJson.writeValueToJSON(g, true, pk.getKey().toLowerCase(), pk.getValue());
+			g.writeEndObject();
+		}
+		g.writeEndArray();
+		g.writeEndArray();
+	}
+
+	public String toConcatString() {
+		if (primaryKeyColumns.isEmpty()) {
+			return database + table;
+		}
+		StringBuilder keys = new StringBuilder();
+		for (Map.Entry<String, Object> pk : primaryKeyColumns) {
+			Object pkValue = pk.getValue();
+			if (pkValue != null) {
+				keys.append(pkValue.toString());
+			}
+		}
+		if (keys.length() == 0) {
+			return "None";
+		}
+		return keys.toString();
+	}
+
+	private void writePrimaryKey(JsonGenerator g, String jsonKey, Object value) throws IOException {
+		MaxwellJson.writeValueToJSON(g, true, jsonKey, value);
+	}
+
+	private void writePrimaryKey(JsonGenerator g, Map.Entry<String,Object> pk) throws IOException {
+		writePrimaryKey(g, pk.getKey(), pk.getValue());
+	}
+
+	private JsonGenerator writeStartCommon(JsonGenerator g) throws IOException {
+		g.writeStartObject(); // start of row {
+
+		g.writeStringField(FieldNames.DATABASE, database);
+		g.writeStringField(FieldNames.TABLE, table);
+		return g;
+	}
+
+	@Override
+	public String toString() {
+		return database + ":" + table + ":" + primaryKeyColumns;
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -11,15 +11,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 
@@ -53,6 +47,7 @@ public class RowMap implements Serializable {
 	private final LinkedHashMap<String, Object> extraAttributes;
 
 	private final List<String> pkColumns;
+	private RowIdentity rowIdentity;
 
 	private long approximateSize;
 
@@ -84,77 +79,20 @@ public class RowMap implements Serializable {
 		this(type, database, table, timestampMillis, pkColumns, nextPosition, null);
 	}
 
-	//Do we want to encrypt this part?
-	public String pkToJson(KeyFormat keyFormat) throws IOException {
-		if ( keyFormat == KeyFormat.HASH )
-			return pkToJsonHash();
-		else
-			return pkToJsonArray();
-	}
-
-	private String pkToJsonHash() throws IOException {
-		MaxwellJson json = MaxwellJson.getInstance();
-		JsonGenerator g = json.reset();
-
-		g.writeStartObject(); // start of row {
-
-		g.writeStringField(FieldNames.DATABASE, database);
-		g.writeStringField(FieldNames.TABLE, table);
-
-		if (pkColumns.isEmpty()) {
-			g.writeStringField(FieldNames.UUID, UUID.randomUUID().toString());
-		} else {
-			for (String pk : pkColumns) {
-				Object pkValue = null;
-				if ( data.containsKey(pk) )
-					pkValue = data.get(pk);
-
-				MaxwellJson.writeValueToJSON(g, true, "pk." + pk.toLowerCase(), pkValue);
+	public RowIdentity getRowIdentity() {
+		if (rowIdentity == null) {
+			List<Map.Entry<String, Object>> entries = new ArrayList<>(pkColumns.size());
+			for (String pk: pkColumns) {
+				entries.add(RowIdentity.pair(pk, data.get(pk)));
 			}
+			rowIdentity = new RowIdentity(database, table, entries);
 		}
 
-		g.writeEndObject(); // end of 'data: { }'
-		return json.consume();
+		return rowIdentity;
 	}
 
-	private String pkToJsonArray() throws IOException {
-		MaxwellJson json = MaxwellJson.getInstance();
-		JsonGenerator g = json.reset();
-
-		g.writeStartArray();
-		g.writeString(database);
-		g.writeString(table);
-
-		g.writeStartArray();
-		for (String pk : pkColumns) {
-			Object pkValue = null;
-			if ( data.containsKey(pk) )
-				pkValue = data.get(pk);
-
-			g.writeStartObject();
-			MaxwellJson.writeValueToJSON(g, true, pk.toLowerCase(), pkValue);
-			g.writeEndObject();
-		}
-		g.writeEndArray();
-		g.writeEndArray();
-		return json.consume();
-	}
-
-	public String pkAsConcatString() {
-		if (pkColumns.isEmpty()) {
-			return database + table;
-		}
-		StringBuilder keys = new StringBuilder();
-		for (String pk : pkColumns) {
-			Object pkValue = null;
-			if (data.containsKey(pk))
-				pkValue = data.get(pk);
-			if (pkValue != null)
-				keys.append(pkValue.toString());
-		}
-		if (keys.length() == 0)
-			return "None";
-		return keys.toString();
+	public String pkToJson(KeyFormat format) throws IOException {
+		return getRowIdentity().toKeyJson(format);
 	}
 
 	public String buildPartitionKey(List<String> partitionColumns) {

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -5,6 +5,7 @@ import com.zendesk.maxwell.producer.EncryptionMode;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.Position;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,9 +82,9 @@ public class RowMap implements Serializable {
 
 	public RowIdentity getRowIdentity() {
 		if (rowIdentity == null) {
-			List<Map.Entry<String, Object>> entries = new ArrayList<>(pkColumns.size());
+			List<Pair<String, Object>> entries = new ArrayList<>(pkColumns.size());
 			for (String pk: pkColumns) {
-				entries.add(RowIdentity.pair(pk, data.get(pk)));
+				entries.add(Pair.of(pk, data.get(pk)));
 			}
 			rowIdentity = new RowIdentity(database, table, entries);
 		}

--- a/src/test/java/com/zendesk/maxwell/row/RowIdentityTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowIdentityTest.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell.row;
 
 import com.google.common.collect.Lists;
 import com.zendesk.maxwell.MaxwellTestJSON;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,7 +16,7 @@ public class RowIdentityTest {
 	@Test
 	public void testToJson() throws IOException {
 		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable",
-			Arrays.asList(RowIdentity.pair("id", 111), RowIdentity.pair("account", 123)));
+			Arrays.asList(Pair.of("id", 111), Pair.of("account", 123)));
 
 		String jsonHash = rowId.toKeyJson(RowMap.KeyFormat.HASH);
 		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"pk.id\":111,\"pk.account\":123}", jsonHash);
@@ -27,7 +28,7 @@ public class RowIdentityTest {
 	@Test
 	public void testPkToJsonArrayWithListData() throws Exception {
 		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable",
-			Arrays.asList(RowIdentity.pair("id", "9001"), RowIdentity.pair("name", Lists.newArrayList("example"))));
+			Arrays.asList(Pair.of("id", "9001"), Pair.of("name", Lists.newArrayList("example"))));
 
 		String jsonString = rowId.toKeyJson(RowMap.KeyFormat.ARRAY);
 

--- a/src/test/java/com/zendesk/maxwell/row/RowIdentityTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowIdentityTest.java
@@ -1,0 +1,50 @@
+package com.zendesk.maxwell.row;
+
+
+import com.google.common.collect.Lists;
+import com.zendesk.maxwell.MaxwellTestJSON;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+public class RowIdentityTest {
+
+	@Test
+	public void testToJson() throws IOException {
+		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable",
+			Arrays.asList(RowIdentity.pair("id", 111), RowIdentity.pair("account", 123)));
+
+		String jsonHash = rowId.toKeyJson(RowMap.KeyFormat.HASH);
+		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"pk.id\":111,\"pk.account\":123}", jsonHash);
+
+		String jsonArray = rowId.toKeyJson(RowMap.KeyFormat.ARRAY);
+		Assert.assertEquals("[\"MyDatabase\",\"MyTable\",[{\"id\":111},{\"account\":123}]]", jsonArray);
+	}
+
+	@Test
+	public void testPkToJsonArrayWithListData() throws Exception {
+		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable",
+			Arrays.asList(RowIdentity.pair("id", "9001"), RowIdentity.pair("name", Lists.newArrayList("example"))));
+
+		String jsonString = rowId.toKeyJson(RowMap.KeyFormat.ARRAY);
+
+		Assert.assertEquals("[\"MyDatabase\",\"MyTable\",[{\"id\":\"9001\"},{\"name\":[\"example\"]}]]",
+			jsonString);
+	}
+
+	@Test
+	public void testPkToJsonHashWithEmptyData() throws Exception {
+		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable", Arrays.asList());
+
+		String jsonString = rowId.toKeyJson(RowMap.KeyFormat.HASH);
+
+		Map<String, Object> jsonMap = MaxwellTestJSON.parseJSON(jsonString);
+
+		Assert.assertTrue(jsonMap.containsKey("_uuid"));
+		Assert.assertEquals("MyDatabase", jsonMap.get("database"));
+		Assert.assertEquals("MyTable", jsonMap.get("table"));
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
+++ b/src/test/java/com/zendesk/maxwell/row/RowMapTest.java
@@ -1,6 +1,5 @@
 package com.zendesk.maxwell.row;
 
-import com.google.common.collect.Lists;
 import com.zendesk.maxwell.MaxwellTestJSON;
 import com.zendesk.maxwell.errors.ProtectedAttributeNameException;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
@@ -9,8 +8,10 @@ import com.zendesk.maxwell.replication.Position;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class RowMapTest {
@@ -41,8 +42,7 @@ public class RowMapTest {
 	}
 
 	@Test
-	public void testPkToJsonHash() throws IOException {
-
+	public void testGetRowIdentity() {
 		List<String> pKeys = new ArrayList<>();
 
 		pKeys.add("id");
@@ -54,73 +54,10 @@ public class RowMapTest {
 		rowMap.putData("id", "9001");
 		rowMap.putData("name", "example");
 
-		String jsonString = rowMap.pkToJson(RowMap.KeyFormat.HASH);
-
-		Assert.assertEquals("{\"database\":\"MyDatabase\",\"table\":\"MyTable\",\"pk.id\":\"9001\",\"pk.name\":\"example\"}",
-				jsonString);
+		RowIdentity pk = rowMap.getRowIdentity();
+		Assert.assertEquals("9001example", pk.toConcatString());
 	}
 
-
-	@Test
-	public void testPkToJsonHashWithEmptyData() throws Exception {
-
-		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", TIMESTAMP_MILLISECONDS, new ArrayList<String>(), POSITION);
-
-		String jsonString = rowMap.pkToJson(RowMap.KeyFormat.HASH);
-
-		Map<String, Object> jsonMap = MaxwellTestJSON.parseJSON(jsonString);
-
-		Assert.assertTrue(jsonMap.containsKey("_uuid"));
-		Assert.assertEquals("MyDatabase", jsonMap.get("database"));
-		Assert.assertEquals("MyTable", jsonMap.get("table"));
-
-
-	}
-
-	@Test
-	public void testPkToJsonArray() throws IOException {
-
-		List<String> pKeys = new ArrayList<>();
-
-		pKeys.add("id");
-
-		pKeys.add("name");
-
-		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
-
-		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", TIMESTAMP_MILLISECONDS, pKeys, position);
-
-		rowMap.putData("id", "9001");
-		rowMap.putData("name", "example");
-
-		String jsonString = rowMap.pkToJson(RowMap.KeyFormat.ARRAY);
-
-		Assert.assertEquals("[\"MyDatabase\",\"MyTable\",[{\"id\":\"9001\"},{\"name\":\"example\"}]]",
-				jsonString);
-
-
-	}
-
-	@Test
-	public void testPkToJsonArrayWithListData() throws Exception {
-		List<String> pKeys = new ArrayList<>();
-
-		pKeys.add("id");
-
-		pKeys.add("name");
-
-		Position position = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
-
-		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", TIMESTAMP_MILLISECONDS, pKeys, position);
-
-		rowMap.putData("id", "9001");
-		rowMap.putData("name", Lists.newArrayList("example"));
-
-		String jsonString = rowMap.pkToJson(RowMap.KeyFormat.ARRAY);
-
-		Assert.assertEquals("[\"MyDatabase\",\"MyTable\",[{\"id\":\"9001\"},{\"name\":[\"example\"]}]]",
-				jsonString);
-	}
 	@Test
 	public void testBuildPartitionKey() {
 		List<String> pKeys = new ArrayList<>();


### PR DESCRIPTION
* extract primary-key related serialization from RowMap into RowIdentity

This is required work for implementing publishing of fallback records in #1176

/cc @osheroff 