### PR TITLE
Minor addition and correction to quickstart guide

### DIFF
--- a/docs/docs/compat.md
+++ b/docs/docs/compat.md
@@ -1,7 +1,7 @@
 ### Requirements:
 ***
 - JRE 7 or above
-- mysql 5.1, 5.5, 5.6, 5.7
+- mysql 5.1, 5.5, 5.6, 5.7, 8
 - kafka 0.8.2 or greater
 
 ### binlog_row_image=MINIMAL

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -49,14 +49,15 @@ to row-based replication.
 
 *Permissions:* Maxwell needs permissions to store state in the database specified by the `schema_database` option (default `maxwell`).
 ```
-mysql> GRANT ALL on maxwell.* to 'maxwell'@'%' identified by 'XXXXXX';
-mysql> GRANT SELECT, REPLICATION CLIENT, REPLICATION SLAVE on *.* to 'maxwell'@'%';
+mysql> CREATE USER 'maxwell'@'%' IDENTIFIED BY 'XXXXXX';
+mysql> GRANT ALL ON maxwell.* TO 'maxwell'@'%';
+mysql> GRANT SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'maxwell'@'%';
 
 # or for running maxwell locally:
 
-mysql> GRANT SELECT, REPLICATION CLIENT, REPLICATION SLAVE on *.* to 'maxwell'@'localhost' identified by 'XXXXXX';
-mysql> GRANT ALL on maxwell.* to 'maxwell'@'localhost';
-
+mysql> CREATE USER 'maxwell'@'localhost' IDENTIFIED BY 'XXXXXX';
+mysql> GRANT ALL ON maxwell.* TO 'maxwell'@'localhost';
+mysql> GRANT SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'maxwell'@'localhost';
 ```
 
 ### Run Maxwell


### PR DESCRIPTION
I noticed that MySQL 8 is not on the supported versions list even though it's supported according to the changelog.

Also, as far as I can see the DDL statements for setting up the `maxwell` user in the quickstart guide aren't quite right - a `CREATE USER` statement is needed - so I've updated those.