### PR TITLE
Refactor: stop passing around bootstrap rows

### DIFF
--- a/bin/maxwell-bootstrap
+++ b/bin/maxwell-bootstrap
@@ -5,6 +5,7 @@ set -e
 base_dir="$(dirname "$0")/.."
 lib_dir="$base_dir/lib"
 lib_dir_development="$base_dir/target/lib"
+
 if [ ! -e "$lib_dir" -a -e "$lib_dir_development" ]; then
 	lib_dir="$lib_dir_development"
 	CLASSPATH="$CLASSPATH:$base_dir/target/classes"

--- a/src/main/java/com/zendesk/maxwell/bootstrap/AbstractBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/AbstractBootstrapper.java
@@ -1,58 +1,36 @@
 package com.zendesk.maxwell.bootstrap;
 
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.replication.Replicator;
 import com.zendesk.maxwell.row.RowMap;
-import com.zendesk.maxwell.producer.AbstractProducer;
 
 import java.io.IOException;
 import java.sql.SQLException;
 
 public abstract class AbstractBootstrapper {
-
 	protected MaxwellContext context;
 
-	public AbstractBootstrapper(MaxwellContext context) { this.context = context; }
+	protected AbstractBootstrapper(MaxwellContext context) {
+		this.context = context;
+	}
 
-	public boolean isStartBootstrapRow(RowMap row) {
+	protected boolean isStartBootstrapRow(RowMap row) {
 		return isBootstrapRow(row) &&
 			row.getData("started_at") == null &&
 			row.getData("completed_at") == null &&
 			( long ) row.getData("is_complete") == 0;
 	}
 
-	public boolean isCompleteBootstrapRow(RowMap row) {
-		return isBootstrapRow(row) &&
-			row.getData("started_at") != null &&
-			row.getData("completed_at") != null &&
-			( long ) row.getData("is_complete") == 1;
-	}
-
-	public boolean isBootstrapRow(RowMap row) {
+	protected boolean isBootstrapRow(RowMap row) {
 		return row.getDatabase().equals(this.context.getConfig().databaseName) &&
 			row.getTable().equals("bootstrap") &&
 			row.getData("client_id").equals(this.context.getConfig().clientID);
 	}
 
-	protected String bootstrapDatabase(RowMap rowmap) {
-		return (String) rowmap.getData("database_name");
-	}
-
-	protected String bootstrapTable(RowMap rowmap) {
-		return (String) rowmap.getData("table_name");
-	}
-
-	protected String bootstrapWhere(RowMap rowmap) {
-		return (String) rowmap.getData("where_clause");
-	}
-
 	abstract public boolean shouldSkip(RowMap row) throws SQLException, IOException;
 
-	abstract public void startBootstrap(RowMap startBootstrapRow, AbstractProducer producer, Replicator replicator) throws Exception;
-
-	abstract public void completeBootstrap(RowMap completeBootstrapRow, AbstractProducer producer, Replicator replicator) throws Exception;
-
-	public abstract void resume(AbstractProducer producer, Replicator replicator) throws Exception;
+	public abstract void resume(AbstractProducer producer, Replicator replicator) throws SQLException;
 
 	public abstract boolean isRunning();
 

--- a/src/main/java/com/zendesk/maxwell/bootstrap/AsynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/AsynchronousBootstrapper.java
@@ -1,7 +1,6 @@
 package com.zendesk.maxwell.bootstrap;
 
 import com.zendesk.maxwell.*;
-import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Replicator;
 import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.row.RowMap;
@@ -10,25 +9,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedList;
-import java.util.NoSuchElementException;
 import java.util.Queue;
 
 public class AsynchronousBootstrapper extends AbstractBootstrapper {
-
-	static final Logger LOGGER = LoggerFactory.getLogger(Replicator.class);
+	static final Logger LOGGER = LoggerFactory.getLogger(AsynchronousBootstrapper.class);
 
 	private Thread thread = null;
-	private Queue<RowMap> queue = new LinkedList<>();
-	private RowMap bootstrappedRow = null;
+	private Queue<BootstrapTask> queue = new LinkedList<>();
+	private BootstrapTask activeTask = null;
+
 	private RowMapBufferByTable skippedRows = null;
 	private SynchronousBootstrapper synchronousBootstrapper = getSynchronousBootstrapper();
 
-	public AsynchronousBootstrapper( MaxwellContext context ) throws IOException {
+	public AsynchronousBootstrapper( MaxwellContext context ) {
 		super(context);
 		skippedRows = new RowMapBufferByTable();
 	}
@@ -38,18 +33,18 @@ public class AsynchronousBootstrapper extends AbstractBootstrapper {
 	}
 
 	@Override
-	public boolean shouldSkip(RowMap row) throws SQLException, IOException {
+	public boolean shouldSkip(RowMap row) throws IOException {
 		// The main replication thread skips rows of the currently bootstrapped
 		// table and the tables that are queued for bootstrap. The bootstrap thread replays them at
 		// the end of the bootstrap. If maxwell is stopped these skipped rows will be lost;
 		// however, at next startup resume() restarts the bootstrap process from the
 		// beginning which restores the consistency of the replication stream.
-		if ( bootstrappedRow != null && haveSameTable(row, bootstrappedRow) ) {
+		if ( activeTask != null && haveSameTable(row, activeTask) ) {
 			skippedRows.add(row);
 			return true;
 		}
-		for ( RowMap queuedRow : queue ) {
-			if ( haveSameTable(row, queuedRow) ) {
+		for ( BootstrapTask task : queue ) {
+			if ( haveSameTable(row, task) ) {
 				skippedRows.add(row);
 				return true;
 			}
@@ -57,124 +52,80 @@ public class AsynchronousBootstrapper extends AbstractBootstrapper {
 		return false;
 	}
 
-	private boolean haveSameTable(RowMap row, RowMap bootstrapStartRow) {
-		String databaseName = bootstrapDatabase(bootstrapStartRow);
-		String tableName = bootstrapTable(bootstrapStartRow);
-		return row.getDatabase().equals(databaseName) && row.getTable().equals(tableName);
+	private boolean haveSameTable(RowMap row, BootstrapTask activeTask) {
+		return row.getDatabase().equals(activeTask.database) && row.getTable().equals(activeTask.table);
 	}
 
-	@Override
-	public void startBootstrap(final RowMap bootstrapStartRow, final AbstractProducer producer, final Replicator replicator) throws Exception {
+	public void startBootstrap(final BootstrapTask task, final AbstractProducer producer, final Replicator replicator) {
 		if (thread == null) {
-			bootstrappedRow = bootstrapStartRow;
-			thread = new Thread(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						synchronousBootstrapper.startBootstrap(bootstrapStartRow, producer, replicator);
-					} catch ( NoSuchElementException e ) {
-						LOGGER.warn(String.format("async bootstrapping cancelled for table %s.%s", bootstrapDatabase(bootstrapStartRow), bootstrapTable(bootstrapStartRow)));
-						cancelBootstrap(bootstrapStartRow, producer, replicator);
-					} catch ( Exception e ) {
-						e.printStackTrace();
-						System.exit(1);
-					}
+			activeTask = task;
+			thread = new Thread(() -> {
+				try {
+					synchronousBootstrapper.performBootstrap(task, producer, replicator);
+				} catch ( Exception e ) {
+					e.printStackTrace();
+					System.exit(1);
+				} finally {
+					activeTask = null;
+					completeBootstrap(task, producer, replicator);
 				}
 			});
 			thread.start();
 		} else {
-			queueRow(bootstrapStartRow);
+			queueTask(task);
 		}
 	}
 
-	private void queueRow(RowMap row) {
-		queue.add(row);
-		LOGGER.info(String.format("async bootstrapping: queued table %s.%s for bootstrapping", bootstrapDatabase(row), bootstrapTable(row)));
+	private void queueTask(BootstrapTask task) {
+		queue.add(task);
+		LOGGER.info(String.format("async bootstrapping: queued table %s.%s for bootstrapping", task.database, task.table));
 	}
 
-	@Override
-	public void completeBootstrap(RowMap bootstrapCompleteRow, AbstractProducer producer, Replicator replicator) throws Exception {
-		String databaseName = bootstrapDatabase(bootstrapCompleteRow);
-		String tableName = bootstrapTable(bootstrapCompleteRow);
-
+	private void completeBootstrap(BootstrapTask task, AbstractProducer producer, Replicator replicator) {
 		try {
-			replaySkippedRows(databaseName, tableName, producer, bootstrapCompleteRow);
-			synchronousBootstrapper.completeBootstrap(bootstrapCompleteRow, producer, replicator);
-			LOGGER.info(String.format("async bootstrapping ended for %s.%s", databaseName, tableName));
+			replaySkippedRows(task, producer);
+			synchronousBootstrapper.completeBootstrap(task, producer, replicator);
 		} catch ( Exception e ) {
 			e.printStackTrace();
 			System.exit(1);
 		} finally {
 			thread = null;
-			bootstrappedRow = null;
 		}
 		if ( !queue.isEmpty() ) {
 			startBootstrap(queue.remove(), producer, replicator);
 		}
 	}
 
-	public void cancelBootstrap(RowMap bootstrapStartRow, AbstractProducer producer, Replicator replicator) {
-		try {
-			replaySkippedRows(bootstrapDatabase(bootstrapStartRow), bootstrapTable(bootstrapStartRow), producer, bootstrapStartRow);
-			thread = null;
-			bootstrappedRow = null;
-			if ( !queue.isEmpty() ) {
-				startBootstrap(queue.remove(), producer, replicator);
-			}
-		} catch ( Exception e ) {
-			e.printStackTrace();
-		}
-	}
 
-	private void replaySkippedRows(String databaseName, String tableName, AbstractProducer producer, RowMap bootstrapCompleteRow) throws Exception {
-		BinlogPosition bootstrapStartBinlogPosition = getBootstrapStartBinlogPosition(bootstrapCompleteRow);
-		LOGGER.info("async bootstrapping: replaying " + skippedRows.size(databaseName, tableName) + " skipped rows...");
-		skippedRows.flushToDisk(databaseName, tableName);
-		while ( skippedRows.size(databaseName, tableName) > 0 ) {
-			RowMap row = skippedRows.removeFirst(databaseName, tableName);
-			if ( bootstrapStartBinlogPosition == null || row.getPosition().getBinlogPosition().newerThan(bootstrapStartBinlogPosition) )
-				producer.push(row);
+	private void replaySkippedRows(BootstrapTask task, AbstractProducer producer) throws Exception {
+		if ( skippedRows.size(task.database, task.table) == 0 )
+			return;
+
+		LOGGER.info("async bootstrapping: replaying " + skippedRows.size(task.database, task.table) + " skipped rows...");
+		skippedRows.flushToDisk(task.database, task.table);
+		while ( skippedRows.size(task.database, task.table) > 0 ) {
+			RowMap row = skippedRows.removeFirst(task.database, task.table);
+			producer.push(row);
 		}
 		LOGGER.info("async bootstrapping: replay complete");
 	}
 
-	private BinlogPosition getBootstrapStartBinlogPosition(RowMap bootstrapCompleteRow) throws SQLException {
-		try ( Connection connection = context.getMaxwellConnection() ) {
-			String sql = "select * from `bootstrap` where id = ?";
-			PreparedStatement preparedStatement = connection.prepareStatement(sql);
-			preparedStatement.setLong(1, ( Long ) bootstrapCompleteRow.getData("id"));
-			ResultSet resultSet = preparedStatement.executeQuery();
-			if ( resultSet.next() ) {
-				return new BinlogPosition(resultSet.getLong("binlog_position"), resultSet.getString("binlog_file"));
-			} else {
-				return null;
-			}
-		}
-	}
 
 	@Override
-	public void resume(AbstractProducer producer, Replicator replicator) throws Exception {
+	public void resume(AbstractProducer producer, Replicator replicator) throws SQLException {
 		synchronousBootstrapper.resume(producer, replicator);
 	}
 
-	public void join() throws InterruptedException {
-		if ( thread != null ) {
-			thread.join();
+	@Override
+	public void work(RowMap row, AbstractProducer producer, Replicator replicator) {
+		if ( isStartBootstrapRow(row) ) {
+			startBootstrap(BootstrapTask.valueOf(row), producer, replicator);
 		}
 	}
 
 	@Override
 	public boolean isRunning() {
 		return thread != null || queue.size() > 0;
-	}
-
-	@Override
-	public void work(RowMap row, AbstractProducer producer, Replicator replicator) throws Exception {
-		if ( isStartBootstrapRow(row) ) {
-			startBootstrap(row, producer, replicator);
-		} else if ( isCompleteBootstrapRow(row) ) {
-			completeBootstrap(row, producer, replicator);
-		}
 	}
 }
 

--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapTask.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapTask.java
@@ -1,0 +1,40 @@
+package com.zendesk.maxwell.bootstrap;
+
+import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.row.RowMap;
+
+import java.sql.Timestamp;
+
+public class BootstrapTask {
+	public String database;
+	public String table;
+	public String whereClause;
+	public Long id;
+	public BinlogPosition startPosition;
+	public boolean complete;
+	public Timestamp startedAt;
+	public Timestamp completedAt;
+
+	public volatile boolean abort;
+
+	public String logString() {
+		String s = String.format("#%d %s.%s", id, database, table);
+		if ( whereClause != null )
+			s += " WHERE " + whereClause;
+		return s;
+	}
+
+	public static BootstrapTask valueOf(RowMap row) {
+		BootstrapTask t = new BootstrapTask();
+		t.database = (String) row.getData("database_name");
+		t.table = (String) row.getData("table_name");
+		t.whereClause = (String) row.getData("where_clause");
+		t.id = (Long) row.getData("id");
+
+		String binlogFile = (String) row.getData("binlog_file");
+		Long binlogOffset = (Long) row.getData("binlog_position");
+
+		t.startPosition = BinlogPosition.at(binlogOffset, binlogFile);
+		return t;
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/bootstrap/NoOpBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/NoOpBootstrapper.java
@@ -7,10 +7,9 @@ import com.zendesk.maxwell.producer.AbstractProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
+
 public class NoOpBootstrapper extends AbstractBootstrapper {
-
-	static final Logger LOGGER = LoggerFactory.getLogger( NoOpBootstrapper.class );
-
 	public NoOpBootstrapper(MaxwellContext context) { super( context ); }
 
 	@Override
@@ -19,13 +18,7 @@ public class NoOpBootstrapper extends AbstractBootstrapper {
 	}
 
 	@Override
-	public void startBootstrap(RowMap startBootstrapRow, AbstractProducer producer, Replicator replicator) throws Exception {}
-
-	@Override
-	public void completeBootstrap(RowMap completeBootstrapRow, AbstractProducer producer, Replicator replicator) throws Exception {}
-
-	@Override
-	public void resume(AbstractProducer producer, Replicator replicator) throws Exception {}
+	public void resume(AbstractProducer producer, Replicator replicator) { }
 
 	@Override
 	public boolean isRunning( ) {
@@ -33,6 +26,6 @@ public class NoOpBootstrapper extends AbstractBootstrapper {
 	}
 
 	@Override
-	public void work(RowMap row, AbstractProducer producer, Replicator replicator) throws Exception {}
+	public void work(RowMap row, AbstractProducer producer, Replicator replicator) {}
 
 }

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -1,10 +1,8 @@
 package com.zendesk.maxwell.bootstrap;
 
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
-import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.AbstractProducer;
-import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.replication.Replicator;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.Database;
@@ -157,6 +155,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 	public void work(RowMap row, AbstractProducer producer, Replicator replicator) throws Exception {
 		try {
 			if ( isStartBootstrapRow(row) ) {
+				producer.push(row);
 				startBootstrap(BootstrapTask.valueOf(row), producer, replicator);
 			}
 		} catch ( NoSuchElementException e ) {

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -3,10 +3,10 @@ package com.zendesk.maxwell.bootstrap;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.replication.Replicator;
 import com.zendesk.maxwell.row.RowMap;
-import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.Table;
@@ -16,7 +16,6 @@ import com.zendesk.maxwell.scripting.Scripting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.*;
 import java.util.Iterator;
@@ -37,36 +36,30 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		return false;
 	}
 
-	@Override
-	public void startBootstrap(RowMap startBootstrapRow, AbstractProducer producer, Replicator replicator) throws Exception {
-		String databaseName = bootstrapDatabase(startBootstrapRow);
-		String tableName = bootstrapTable(startBootstrapRow);
+	public void startBootstrap(BootstrapTask task, AbstractProducer producer, Replicator replicator) throws Exception {
+		performBootstrap(task, producer, replicator);
+		completeBootstrap(task, producer, replicator);
+	}
 
-		String whereClause = bootstrapWhere(startBootstrapRow);
-
-		String logString = String.format("bootstrapping request for %s.%s", databaseName, tableName);
-		if ( whereClause != null ) {
-			logString += String.format(" with where clause %s", whereClause);
-		}
-		LOGGER.debug(logString);
+	public void performBootstrap(BootstrapTask task, AbstractProducer producer, Replicator replicator) throws Exception {
+		LOGGER.debug("bootstrapping requested for " + task.logString());
 
 		Schema schema = replicator.getSchema();
-		Database database = findDatabase(schema, databaseName);
-		Table table = findTable(tableName, database);
+		Database database = findDatabase(schema, task.database);
+		Table table = findTable(task.table, database);
 
 		Long schemaId = replicator.getSchemaId();
-		Position position = startBootstrapRow.getPosition();
-		producer.push(startBootstrapRow);
-		producer.push(bootstrapStartRowMap(table, position));
-		LOGGER.info(String.format("bootstrapping started for %s.%s, binlog position is %s", databaseName, tableName, position.toString()));
+		producer.push(bootstrapStartRowMap(table));
+		LOGGER.info(String.format("bootstrapping started for %s.%s", task.database, task.table));
+
 		try ( Connection connection = getConnection();
 			  Connection streamingConnection = getStreamingConnection()) {
-			setBootstrapRowToStarted(startBootstrapRow, connection);
-			ResultSet resultSet = getAllRows(databaseName, tableName, schema, whereClause, streamingConnection);
+			setBootstrapRowToStarted(task.id, connection);
+			ResultSet resultSet = getAllRows(task.database, task.table, table, task.whereClause, streamingConnection);
 			int insertedRows = 0;
 			lastInsertedRowsUpdateTimeMillis = 0; // ensure updateInsertedRowsColumn is called at least once
 			while ( resultSet.next() ) {
-				RowMap row = bootstrapEventRowMap("bootstrap-insert", table, position);
+				RowMap row = bootstrapEventRowMap("bootstrap-insert", table);
 				setRowValues(row, resultSet, table);
 				row.setSchemaId(schemaId);
 
@@ -79,22 +72,21 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 
 				producer.push(row);
 				++insertedRows;
-				updateInsertedRowsColumn(insertedRows, startBootstrapRow, position.getBinlogPosition(), connection);
+				updateInsertedRowsColumn(insertedRows, task.id, connection);
 			}
-			setBootstrapRowToCompleted(insertedRows, startBootstrapRow, connection);
+			setBootstrapRowToCompleted(insertedRows, task.id, connection);
+		} catch ( NoSuchElementException e ) {
+			LOGGER.info("bootstrapping aborted for " + task.logString());
 		}
 	}
 
-	private void updateInsertedRowsColumn(int insertedRows, RowMap startBootstrapRow, BinlogPosition position, Connection connection) throws SQLException, NoSuchElementException {
+	private void updateInsertedRowsColumn(int insertedRows, Long id, Connection connection) throws SQLException, NoSuchElementException {
 		long now = System.currentTimeMillis();
 		if ( now - lastInsertedRowsUpdateTimeMillis > INSERTED_ROWS_UPDATE_PERIOD_MILLIS ) {
-			long rowId = ( long ) startBootstrapRow.getData("id");
-			String sql = "update `bootstrap` set inserted_rows = ?, binlog_file = ?, binlog_position = ? where id = ?";
+			String sql = "update `bootstrap` set inserted_rows = ? where id = ?";
 			PreparedStatement preparedStatement = connection.prepareStatement(sql);
 			preparedStatement.setInt(1, insertedRows);
-			preparedStatement.setString(2, position.getFile());
-			preparedStatement.setLong(3, position.getOffset());
-			preparedStatement.setLong(4, rowId);
+			preparedStatement.setLong(2, id);
 			if ( preparedStatement.executeUpdate() == 0 ) {
 				throw new NoSuchElementException();
 			}
@@ -114,43 +106,37 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		return conn;
 	}
 
-	private RowMap bootstrapStartRowMap(Table table, Position position) {
-		return bootstrapEventRowMap("bootstrap-start", table, position);
+	private RowMap bootstrapStartRowMap(Table table) {
+		return bootstrapEventRowMap("bootstrap-start", table);
 	}
 
-	private RowMap bootstrapCompleteRowMap(Table table, Position position) {
-		return bootstrapEventRowMap("bootstrap-complete", table, position);
+	private RowMap bootstrapCompleteRowMap(Table table) {
+		return bootstrapEventRowMap("bootstrap-complete", table);
 	}
 
-	private RowMap bootstrapEventRowMap(String type, Table table, Position position) {
+	private RowMap bootstrapEventRowMap(String type, Table table) {
 		return new RowMap(
 				type,
 				table.getDatabase(),
 				table.getName(),
 				System.currentTimeMillis(),
 				table.getPKList(),
-				position);
+				null);
+	}
+
+	public void completeBootstrap(BootstrapTask task, AbstractProducer producer, Replicator replicator) throws Exception {
+		Database database = findDatabase(replicator.getSchema(), task.database);
+		ensureTable(task.table, database);
+		Table table = findTable(task.table, database);
+
+		producer.push(bootstrapCompleteRowMap(table));
+
+		LOGGER.info("bootstrapping ended for " + task.logString());
 	}
 
 	@Override
-	public void completeBootstrap(RowMap completeBootstrapRow, AbstractProducer producer, Replicator replicator) throws Exception {
-		String databaseName = bootstrapDatabase(completeBootstrapRow);
-		String tableName = bootstrapTable(completeBootstrapRow);
-
-		Database database = findDatabase(replicator.getSchema(), databaseName);
-		ensureTable(tableName, database);
-		Table table = findTable(tableName, database);
-
-		Position position = completeBootstrapRow.getPosition();
-		producer.push(completeBootstrapRow);
-		producer.push(bootstrapCompleteRowMap(table, position));
-
-		LOGGER.info(String.format("bootstrapping ended for %s.%s", databaseName, tableName));
-	}
-
-	@Override
-	public void resume(AbstractProducer producer, Replicator replicator) throws Exception {
-		try ( Connection connection = context.getMaxwellConnection() ) {
+	public void resume(AbstractProducer producer, Replicator replicator) throws SQLException {
+		try (Connection connection = context.getMaxwellConnection()) {
 			// This update resets all rows of incomplete bootstraps to their original state.
 			// These updates are treated as fresh bootstrap requests and trigger a restart
 			// of the bootstrap process from the beginning.
@@ -171,9 +157,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 	public void work(RowMap row, AbstractProducer producer, Replicator replicator) throws Exception {
 		try {
 			if ( isStartBootstrapRow(row) ) {
-				startBootstrap(row, producer, replicator);
-			} else if ( isCompleteBootstrapRow(row) ) {
-				completeBootstrap(row, producer, replicator);
+				startBootstrap(BootstrapTask.valueOf(row), producer, replicator);
 			}
 		} catch ( NoSuchElementException e ) {
 			LOGGER.info(String.format("bootstrapping cancelled for %s.%s", row.getDatabase(), row.getTable()));
@@ -198,10 +182,10 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		findTable(tableName, database);
 	}
 
-	private ResultSet getAllRows(String databaseName, String tableName, Schema schema, String whereClause,
-								Connection connection) throws SQLException, InterruptedException {
+	private ResultSet getAllRows(String databaseName, String tableName, Table table, String whereClause,
+								Connection connection) throws SQLException {
 		Statement statement = createBatchStatement(connection);
-		String pk = schema.findDatabase(databaseName).findTable(tableName).getPKString();
+		String pk = table.getPKString();
 
 		String sql = String.format("select * from `%s`.%s", databaseName, tableName);
 
@@ -216,32 +200,32 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		return statement.executeQuery(sql);
 	}
 
-	private Statement createBatchStatement(Connection connection) throws SQLException, InterruptedException {
+	private Statement createBatchStatement(Connection connection) throws SQLException {
 		Statement statement = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 		statement.setFetchSize(Integer.MIN_VALUE);
 		return statement;
 	}
 
-	private void setBootstrapRowToStarted(RowMap startBootstrapRow, Connection connection) throws SQLException, NoSuchElementException {
-		String sql = "update `bootstrap` set started_at=NOW() where id=?";
-		PreparedStatement preparedStatement = connection.prepareStatement(sql);
-		preparedStatement.setLong(1, ( Long ) startBootstrapRow.getData("id"));
+	private final String startBootstrapSQL = "update `bootstrap` set started_at=NOW() where id=?";
+	private void setBootstrapRowToStarted(Long id, Connection connection) throws SQLException, NoSuchElementException {
+		PreparedStatement preparedStatement = connection.prepareStatement(startBootstrapSQL);
+		preparedStatement.setLong(1, id);
 		if ( preparedStatement.executeUpdate() == 0) {
 			throw new NoSuchElementException();
 		}
 	}
 
-	private void setBootstrapRowToCompleted(int insertedRows, RowMap startBootstrapRow, Connection connection) throws SQLException, NoSuchElementException {
-		String sql = "update `bootstrap` set is_complete=1, inserted_rows=?, completed_at=NOW() where id=?";
-		PreparedStatement preparedStatement = connection.prepareStatement(sql);
+	private final String completeBootstrapSQL = "update `bootstrap` set is_complete=1, inserted_rows=?, completed_at=NOW() where id=?";
+	private void setBootstrapRowToCompleted(int insertedRows, Long id, Connection connection) throws SQLException, NoSuchElementException {
+		PreparedStatement preparedStatement = connection.prepareStatement(completeBootstrapSQL);
 		preparedStatement.setInt(1, insertedRows);
-		preparedStatement.setLong(2, ( Long ) startBootstrapRow.getData("id"));
+		preparedStatement.setLong(2, id);
 		if ( preparedStatement.executeUpdate() == 0) {
 			throw new NoSuchElementException();
 		}
 	}
 
-	private void setRowValues(RowMap row, ResultSet resultSet, Table table) throws SQLException, IOException {
+	private void setRowValues(RowMap row, ResultSet resultSet, Table table) throws SQLException {
 		Iterator<ColumnDef> columnDefinitions = table.getColumnList().iterator();
 		int columnIndex = 1;
 		while ( columnDefinitions.hasNext() ) {

--- a/src/main/java/com/zendesk/maxwell/row/RowMap.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMap.java
@@ -157,12 +157,14 @@ public class RowMap implements Serializable {
 				g.writeBooleanField(FieldNames.COMMIT, true);
 		}
 
-		BinlogPosition binlogPosition = this.position.getBinlogPosition();
-		if ( outputConfig.includesBinlogPosition )
-			g.writeStringField(FieldNames.POSITION, binlogPosition.getFile() + ":" + binlogPosition.getOffset());
+		if ( this.position != null ) {
+			BinlogPosition binlogPosition = this.position.getBinlogPosition();
+			if ( outputConfig.includesBinlogPosition )
+				g.writeStringField(FieldNames.POSITION, binlogPosition.getFile() + ":" + binlogPosition.getOffset());
 
-		if ( outputConfig.includesGtidPosition)
-			g.writeStringField(FieldNames.GTID, binlogPosition.getGtid());
+			if ( outputConfig.includesGtidPosition)
+				g.writeStringField(FieldNames.GTID, binlogPosition.getGtid());
+		}
 
 		if ( outputConfig.includesServerId && this.serverId != null ) {
 			g.writeNumberField(FieldNames.SERVER_ID, this.serverId);

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -239,7 +239,7 @@ public class MaxwellTestSupport {
 
 			lastPositionRead = row.getPosition();
 
-			if ( lastPositionRead.getLastHeartbeatRead() >= finalHeartbeat ) {
+			if ( lastPositionRead != null && lastPositionRead.getLastHeartbeatRead() >= finalHeartbeat ) {
 				// consume whatever's left over in the buffer.
 				for ( ;; ) {
 					RowMap r = maxwell.poll(100);


### PR DESCRIPTION
I've been meaning for some time to move the triggering of bootstraps away from replication, this will let maxwell perform bootstraps while replicating from a slave. 

The first step here is to start to untangle the notion that bootstrap control is tied directly to `RowMap`