### PR TITLE
getInitialPosition(): do not take other client's position if the gtidMode is on

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -109,7 +109,7 @@ public class Maxwell implements Runnable {
 			   if so we have to start at that position or else
 			   we could miss schema changes, see https://github.com/zendesk/maxwell/issues/782 */
 
-			if ( initial == null ) {
+			if ( initial == null && !config.gtidMode) {
 				initial = this.context.getOtherClientPosition();
 				if ( initial != null ) {
 					LOGGER.info("Found previous client position: " + initial);


### PR DESCRIPTION
Hello,

Recently I tried to enable `gtid_mode = true` in production, but have got this error:

```
17:57:52,656 INFO  BinlogConnectorLifecycleListener - Binlog disconnected.
17:57:52,713 WARN  BinlogConnectorReplicator - replicator stopped at position: ac3d712f-51eb-11e8-a672-e04f43ca7a68:1-960618007,be3510e0-fdda-11e8-9ae8-e04f43ca9e26:1-854502567,f9fe5e51-3b48-11e9-b6db-6c0b84d5cfe8:1-235523016 -- restarting
17:57:52,757 INFO  BinaryLogClient - Connected to mysql-xx-master.intra.prod:27010 at ac3d712f-51eb-11e8-a672-e04f43ca7a68:1-960618007,be3510e0-fdda-11e8-9ae8-e04f43ca9e26:1-854502567,f9fe5e51-3b48-11e9-b6db-6c0b84d5cfe8:1-235523016 (sid:6379, cid:10738774)
17:57:52,757 INFO  BinlogConnectorLifecycleListener - Binlog connected.
17:57:52,800 WARN  BinlogConnectorLifecycleListener - Communication failure.
com.github.shyiko.mysql.binlog.network.ServerException: The slave is connecting using CHANGE MASTER TO MASTER_AUTO_POSITION = 1, but the master has purged binary logs containing GTIDs that the slave requires.
    at com.github.shyiko.mysql.binlog.BinaryLogClient.listenForEventPackets(BinaryLogClient.java:882) [mysql-binlog-connector-java-0.16.1.jar:0.16.1]
    at com.github.shyiko.mysql.binlog.BinaryLogClient.connect(BinaryLogClient.java:559) [mysql-binlog-connector-java-0.16.1.jar:0.16.1]
    at com.github.shyiko.mysql.binlog.BinaryLogClient$7.run(BinaryLogClient.java:793) [mysql-binlog-connector-java-0.16.1.jar:0.16.1]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_45]
17:57:52,800 INFO  BinlogConnectorLifecycleListener - Binlog disconnected.
17:57:52,857 WARN  BinlogConnectorReplicator - replicator stopped at position: ac3d712f-51eb-11e8-a672-e04f43ca7a68:1-960618007,be3510e0-fdda-11e8-9ae8-e04f43ca9e26:1-854502567,f9fe5e51-3b48-11e9-b6db-6c0b84d5cfe8:1-235523016 -- restarting
17:57:52,905 INFO  BinaryLogClient - Connected to mysql-xx-master.intra.prod:27010 at ac3d712f-51eb-11e8-a672-e04f43ca7a68:1-960618007,be3510e0-fdda-11e8-9ae8-e04f43ca9e26:1-854502567,f9fe5e51-3b48-11e9-b6db-6c0b84d5cfe8:1-235523016 (sid:6379, cid:10738775)
```

After investigation, I found the root cause is Maxwell took another database's GTID position after restart. The mysql master don't have the GTID set, so the error is reported.

![Screen Shot 2019-03-20 at 6 02 45 PM](https://user-images.githubusercontent.com/129800/54676960-e09cbc80-4b3c-11e9-8ba2-b8f96a6bb4a7.png)

`getLatestFromAnyClient()` takes the last position which `server_id = ?`, but in the GTID mode, all the positions' server_id are `DEFAULT_GTID_SERVER_ID`, which is 0. We deployed many Maxwell instances in production, and they share the same metadata database. After the GTID mode got enabled, the newly created Maxwell instance will always getLatestFromAnyClient() by `server_id = 0` to get wrong GTID position, we have to insert into the `positions` table manually with the correct GTID every time.

Maybe it'd be better to not `getLatestFromAnyClient()` when the GTID mode is on?

Thanks.