### PR TITLE
issue #1216, deal with bizarre ordering issues on column renames

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -257,7 +257,7 @@ public class Table {
 		columns.remove(idx);
 
 		int index = position.index(this, idx);
-		if ( index == ColumnPosition.DEFER ) {
+		if ( index == ColumnPosition.AFTER_NOT_FOUND) {
 			deferred.add(new DeferredPositionUpdate(definition.getName(), position));
 			index = 0;
 		}
@@ -270,7 +270,7 @@ public class Table {
 		ColumnDef def = columns.remove(idx);
 		int newIndex = position.index(this, idx);
 
-		if ( newIndex == ColumnPosition.DEFER )
+		if ( newIndex == ColumnPosition.AFTER_NOT_FOUND)
 			throw new InvalidSchemaError("Couldn't find column " + position.afterColumn + " to place after");
 
 		columns.add(newIndex, def);

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -3,6 +3,7 @@ package com.zendesk.maxwell.schema;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import com.zendesk.maxwell.schema.ddl.DeferredPositionUpdate;
 import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 import com.zendesk.maxwell.schema.ddl.ColumnPosition;
 
@@ -247,14 +248,32 @@ public class Table {
 		columns.add(idx, column);
 	}
 
-	public void changeColumn(int idx, ColumnPosition position, ColumnDef definition) throws InvalidSchemaError {
+	public void changeColumn(int idx, ColumnPosition position, ColumnDef definition, List<DeferredPositionUpdate> deferred) throws InvalidSchemaError {
 		// when we go to rename the PK column, we need to make sure the old column name
 		// is still there for (for normalization of pk-columns).
 		ColumnDef oldColumn = columns.get(idx);
 		renamePKColumn(oldColumn.getName(), definition.getName());
 
 		columns.remove(idx);
-		columns.add(position.index(this, idx), definition);
+
+		int index = position.index(this, idx);
+		if ( index == ColumnPosition.DEFER ) {
+			deferred.add(new DeferredPositionUpdate(definition.getName(), position));
+			index = 0;
+		}
+
+		columns.add(index, definition);
+	}
+
+	public void moveColumn(String name, ColumnPosition position) throws InvalidSchemaError {
+		int idx = columns.indexOf(name);
+		ColumnDef def = columns.remove(idx);
+		int newIndex = position.index(this, idx);
+
+		if ( newIndex == ColumnPosition.DEFER )
+			throw new InvalidSchemaError("Couldn't find column " + position.afterColumn + " to place after");
+
+		columns.add(newIndex, def);
 	}
 
 	public void setDatabase(String database) {

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/AddColumnMod.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/AddColumnMod.java
@@ -19,7 +19,7 @@ class AddColumnMod extends ColumnMod {
 	public void apply(Table table, List<DeferredPositionUpdate> deferred) throws InvalidSchemaError {
 		int index = position.index(table, null);
 
-		if ( index == ColumnPosition.DEFER ) {
+		if ( index == ColumnPosition.AFTER_NOT_FOUND) {
 			deferred.add(new DeferredPositionUpdate(definition.getName(), position));
 			index = 0;
 		}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/AddColumnMod.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/AddColumnMod.java
@@ -3,6 +3,8 @@ package com.zendesk.maxwell.schema.ddl;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
+import java.util.List;
+
 class AddColumnMod extends ColumnMod {
 	public ColumnDef definition;
 	public ColumnPosition position;
@@ -14,8 +16,16 @@ class AddColumnMod extends ColumnMod {
 	}
 
 	@Override
-	public void apply(Table table) throws InvalidSchemaError {
-		table.addColumn(position.index(table, null), this.definition);
+	public void apply(Table table, List<DeferredPositionUpdate> deferred) throws InvalidSchemaError {
+		int index = position.index(table, null);
+
+		if ( index == ColumnPosition.DEFER ) {
+			deferred.add(new DeferredPositionUpdate(definition.getName(), position));
+			index = 0;
+		}
+
+		table.addColumn(index, this.definition);
+
 	}
 }
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ChangeColumnMod.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ChangeColumnMod.java
@@ -3,6 +3,8 @@ package com.zendesk.maxwell.schema.ddl;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
+import java.util.List;
+
 class ChangeColumnMod extends ColumnMod {
 	public ColumnDef definition;
 	public ColumnPosition position;
@@ -14,9 +16,9 @@ class ChangeColumnMod extends ColumnMod {
 	}
 
 	@Override
-	public void apply(Table table) throws InvalidSchemaError {
+	public void apply(Table table, List<DeferredPositionUpdate> deferred) throws InvalidSchemaError {
 		int idx = originalIndex(table);
-		table.changeColumn(idx, position, definition);
+		table.changeColumn(idx, position, definition, deferred);
 	}
 }
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ColumnMod.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ColumnMod.java
@@ -2,6 +2,8 @@ package com.zendesk.maxwell.schema.ddl;
 
 import com.zendesk.maxwell.schema.Table;
 
+import java.util.List;
+
 abstract class ColumnMod {
 	public String name;
 
@@ -18,5 +20,5 @@ abstract class ColumnMod {
 		return originalIndex;
 	}
 
-	public abstract void apply(Table table) throws InvalidSchemaError;
+	public abstract void apply(Table table, List<DeferredPositionUpdate> deferred) throws InvalidSchemaError;
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ColumnPosition.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ColumnPosition.java
@@ -4,7 +4,7 @@ import com.zendesk.maxwell.schema.Table;
 
 public class ColumnPosition {
 	enum Position { FIRST, AFTER, DEFAULT };
-	public static final int DEFER = -999;
+	public static final int AFTER_NOT_FOUND = -999;
 
 	public Position position;
 	public String afterColumn;
@@ -28,7 +28,7 @@ public class ColumnPosition {
 
 			// see issue #1216
 			if ( afterIdx == -1 )
-				return DEFER;
+				return AFTER_NOT_FOUND;
 
 			return afterIdx + 1;
 		}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ColumnPosition.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ColumnPosition.java
@@ -4,6 +4,7 @@ import com.zendesk.maxwell.schema.Table;
 
 public class ColumnPosition {
 	enum Position { FIRST, AFTER, DEFAULT };
+	public static final int DEFER = -999;
 
 	public Position position;
 	public String afterColumn;
@@ -12,7 +13,7 @@ public class ColumnPosition {
 		this.position = Position.DEFAULT;
 	}
 
-	public int index(Table t, Integer defaultIndex) throws InvalidSchemaError {
+	public int index(Table t, Integer defaultIndex) {
 		switch(position) {
 		case FIRST:
 			return 0;
@@ -24,8 +25,11 @@ public class ColumnPosition {
 
 		case AFTER:
 			int afterIdx = t.findColumnIndex(afterColumn);
+
+			// see issue #1216
 			if ( afterIdx == -1 )
-				throw new InvalidSchemaError("Could not find column " + afterColumn + " (needed in AFTER statement)");
+				return DEFER;
+
 			return afterIdx + 1;
 		}
 		return -1;

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DeferredPositionUpdate.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DeferredPositionUpdate.java
@@ -1,0 +1,11 @@
+package com.zendesk.maxwell.schema.ddl;
+
+public class DeferredPositionUpdate {
+	public String column;
+	public ColumnPosition position;
+
+	public DeferredPositionUpdate(String column, ColumnPosition position) {
+		this.column = column;
+		this.position = position;
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/RemoveColumnMod.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/RemoveColumnMod.java
@@ -2,13 +2,15 @@ package com.zendesk.maxwell.schema.ddl;
 
 import com.zendesk.maxwell.schema.Table;
 
+import java.util.List;
+
 class RemoveColumnMod extends ColumnMod {
 	public RemoveColumnMod(String name) {
 		super(name);
 	}
 
 	@Override
-	public void apply(Table table) throws InvalidSchemaError {
+	public void apply(Table table, List<DeferredPositionUpdate> deferred) throws InvalidSchemaError {
 		table.removeColumn(originalIndex(table));
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/RenameColumnMod.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/RenameColumnMod.java
@@ -2,6 +2,8 @@ package com.zendesk.maxwell.schema.ddl;
 
 import com.zendesk.maxwell.schema.Table;
 
+import java.util.List;
+
 public class RenameColumnMod extends ColumnMod  {
 	private final String oldName, newName;
 
@@ -12,7 +14,7 @@ public class RenameColumnMod extends ColumnMod  {
 	}
 
 	@Override
-	public void apply(Table table) throws InvalidSchemaError {
+	public void apply(Table table, List<DeferredPositionUpdate> deferred) throws InvalidSchemaError {
 		int idx = originalIndex(table);
 		table.renameColumn(idx, newName);
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/TableAlter.java
@@ -48,8 +48,13 @@ public class TableAlter extends SchemaChange {
 			table.database = newDatabase;
 		}
 
+		List<DeferredPositionUpdate> deferred = new ArrayList<>();
 		for (ColumnMod mod : columnMods) {
-			mod.apply(table);
+			mod.apply(table, deferred);
+		}
+
+		for ( DeferredPositionUpdate def : deferred ) {
+			table.moveColumn(def.column, def.position);
 		}
 
 		if ( convertCharset != null ) {

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -564,4 +564,16 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		// test if non-Latin column name outputs correctly
 		assertTrue(rows.get(1).toJSON(ddlOutputConfig()).contains("\"type\":\"int\",\"name\":\"中文欄位\""));
 	}
+
+	@Test
+	public void testHandleReferencingRenamedColumn() throws Exception {
+		String [] sql = {
+			"create table t ( a int, b varchar(255))",
+			"alter table t change column a a int after b_gets_renamed, change column b b_gets_renamed varchar(255)",
+			"create table tt ( a int, b smallint )",
+			"alter table tt add column c int after a_gets_renamed, change column a a_gets_renamed int"
+		};
+
+		testIntegration(sql);
+	}
 }


### PR DESCRIPTION
there's some implementation detail in mysql that allows for a column renamed
later in a DDL statement to be referenced by the new name (and, in fact,
requires it).  We've always processed things in a single shot,
sequentially, but this breaks that assumption.  So we special case this
thing and just backtrack and patch it up at the end