### PR TITLE
gtid-reconnects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>com.github.shyiko</groupId>
       <artifactId>mysql-binlog-connector-java</artifactId>
-      <version>0.16.1</version>
+      <version>0.17.0</version>
     </dependency>
     <dependency>
       <groupId>net.sf.jopt-simple</groupId>

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -210,12 +210,11 @@ public class Maxwell implements Runnable {
 			false,
 			config.clientID,
 			context.getHeartbeatNotifier(),
-			config.scripting
+			config.scripting,
+			context.getFilter()
 		);
 
 		bootstrapper.resume(producer, replicator);
-
-		replicator.setFilter(context.getFilter());
 
 		context.setReplicator(replicator);
 		this.context.start();

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell.bootstrap;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.Position;
@@ -255,7 +256,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 
 			row.putData(
 				columnDefinition.getName(),
-				columnValue == null ? null : columnDefinition.asJSON(columnValue)
+				columnValue == null ? null : columnDefinition.asJSON(columnValue, new MaxwellOutputConfig())
 			);
 
 			++columnIndex;

--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -69,10 +69,9 @@ public class Recovery {
 					true,
 					recoveryInfo.clientID,
 					new HeartbeatNotifier(),
-					null
+					null,
+					new RecoveryFilter(this.maxwellDatabaseName)
 			);
-
-			replicator.setFilter(new RecoveryFilter(this.maxwellDatabaseName));
 
 			HeartbeatRowMap h = findHeartbeat(replicator);
 			if ( h != null ) {

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -84,7 +84,8 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		boolean stopOnEOF,
 		String clientID,
 		HeartbeatNotifier heartbeatNotifier,
-		Scripting scripting
+		Scripting scripting,
+		Filter filter
 	) {
 		this.clientID = clientID;
 		this.bootstrapper = bootstrapper;
@@ -96,6 +97,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		this.scripting = scripting;
 		this.schemaStore = schemaStore;
 		this.tableCache = new TableCache(maxwellSchemaDatabaseName);
+		this.filter = filter;
 
 		/* setup metrics */
 		rowCounter = metrics.getRegistry().counter(
@@ -512,10 +514,6 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 			}
 
 		}
