### PR TITLE
Issue #1173, allow configuration and turning off of zero datetimes

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -104,6 +104,7 @@ output_thread_id               | BOOLEAN  | records include thread_id           
 output_schema_id               | BOOLEAN  | records include schema_id, schema_id is the id of the latest schema tracked by maxwell and doesn't relate to any mysql tracked value                  | false
 output_row_query               | BOOLEAN  | records include INSERT/UPDATE/DELETE statement. Mysql option "binlog_rows_query_log_events" must be enabled | false
 output_ddl                     | BOOLEAN  | output DDL (table-alter, table-create, etc) events  | false
+output_null_zerodates          | BOOLEAN  | should we transform '0000-00-00' to null? | false
 &nbsp;
 **filtering**
 filter                         | STRING            | filter rules, eg `exclude: db.*, include: *.tbl, include: *./bar(bar)?/, exclude: foo.bar.col=val` |

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -210,7 +210,8 @@ public class Maxwell implements Runnable {
 			false,
 			config.clientID,
 			context.getHeartbeatNotifier(),
-			config.scripting
+			config.scripting,
+			config.outputConfig
 		);
 
 		bootstrapper.resume(producer, replicator);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -222,6 +222,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "output_thread_id", "produced records include thread_id; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_schema_id", "produced records include schema_id; [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "output_row_query", "produced records include query, binlog option \"binlog_rows_query_log_events\" must be enabled; [true|false]. default: false" ).withOptionalArg();
+		parser.accepts( "output_null_zerodates", "convert '0000-00-00' dates/datetimes to null default: false" ).withOptionalArg();
 		parser.accepts( "output_ddl", "produce DDL records to ddl_kafka_topic [true|false]. default: false" ).withOptionalArg();
 		parser.accepts( "exclude_columns", "suppress these comma-separated columns from output" ).withRequiredArg();
 		parser.accepts( "ddl_kafka_topic", "optionally provide an alternate topic to push DDL records to. default: kafka_topic" ).withRequiredArg();
