### PR TITLE
Move maxwell-database checks into `Filter` object

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -604,7 +604,7 @@ public class MaxwellConfig extends AbstractConfig {
 						includeColumnValues
 					);
 				} else {
-					this.filter = new Filter(this.databaseName);
+					this.filter = new Filter(this.databaseName, "");
 				}
 			}
 		} catch (InvalidFilterException e) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -581,7 +581,7 @@ public class MaxwellConfig extends AbstractConfig {
 			return;
 		try {
 			if ( this.filterList != null ) {
-				this.filter = new Filter(filterList);
+				this.filter = new Filter(this.databaseName, filterList);
 			} else {
 				boolean hasOldStyleFilters =
 					includeDatabases != null ||
@@ -594,6 +594,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 				if ( hasOldStyleFilters ) {
 					this.filter = Filter.fromOldFormat(
+						this.databaseName,
 						includeDatabases,
 						excludeDatabases,
 						includeTables,
@@ -603,7 +604,7 @@ public class MaxwellConfig extends AbstractConfig {
 						includeColumnValues
 					);
 				} else {
-					this.filter = new Filter();
+					this.filter = new Filter(this.databaseName);
 				}
 			}
 		} catch (InvalidFilterException e) {

--- a/src/main/java/com/zendesk/maxwell/filtering/Filter.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/Filter.java
@@ -10,14 +10,20 @@ public class Filter {
 	static final Logger LOGGER = LoggerFactory.getLogger(Filter.class);
 
 	private final List<FilterPattern> patterns;
+	private String maxwellDB;
 
 	public Filter() {
 		this.patterns = new ArrayList<>();
+		this.maxwellDB = "maxwell";
 	}
-
 	public Filter(String filterString) throws InvalidFilterException {
 		this();
+		patterns.addAll(new FilterParser(filterString).parse());
+	}
 
+	public Filter(String maxwellDB, String filterString) throws InvalidFilterException {
+		this();
+		this.maxwellDB = maxwellDB;
 		patterns.addAll(new FilterParser(filterString).parse());
 	}
 
@@ -123,6 +129,7 @@ public class Filter {
 	}
 
 	public static Filter fromOldFormat(
+		String maxwellDB,
 		String includeDatabases,
 		String excludeDatabases,
 		String includeTables,
@@ -181,6 +188,6 @@ public class Filter {
 		LOGGER.warn("using exclude/include/includeColumns is deprecated.  Please update your configuration to use: ");
 		LOGGER.warn("filter = \"" + filterRulesAsString + "\"");
 
-		return new Filter(filterRulesAsString);
+		return new Filter(maxwellDB, filterRulesAsString);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/filtering/Filter.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/Filter.java
@@ -27,7 +27,7 @@ public class Filter {
 		patterns.addAll(new FilterParser(filterString).parse());
 	}
 
-	public static boolean isSystemWhitelisted(String maxwellDB, String database, String table) {
+	public boolean isSystemWhitelisted(String database, String table) {
 		return maxwellDB.equals(database)
 			&& ("bootstrap".equals(table) || "heartbeats".equals(table));
 	}
@@ -68,6 +68,9 @@ public class Filter {
 	}
 
 	public boolean isTableBlacklisted(String database, String table) {
+		if ( isSystemBlacklisted(database, table) )
+			return true;
+
 		FilterResult match = new FilterResult();
 
 		for ( FilterPattern p : patterns ) {
@@ -92,16 +95,6 @@ public class Filter {
 	public static boolean isSystemBlacklisted(String databaseName, String tableName) {
 		return "mysql".equals(databaseName) &&
 			("ha_health_check".equals(tableName) || StringUtils.startsWith(tableName, "rds_heartbeat"));
-	}
-
-	public static boolean isTableBlacklisted(Filter filter, String database, String table) {
-		if ( isSystemBlacklisted(database, table) )
-			return true;
-
-		if ( filter == null )
-			return false;
-
-		return filter.isTableBlacklisted(database, table);
 	}
 
 	public static boolean includes(Filter filter, String database, String table) {

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -292,7 +292,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 	private boolean shouldOutputEvent(String database, String table, Filter filter, Set<String> columnNames) {
 		if ( Filter.isSystemBlacklisted(database, table) )
 			return false;
-		else if ( Filter.isSystemWhitelisted(maxwellSchemaDatabaseName, database, table) )
+		else if ( filter.isSystemWhitelisted(database, table) )
 			return true;
 		else {
 			if ( Filter.includes(filter, database, table) )
@@ -304,8 +304,8 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 
 
 	private boolean shouldOutputRowMap(String database, String table, RowMap rowMap, Filter filter) {
-		return Filter.isSystemWhitelisted(maxwellSchemaDatabaseName, database, table) ||
-			Filter.includes(filter, database, table, rowMap.getData());
+		return filter.isSystemWhitelisted(database, table) ||
+			filter.includes(database, table, rowMap.getData());
 	}
 
 	/**

--- a/src/main/java/com/zendesk/maxwell/replication/TableCache.java
+++ b/src/main/java/com/zendesk/maxwell/replication/TableCache.java
@@ -18,7 +18,7 @@ public class TableCache {
 
 	public void processEvent(Schema schema, Filter filter, Long tableId, String dbName, String tblName) {
 		if ( !tableMapCache.containsKey(tableId) ) {
-			if ( Filter.isTableBlacklisted(filter, dbName, tblName) && !Filter.isSystemWhitelisted(maxwellDB, dbName, tblName)) {
+			if ( filter.isTableBlacklisted(dbName, tblName) && !filter.isSystemWhitelisted(dbName, tblName)) {
 				blacklistedTableCache.put(tableId, tblName);
 				return;
 			}

--- a/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
+++ b/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
@@ -130,7 +130,7 @@ public class FilterTest {
 
 	@Test
 	public void TestOldFiltersExcludeDB() throws Exception {
-		Filter f = Filter.fromOldFormat(null, "foo, /bar/", null, null, null, null, null);
+		Filter f = Filter.fromOldFormat("maxwell", null, "foo, /bar/", null, null, null, null, null);
 		List<FilterPattern> rules = f.getRules();
 		assertEquals(2, rules.size());
 		assertEquals("exclude: foo.*", rules.get(0).toString());
@@ -139,7 +139,7 @@ public class FilterTest {
 
 	@Test
 	public void TestOldFiltersIncludeDB() throws Exception {
-		Filter f = Filter.fromOldFormat("foo", null, null, null, null, null, null);
+		Filter f = Filter.fromOldFormat("maxwell", "foo", null, null, null, null, null, null);
 		List<FilterPattern> rules = f.getRules();
 		assertEquals(2, rules.size());
 		assertEquals("exclude: *.*", rules.get(0).toString());
@@ -148,7 +148,7 @@ public class FilterTest {
 
 	@Test
 	public void TestOldFiltersExcludeTable() throws Exception {
-		Filter f = Filter.fromOldFormat(null, null, null, "tbl", null, null, null);
+		Filter f = Filter.fromOldFormat("maxwell", null, null, null, "tbl", null, null, null);
 		List<FilterPattern> rules = f.getRules();
 		assertEquals(1, rules.size());
 		assertEquals("exclude: *.tbl", rules.get(0).toString());
@@ -156,7 +156,7 @@ public class FilterTest {
 
 	@Test
 	public void TestOldFiltersIncludeTable() throws Exception {
-		Filter f = Filter.fromOldFormat(null, null, "/foo.*bar/", null, null, null, null);
+		Filter f = Filter.fromOldFormat("maxwell", null, null, "/foo.*bar/", null, null, null, null);
 		List<FilterPattern> rules = f.getRules();
 		assertEquals(2, rules.size());
 		assertEquals("exclude: *.*", rules.get(0).toString());
@@ -165,7 +165,7 @@ public class FilterTest {
 
 	@Test
 	public void TestOldFiltersIncludeColumnValues() throws Exception {
-		Filter f = Filter.fromOldFormat(null, null, null, null, null, null, "foo=bar");
+		Filter f = Filter.fromOldFormat("maxwell", null, null, null, null, null, null, "foo=bar");
 		List<FilterPattern> rules = f.getRules();
 		assertEquals(2, rules.size());
 		assertEquals("exclude: *.*.foo=*", rules.get(0).toString());

--- a/src/test/java/com/zendesk/maxwell/replication/TableCacheTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/TableCacheTest.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.replication;
 
 import com.zendesk.maxwell.MaxwellTestWithIsolatedServer;
+import com.zendesk.maxwell.filtering.Filter;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaCapturer;
 import org.junit.Test;
@@ -11,6 +12,6 @@ public class TableCacheTest extends MaxwellTestWithIsolatedServer {
 		Schema schema = new SchemaCapturer(server.getConnection(), buildContext().getCaseSensitivity()).capture();
 		TableCache cache = new TableCache("maxwell");
 		// ensure we don't crash on not-really-existant alibaba tables
-		cache.processEvent(schema, null, 1L, "mysql", "ha_health_check");
+		cache.processEvent(schema, new Filter(), 1L, "mysql", "ha_health_check");
 	}
 }


### PR DESCRIPTION
this is a refactor that prepares to fix a bug where we were *still* allowing blacklists (aka the worst feature ever) to block maxwell schema changes from being processed.

We now assert that Filter may not be null and that it is initialized with the maxwell database name.