-	}
-
-	public void setFilter(Filter filter) {
-		this.filter = filter;
 	}
 
 	protected BinlogConnectorEvent pollEvent() throws InterruptedException {

--- a/src/main/java/com/zendesk/maxwell/replication/Replicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/Replicator.java
@@ -10,7 +10,6 @@ import com.zendesk.maxwell.util.StoppableTask;
  * Created by ben on 10/23/16.
  */
 public interface Replicator extends StoppableTask {
-	void setFilter(Filter filter);
 	void startReplicator() throws Exception;
 	RowMap getRow() throws Exception;
 	Long getLastHeartbeatRead();

--- a/src/main/java/com/zendesk/maxwell/replication/ReplicatorNotReadyException.java
+++ b/src/main/java/com/zendesk/maxwell/replication/ReplicatorNotReadyException.java
@@ -1,0 +1,7 @@
+package com.zendesk.maxwell.replication;
+
+public class ReplicatorNotReadyException extends Exception {
+	public ReplicatorNotReadyException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
@@ -49,6 +49,6 @@ public class BitColumnDef extends ColumnDef {
 
 	@Override
 	public String toSQL(Object value) {
-		return asJSON(value).toString();
+		return asJSON(value, null).toString();
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/YearColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/YearColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 import java.sql.Date;
 import java.util.Calendar;
 
@@ -9,7 +11,7 @@ public class YearColumnDef extends ColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig outputConfig) {
 		if ( value instanceof Date ) {
 			Calendar calendar = Calendar.getInstance();
 			calendar.setTime(( java.sql.Date ) value);

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -5,6 +5,7 @@ import com.github.shyiko.mysql.binlog.network.SSLMode;
 import com.zendesk.maxwell.filtering.Filter;
 import com.zendesk.maxwell.filtering.InvalidFilterException;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+import com.zendesk.maxwell.replication.MysqlVersion;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.Schema;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 public class MaxwellTestSupport {
 	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellTestSupport.class);
@@ -295,5 +297,10 @@ public class MaxwellTestSupport {
 
 		List<String> diff = topSchema.diff(bottomSchema, "followed schema", "recaptured schema");
 		assertThat(StringUtils.join(diff.iterator(), "\n"), diff.size(), is(0));
+	}
+
+	public static void requireMinimumVersion(MysqlIsolatedServer server, MysqlVersion minimum) {
+		// skips this test if running an older MYSQL version
+		assumeTrue(server.getVersion().atLeast(minimum));
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestWithIsolatedServer.java
@@ -132,8 +132,7 @@ public class MaxwellTestWithIsolatedServer extends TestWithNameLogging {
 	}
 
 	protected void requireMinimumVersion(MysqlVersion minimum) {
-		// skips this test if running an older MYSQL version
-		assumeTrue(server.getVersion().atLeast(minimum));
+		MaxwellTestSupport.requireMinimumVersion(server, minimum);
 	}
 
 	protected void requireMinimumVersion(int major, int minor) {

--- a/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlIsolatedServer.java
@@ -19,9 +19,9 @@ import java.util.Map;
 public class MysqlIsolatedServer {
 	public static final Long SERVER_ID = 4321L;
 
-	public final MysqlVersion VERSION_5_5 = new MysqlVersion(5, 5);
-	public final MysqlVersion VERSION_5_6 = new MysqlVersion(5, 6);
-	public final MysqlVersion VERSION_5_7 = new MysqlVersion(5, 7);
+	public static final MysqlVersion VERSION_5_5 = new MysqlVersion(5, 5);
+	public static final MysqlVersion VERSION_5_6 = new MysqlVersion(5, 6);
+	public static final MysqlVersion VERSION_5_7 = new MysqlVersion(5, 7);
 
 	private Connection connection;
 	private int port;

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
@@ -14,6 +14,7 @@ import com.zendesk.maxwell.TestWithNameLogging;
 import com.zendesk.maxwell.bootstrap.SynchronousBootstrapper;
 import com.zendesk.maxwell.monitoring.NoOpMetrics;
 import com.zendesk.maxwell.producer.BufferedProducer;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.MysqlSchemaStore;
 import org.junit.Test;
@@ -97,7 +98,8 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 			"maxwell-client",
 			new HeartbeatNotifier(),
 			null,
-			context.getFilter()
+			context.getFilter(),
+			new MaxwellOutputConfig()
 		);
 
 		EventDeserializer eventDeserializer = new EventDeserializer();

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 
@@ -70,8 +71,9 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 
 	@Test
 	public void testGTIDReconnects() throws Exception {
+		assumeTrue(MysqlIsolatedServer.getVersion().atLeast(MysqlIsolatedServer.VERSION_5_6));
+
 		MysqlIsolatedServer server = MaxwellTestSupport.setupServer("--gtid_mode=ON --enforce-gtid-consistency=true");
-		MaxwellTestSupport.requireMinimumVersion(server, MysqlIsolatedServer.VERSION_5_6);
 		MaxwellTestSupport.setupSchema(server, false);
 
 		server.execute("create table test.t ( i int )");

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
@@ -71,6 +71,7 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 	@Test
 	public void testGTIDReconnects() throws Exception {
 		MysqlIsolatedServer server = MaxwellTestSupport.setupServer("--gtid_mode=ON --enforce-gtid-consistency=true");
+		MaxwellTestSupport.requireMinimumVersion(server, MysqlIsolatedServer.VERSION_5_6);
 		MaxwellTestSupport.setupSchema(server, false);
 
 		server.execute("create table test.t ( i int )");

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
@@ -84,18 +84,14 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 		Position position = Position.capture(server.getConnection(), true);
 		MaxwellContext context = MaxwellTestSupport.buildContext(server.getPort(), position, null);
 
-		BufferedProducer producer = new BufferedProducer(context, 1);
-		NoOpMetrics metrics = new NoOpMetrics();
-
-
 		BinlogConnectorReplicator replicator = new BinlogConnectorReplicator(
 			new MysqlSchemaStore(context, position),
-			producer,
+			new BufferedProducer(context, 1),
 			new SynchronousBootstrapper(context),
 			context.getConfig().maxwellMysql,
 			333098L,
 			"maxwell",
-			metrics,
+			new NoOpMetrics(),
 			position,
 			false,
 			"maxwell-client",

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
@@ -1,0 +1,85 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.WriteRowsEventDataDeserializer;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.MaxwellTestSupport;
+import com.zendesk.maxwell.MysqlIsolatedServer;
+import com.zendesk.maxwell.TestWithNameLogging;
+import com.zendesk.maxwell.bootstrap.SynchronousBootstrapper;
+import com.zendesk.maxwell.monitoring.NoOpMetrics;
+import com.zendesk.maxwell.producer.BufferedProducer;
+import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.schema.MysqlSchemaStore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
+
+	private class DisconnectingDeserializer	extends WriteRowsEventDataDeserializer {
+		public DisconnectingDeserializer(Map<Long, TableMapEventData> tableMapEventByTableId) {
+			super(tableMapEventByTableId);
+		}
+
+		@Override
+		public WriteRowsEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
+			WriteRowsEventData d = super.deserialize(inputStream);
+			System.out.println(d.getRows());
+			//if ( d.getRows().get(0).toString().equals("hello"))
+			return d;
+		}
+	}
+
+	@Test
+	public void testGTIDReconnects() throws Exception {
+		MysqlIsolatedServer server = MaxwellTestSupport.setupServer("--gtid_mode=ON --enforce-gtid-consistency=true");
+		MaxwellTestSupport.setupSchema(server);
+
+		server.execute("create table test.t ( i int )");
+		server.execute("insert into test.t set i = 1");
+
+		Position position = Position.capture(server.getConnection(), true);
+		MaxwellContext context = MaxwellTestSupport.buildContext(server.getPort(), position, null);
+
+		BufferedProducer producer = new BufferedProducer(context, 1);
+		NoOpMetrics metrics = new NoOpMetrics();
+
+
+		BinlogConnectorReplicator replicator = new BinlogConnectorReplicator(
+			new MysqlSchemaStore(context, position),
+			producer,
+			new SynchronousBootstrapper(context),
+			context.getConfig().maxwellMysql,
+			333098L,
+			"maxwell",
+			metrics,
+			position,
+			false,
+			"maxwell-client",
+			new HeartbeatNotifier(),
+			null,
+			context.getFilter()
+		);
+
+		EventDeserializer eventDeserializer = new EventDeserializer();
+		eventDeserializer.setCompatibilityMode(
+			EventDeserializer.CompatibilityMode.DATE_AND_TIME_AS_LONG_MICRO,
+			EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY,
+			EventDeserializer.CompatibilityMode.INVALID_DATE_AND_TIME_AS_MIN_VALUE
+		);
+		eventDeserializer.setEventDataDeserializer(EventType.EXT_WRITE_ROWS, new DisconnectingDeserialzier());
+
+		replicator.client.setEventDeserializer();
+
+		replicator.startReplicator();
+
+		server.execute("insert into test.t set i = 2");
+		RowMap r = replicator.getRow();
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
@@ -4,6 +4,7 @@ import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
 import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.TableMapEventDataDeserializer;
 import com.github.shyiko.mysql.binlog.event.deserialization.WriteRowsEventDataDeserializer;
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 import com.zendesk.maxwell.MaxwellContext;
@@ -17,12 +18,35 @@ import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.MysqlSchemaStore;
 import org.junit.Test;
 
+import java.io.EOFException;
 import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 
+	private class TestTableMapEventDeserializer extends TableMapEventDataDeserializer {
+		public HashMap<Long, TableMapEventData> map;
+
+		public TestTableMapEventDeserializer() {
+			this.map = new HashMap<>();
+		}
+
+		@Override
+		public TableMapEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
+			TableMapEventData data = super.deserialize(inputStream);
+			map.put(data.getTableId(), data);
+			return data;
+		}
+	}
+
+	public final static int THROWME = 333;
 	private class DisconnectingDeserializer	extends WriteRowsEventDataDeserializer {
+		private boolean thrown = false;
 		public DisconnectingDeserializer(Map<Long, TableMapEventData> tableMapEventByTableId) {
 			super(tableMapEventByTableId);
 		}
@@ -30,8 +54,16 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 		@Override
 		public WriteRowsEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
 			WriteRowsEventData d = super.deserialize(inputStream);
-			System.out.println(d.getRows());
-			//if ( d.getRows().get(0).toString().equals("hello"))
+			List<Serializable[]> list = d.getRows();
+			if ( !thrown && list.get(0)[0] instanceof Integer ) {
+				Integer i = (Integer) list.get(0)[0];
+				if ( i == THROWME ) {
+					thrown = true;
+					inputStream.close();
+					throw new EOFException();
+				}
+			}
+
 			return d;
 		}
 	}
@@ -39,10 +71,12 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 	@Test
 	public void testGTIDReconnects() throws Exception {
 		MysqlIsolatedServer server = MaxwellTestSupport.setupServer("--gtid_mode=ON --enforce-gtid-consistency=true");
-		MaxwellTestSupport.setupSchema(server);
+		MaxwellTestSupport.setupSchema(server, false);
 
 		server.execute("create table test.t ( i int )");
-		server.execute("insert into test.t set i = 1");
+		server.execute("create table test.u ( i int )");
+		// prime GTID set
+		server.execute("insert into test.t set i = 111");
 
 		Position position = Position.capture(server.getConnection(), true);
 		MaxwellContext context = MaxwellTestSupport.buildContext(server.getPort(), position, null);
@@ -73,13 +107,27 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 			EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY,
 			EventDeserializer.CompatibilityMode.INVALID_DATE_AND_TIME_AS_MIN_VALUE
 		);
-		eventDeserializer.setEventDataDeserializer(EventType.EXT_WRITE_ROWS, new DisconnectingDeserialzier());
 
-		replicator.client.setEventDeserializer();
+		TestTableMapEventDeserializer tmd = new TestTableMapEventDeserializer();
+		eventDeserializer.setEventDataDeserializer(EventType.TABLE_MAP, tmd);
+		DisconnectingDeserializer dd = (DisconnectingDeserializer) new DisconnectingDeserializer(tmd.map).setMayContainExtraInformation(true);
+		eventDeserializer.setEventDataDeserializer(EventType.EXT_WRITE_ROWS, dd);
+		replicator.client.setEventDeserializer(eventDeserializer);
 
 		replicator.startReplicator();
+		// prime up maxwell, let it capture schema and such.
+		server.execute("insert into test.t set i = 111");
+		while ( replicator.getRow() != null ) { }
 
-		server.execute("insert into test.t set i = 2");
-		RowMap r = replicator.getRow();
+
+		server.getConnection().setAutoCommit(false);
+		server.execute("BEGIN");
+		server.execute("insert into test.t set i = 222");
+		server.execute("insert into test.u set i = " + THROWME);
+		server.execute("COMMIT");
+
+		assertEquals(222L, replicator.getRow().getData().get("i"));
+		assertEquals(333L, replicator.getRow().getData().get("i"));
+		assertEquals(null, replicator.getRow());
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
@@ -120,7 +120,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 		byte input[] = new byte[] { (byte) 126, (byte) 126, (byte) 126, (byte) 126 };
 
 		ColumnDef d = ColumnDef.build("bar", "ascii", "varchar", (short) 1, false, null, null);
-		assertThat((String) d.asJSON(input), is("~~~~"));
+		assertThat((String) d.asJSON(input, null), is("~~~~"));
 	}
 
 	@Test
@@ -129,7 +129,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 
 		ColumnDef d = ColumnDef.build("bar", "latin1", "varchar", (short) 1, false, null, null);
 
-		assertThat((String) d.asJSON(input), is("©©©©"));
+		assertThat((String) d.asJSON(input, null), is("©©©©"));
 	}
 
 	@Test
@@ -139,7 +139,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 
 		ColumnDef d = ColumnDef.build("bar", "ascii", "json", (short) 1, false, null, null);
 
-		RawJSONString result = (RawJSONString) d.asJSON(input);
+		RawJSONString result = (RawJSONString) d.asJSON(input, null);
 		assertThat(result.json, is("{\"id\":3}"));
 	}
 
@@ -149,7 +149,7 @@ public class ColumnDefTest extends TestWithNameLogging {
 
 		ColumnDef d = ColumnDef.build("bar", "ascii", "json", (short) 1, false, null, null);
 
-		RawJSONString result = (RawJSONString) d.asJSON(input);
+		RawJSONString result = (RawJSONString) d.asJSON(input, null);
 		assertThat(result.json, is("null"));
 	}
 


### PR DESCRIPTION
This is a PR to address the situation brought up in #1129.  The summary is that on unstable networks (kubernetes, in this case), maxwell was being disconnected from mysql in a great deal of locations, including in the middle of a large GTID transaction.  When this would happen we'd end up accidentally advancing the binlog position *past* the end of the transaction, hilarity ensues.

To fix this, first we bring in a PR for binlog connector: https://github.com/shyiko/mysql-binlog-connector-java/pull/250 that delays updating the GTID set until we hit the COMMIT or XID event.  This allows us to restart the binary log client in the correct spot.  Then, we modify `getTransactionEvents` to bail out when we detect a restart.

Any/all comments appreciated @ericwush @timbertson @liulikun.  