@@ -514,6 +515,7 @@ public class MaxwellConfig extends AbstractConfig {
 		outputConfig.includesSchemaId = fetchBooleanOption("output_schema_id", options, properties, false);
 		outputConfig.includesRowQuery = fetchBooleanOption("output_row_query", options, properties, false);
 		outputConfig.outputDDL	= fetchBooleanOption("output_ddl", options, properties, false);
+		outputConfig.zeroDatesAsNull = fetchBooleanOption("output_null_zerodates", options, properties, false);
 		this.excludeColumns     = fetchOption("exclude_columns", options, properties, null);
 
 		String encryptionMode = fetchOption("encrypt", options, properties, "none");

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellOutputConfig.java
@@ -19,6 +19,7 @@ public class MaxwellOutputConfig {
 	public List<Pattern> excludeColumns;
 	public EncryptionMode encryptionMode;
 	public String secretKey;
+	public boolean zeroDatesAsNull;
 
 	public MaxwellOutputConfig() {
 		this.includesBinlogPosition = false;
@@ -30,6 +31,7 @@ public class MaxwellOutputConfig {
 		this.includesSchemaId = false;
 		this.includesRowQuery = false;
 		this.outputDDL = false;
+		this.zeroDatesAsNull = false;
 		this.excludeColumns = new ArrayList<>();
 		this.encryptionMode = EncryptionMode.ENCRYPT_NONE;
 		this.secretKey = null;

--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -4,6 +4,7 @@ import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.MaxwellMysqlConfig;
 import com.zendesk.maxwell.monitoring.Metrics;
 import com.zendesk.maxwell.monitoring.NoOpMetrics;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogConnectorReplicator;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.HeartbeatNotifier;
@@ -69,7 +70,8 @@ public class Recovery {
 					true,
 					recoveryInfo.clientID,
 					new HeartbeatNotifier(),
-					null
+					null,
+					new MaxwellOutputConfig()
 			);
 
 			replicator.setFilter(new RecoveryFilter(this.maxwellDatabaseName));

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEvent.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.replication;
 
 import com.github.shyiko.mysql.binlog.event.*;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
@@ -12,19 +13,21 @@ public class BinlogConnectorEvent {
 	public static final String BEGIN = "BEGIN";
 	public static final String COMMIT = "COMMIT";
 	public static final String SAVEPOINT = "SAVEPOINT";
+	private final MaxwellOutputConfig outputConfig;
 	private BinlogPosition position;
 	private BinlogPosition nextPosition;
 	private final Event event;
 	private final String gtidSetStr;
 	private final String gtid;
 
-	public BinlogConnectorEvent(Event event, String filename, String gtidSetStr, String gtid) {
+	public BinlogConnectorEvent(Event event, String filename, String gtidSetStr, String gtid, MaxwellOutputConfig outputConfig) {
 		this.event = event;
 		this.gtidSetStr = gtidSetStr;
 		this.gtid = gtid;
 		EventHeaderV4 hV4 = (EventHeaderV4) event.getHeader();
 		this.nextPosition = new BinlogPosition(gtidSetStr, gtid, hV4.getNextPosition(), filename);
 		this.position = new BinlogPosition(gtidSetStr, gtid, hV4.getPosition(), filename);
+		this.outputConfig = outputConfig;
 	}
 
 	public Event getEvent() {
@@ -105,7 +108,7 @@ public class BinlogConnectorEvent {
 			if ( includedColumns.get(colIdx) ) {
 				Object json = null;
 				if ( data[dataIdx] != null ) {
-					json = cd.asJSON(data[dataIdx]);
+					json = cd.asJSON(data[dataIdx], outputConfig);
 				}
 				row.putData(cd.getName(), json);
 				dataIdx++;
@@ -121,7 +124,7 @@ public class BinlogConnectorEvent {
 			if ( oldIncludedColumns.get(colIdx) ) {
 				Object json = null;
 				if ( oldData[dataIdx] != null ) {
-					json = cd.asJSON(oldData[dataIdx]);
+					json = cd.asJSON(oldData[dataIdx], outputConfig);
 				}
 
 				if (!row.hasData(cd.getName())) {

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
@@ -7,6 +7,7 @@ import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.GtidEventData;
 import com.zendesk.maxwell.monitoring.Metrics;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,16 +22,20 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener {
 	private final Timer queueTimer;
 	protected final AtomicBoolean mustStop = new AtomicBoolean(false);
 	private final BinaryLogClient client;
+	private final MaxwellOutputConfig outputConfig;
 	private long replicationLag;
 	private String gtid;
 
 	public BinlogConnectorEventListener(
 		BinaryLogClient client,
 		BlockingQueue<BinlogConnectorEvent> q,
-		Metrics metrics) {
+		Metrics metrics,
+		MaxwellOutputConfig outputConfig
+	) {
 		this.client = client;
 		this.queue = q;
 		this.queueTimer =  metrics.getRegistry().timer(metrics.metricName("replication", "queue", "time"));
+		this.outputConfig = outputConfig;
 
 		final BinlogConnectorEventListener self = this;
 		metrics.register(metrics.metricName("replication", "lag"), (Gauge<Long>) () -> self.replicationLag);
@@ -49,7 +54,7 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener {
 			gtid = ((GtidEventData)event.getData()).getGtid();
 		}
 
-		BinlogConnectorEvent ep = new BinlogConnectorEvent(event, client.getBinlogFilename(), client.getGtidSet(), gtid);
+		BinlogConnectorEvent ep = new BinlogConnectorEvent(event, client.getBinlogFilename(), client.getGtidSet(), gtid, outputConfig);
 
 		if (ep.isCommitEvent()) {
 			trackMetrics = true;

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -14,6 +14,7 @@ import com.zendesk.maxwell.bootstrap.AbstractBootstrapper;
 import com.zendesk.maxwell.filtering.Filter;
 import com.zendesk.maxwell.monitoring.Metrics;
 import com.zendesk.maxwell.producer.AbstractProducer;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMapBuffer;
@@ -84,7 +85,8 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		boolean stopOnEOF,
 		String clientID,
 		HeartbeatNotifier heartbeatNotifier,
-		Scripting scripting
+		Scripting scripting,
+		MaxwellOutputConfig outputConfig
 	) {
 		this.clientID = clientID;
 		this.bootstrapper = bootstrapper;
@@ -133,7 +135,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 			EventDeserializer.CompatibilityMode.INVALID_DATE_AND_TIME_AS_MIN_VALUE
 		);
 		this.client.setEventDeserializer(eventDeserializer);
-		this.binlogEventListener = new BinlogConnectorEventListener(client, queue, metrics);
+		this.binlogEventListener = new BinlogConnectorEventListener(client, queue, metrics, outputConfig);
 		this.client.setBlocking(!stopOnEOF);
 		this.client.registerEventListener(binlogEventListener);
 		this.client.registerLifecycleListener(binlogLifecycleListener);

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BigIntColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 import java.math.BigInteger;
 
 public class BigIntColumnDef extends ColumnDef {
@@ -28,7 +30,7 @@ public class BigIntColumnDef extends ColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
 		return toNumeric(value);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/BitColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 import java.math.BigInteger;
 import java.util.BitSet;
 
@@ -9,7 +11,7 @@ public class BitColumnDef extends ColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig outputConfig) {
 		byte[] bytes;
 		if( value instanceof Boolean ){
 			bytes = new byte[]{(byte) (( Boolean ) value ? 1 : 0)};

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -23,6 +23,7 @@ public abstract class ColumnDef implements Cloneable {
 
 	public abstract String toSQL(Object value);
 
+	@Deprecated
 	public Object asJSON(Object value) {
 		return asJSON(value, new MaxwellOutputConfig());
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDef.java
@@ -2,6 +2,7 @@ package com.zendesk.maxwell.schema.columndef;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.util.DynamicEnum;
 
 @JsonSerialize(using=ColumnDefSerializer.class)
@@ -23,9 +24,12 @@ public abstract class ColumnDef implements Cloneable {
 	public abstract String toSQL(Object value);
 
 	public Object asJSON(Object value) {
-		return value;
+		return asJSON(value, new MaxwellOutputConfig());
 	}
 
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
+		return value;
+	}
 
 	public ColumnDef clone() {
 		try {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefWithLength.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/ColumnDefWithLength.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 public abstract class ColumnDefWithLength extends ColumnDef {
 	protected Long columnLength;
 
@@ -27,12 +29,12 @@ public abstract class ColumnDefWithLength extends ColumnDef {
 
 	@Override
 	public String toSQL(Object value) {
-		return "'" + formatValue(value) + "'";
+		return "'" + formatValue(value, new MaxwellOutputConfig()) + "'";
 	}
 
 	@Override
-	public Object asJSON(Object value) {
-		return formatValue(value);
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
+		return formatValue(value, config);
 	}
 
 	public Long getColumnLength() { return columnLength ; }
@@ -41,7 +43,7 @@ public abstract class ColumnDefWithLength extends ColumnDef {
 		this.columnLength = length;
 	}
 
-	protected abstract String formatValue(Object value);
+	protected abstract String formatValue(Object value, MaxwellOutputConfig config);
 
 	protected static String appendFractionalSeconds(String value, int nanos, Long columnLength) {
 		if ( columnLength == 0L )

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 public class DateColumnDef extends ColumnDef {
 	public DateColumnDef(String name, String type, short pos) {
 		super(name, type, pos);
@@ -15,9 +17,13 @@ public class DateColumnDef extends ColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
-		if ( value instanceof Long && (Long) value == Long.MIN_VALUE )
-			return "0000-00-00";
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
+		if ( value instanceof Long && (Long) value == Long.MIN_VALUE ) {
+			if ( config.zeroDatesAsNull )
+				return null;
+			else
+				return "0000-00-00";
+		}
 
 		return DateFormatter.formatDate(value);
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 import java.sql.Timestamp;
 
 public class DateTimeColumnDef extends ColumnDefWithLength {
@@ -8,19 +10,20 @@ public class DateTimeColumnDef extends ColumnDefWithLength {
 	}
 
 	final private boolean isTimestamp = getType().equals("timestamp");
-	protected String formatValue(Object value) {
+	protected String formatValue(Object value, MaxwellOutputConfig config) {
 		// special case for those broken mysql dates.
 		if ( value instanceof Long ) {
 			Long v = (Long) value;
-			if ( v == Long.MIN_VALUE || (v == 0L && isTimestamp) )
-				return appendFractionalSeconds("0000-00-00 00:00:00", 0, columnLength);
+			if ( v == Long.MIN_VALUE || (v == 0L && isTimestamp) ) {
+				if ( config.zeroDatesAsNull )
+					return null;
+				else
+					return appendFractionalSeconds("0000-00-00 00:00:00", 0, columnLength);
+			}
 		}
 
 		Timestamp ts = DateFormatter.extractTimestamp(value);
 		String dateString = DateFormatter.formatDateTime(value, ts);
-		if ( dateString == null )
-			return null;
-		else
-			return appendFractionalSeconds(dateString, ts.getNanos(), columnLength);
+		return appendFractionalSeconds(dateString, ts.getNanos(), columnLength);
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/EnumColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/EnumColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 public class EnumColumnDef extends EnumeratedColumnDef {
 	public EnumColumnDef(String name, String type, short pos, String[] enumValues) {
 		super(name, type, pos, enumValues);
@@ -11,7 +13,7 @@ public class EnumColumnDef extends EnumeratedColumnDef {
 	}
 
 	@Override
-	public String asJSON(Object value) {
+	public String asJSON(Object value, MaxwellOutputConfig config) {
 		return asString(value);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/GeometryColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/GeometryColumnDef.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell.schema.columndef;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKBReader;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 
 import java.util.Arrays;
 
@@ -15,7 +16,7 @@ public class GeometryColumnDef extends ColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
 		Geometry geometry = null;
 		if ( value instanceof Geometry ) {
 			geometry = (Geometry) value;

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/IntColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 public class IntColumnDef extends ColumnDef {
 	public int bits;
 
@@ -44,7 +46,7 @@ public class IntColumnDef extends ColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
 		return toLong(value);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/JsonColumnDef.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
 import com.github.shyiko.mysql.binlog.event.deserialization.json.JsonBinary;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.row.RawJSONString;
 
 import java.io.IOException;
@@ -13,7 +14,7 @@ public class JsonColumnDef extends ColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
 		String jsonString;
 
 		if ( value instanceof String ) {

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/SetColumnDef.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell.schema.columndef;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import org.apache.commons.lang3.StringUtils;
 
 public class SetColumnDef extends EnumeratedColumnDef {
@@ -16,7 +17,7 @@ public class SetColumnDef extends EnumeratedColumnDef {
 	}
 
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
 		return asList(value);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/StringColumnDef.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell.schema.columndef;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 
@@ -60,7 +61,7 @@ public class StringColumnDef extends ColumnDef {
 		}
 	}
 	@Override
-	public Object asJSON(Object value) {
+	public Object asJSON(Object value, MaxwellOutputConfig config) {
 
 		if ( value instanceof String ) {
 			return value;

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/TimeColumnDef.java
@@ -1,5 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+
 import java.sql.Time;
 import java.sql.Timestamp;
 
@@ -8,7 +10,7 @@ public class TimeColumnDef extends ColumnDefWithLength {
 		super(name, type, pos, columnLength);
 	}
 
-	protected String formatValue(Object value) {
+	protected String formatValue(Object value, MaxwellOutputConfig config) {
 		if ( value instanceof Timestamp ) {
 			Time time = new Time(((Timestamp) value).getTime());
 			String timeAsStr = String.valueOf(time);

--- a/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
@@ -2,9 +2,7 @@ package com.zendesk.maxwell.schema.columndef;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -14,6 +12,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import com.zendesk.maxwell.TestWithNameLogging;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.row.RawJSONString;
 import org.junit.After;
 import org.junit.Before;
@@ -224,6 +223,17 @@ public class ColumnDefTest extends TestWithNameLogging {
 	}
 
 	@Test
+	public void TestDateZeroDates() {
+		ColumnDef d = build("date", true);
+
+		MaxwellOutputConfig config = new MaxwellOutputConfig();
+		config.zeroDatesAsNull = true;
+
+		assertEquals(null, d.asJSON(Long.MIN_VALUE, config));
+	}
+
+
+	@Test
 	public void TestDateTime() throws ParseException {
 		ColumnDef d = build("datetime", true);
 		assertThat(d, instanceOf(DateTimeColumnDef.class));
@@ -231,6 +241,16 @@ public class ColumnDefTest extends TestWithNameLogging {
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 		Date date = simpleDateFormat.parse("1979-10-01 19:19:19");
 		assertThat(d.toSQL(date), is("'1979-10-01 19:19:19'"));
+	}
+
+	@Test
+	public void TestDateTimeZeroDates() {
+		ColumnDef d = build("datetime", true);
+
+		MaxwellOutputConfig config = new MaxwellOutputConfig();
+		config.zeroDatesAsNull = true;
+
+		assertEquals(null, d.asJSON(Long.MIN_VALUE, config));
 	}
 
 	@Test
@@ -263,11 +283,11 @@ public class ColumnDefTest extends TestWithNameLogging {
 		assertThat(d, instanceOf(DateTimeColumnDef.class));
 
 		Timestamp t = Timestamp.valueOf("1979-10-01 19:19:19.001000");
-		org.junit.Assert.assertEquals(1000000, t.getNanos());
+		assertEquals(1000000, t.getNanos());
 		assertThat(d.toSQL(t), is("'1979-10-01 19:19:19.001000'"));
 
 		t = Timestamp.valueOf("1979-10-01 19:19:19.000001");
-		org.junit.Assert.assertEquals(1000, t.getNanos());
+		assertEquals(1000, t.getNanos());
 		assertThat(d.toSQL(t), is("'1979-10-01 19:19:19.000001'"));
 
 		t = Timestamp.valueOf("1979-10-01 19:19:19.345678");


### PR DESCRIPTION
I'd say that zero datetimes, along with blacklisting, have eaten up an immense amount of time relative to their value.

This PR adds `--output_null_zerodates`, which allows the user to cast all '0000-00-00' dates/datetimes to NULLs.

If I think about it, I shoulda just cast them to null in the first place.  

Maybe.