### PR TITLE
Set metricsPrefix even when metricsReportingType is not set

### DIFF
--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
@@ -40,12 +40,12 @@ public class MaxwellMetrics implements Metrics {
 	}
 
 	private void setup(MaxwellConfig config) {
+		metricsPrefix = config.metricsPrefix;
+
 		if (config.metricsReportingType == null) {
 			LOGGER.warn("Metrics will not be exposed: metricsReportingType not configured.");
 			return;
 		}
-
-		metricsPrefix = config.metricsPrefix;
 
 		if (config.metricsJvm) {
 			config.metricRegistry.register(metricName("jvm", "memory_usage"), new MemoryUsageGaugeSet());


### PR DESCRIPTION
When metricsPrefix is set and metricsReportingType is not set, Maxwell-level Metrics 
(e.g. replication.lag, messages.succeeded) are still created and updated in the MetricRegistry
(MaxwellConfig.metricRegistry) but without the prefix. This is a problem when using Maxwell
as an embedded library -- the set prefix is not respected when the container application
provides the MetricRegistry.

Closes #1205