### PR TITLE
refactor: tease Replicator out of Bootstrapper

### DIFF
--- a/src/main/java/com/zendesk/maxwell/CaseSensitivity.java
+++ b/src/main/java/com/zendesk/maxwell/CaseSensitivity.java
@@ -1,3 +1,5 @@
 package com.zendesk.maxwell;
 
 public enum CaseSensitivity { CASE_SENSITIVE, CONVERT_TO_LOWER, CONVERT_ON_COMPARE };
+
+

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -215,7 +215,7 @@ public class Maxwell implements Runnable {
 			config.outputConfig
 		);
 
-		bootstrapper.resume(producer, replicator);
+		bootstrapper.resume(producer);
 
 		context.setReplicator(replicator);
 		this.context.start();

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -62,6 +62,7 @@ public class MaxwellContext {
 
 		this.replicationConnectionPool = new ConnectionPool("ReplicationConnectionPool", 10, 0, 10,
 				config.replicationMysql.getConnectionURI(false), config.replicationMysql.user, config.replicationMysql.password);
+		this.replicationConnectionPool.setCaching(false);
 
 		if (config.schemaMysql.host == null) {
 			this.schemaConnectionPool = null;

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -301,30 +301,12 @@ public class MaxwellContext {
 	}
 
 	public CaseSensitivity getCaseSensitivity() throws SQLException {
-		if ( this.caseSensitivity != null )
-			return this.caseSensitivity;
-
-		try ( Connection c = getReplicationConnection()) {
-			ResultSet rs = c.createStatement().executeQuery("select @@lower_case_table_names");
-			if ( !rs.next() )
-				throw new RuntimeException("Could not retrieve @@lower_case_table_names!");
-
-			int value = rs.getInt(1);
-			switch(value) {
-				case 0:
-					this.caseSensitivity = CaseSensitivity.CASE_SENSITIVE;
-					break;
-				case 1:
-					this.caseSensitivity = CaseSensitivity.CONVERT_TO_LOWER;
-					break;
-				case 2:
-					this.caseSensitivity = CaseSensitivity.CONVERT_ON_COMPARE;
-					break;
-				default:
-					throw new RuntimeException("Unknown value for @@lower_case_table_names: " + value);
+		if ( this.caseSensitivity == null ) {
+			try (Connection c = getReplicationConnection()) {
+				this.caseSensitivity = MaxwellMysqlStatus.captureCaseSensitivity(c);
 			}
-			return this.caseSensitivity;
 		}
+		return this.caseSensitivity;
 	}
 
 	public AbstractProducer getProducer() throws IOException {

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlStatus.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlStatus.java
@@ -84,4 +84,22 @@ public class MaxwellMysqlStatus {
 		m.ensureVariableState("log_slave_updates", "ON");
 		m.ensureVariableState("enforce_gtid_consistency", "ON");
 	}
+
+	public static CaseSensitivity captureCaseSensitivity(Connection c) throws SQLException {
+		ResultSet rs = c.createStatement().executeQuery("select @@lower_case_table_names");
+		if ( !rs.next() )
+			throw new RuntimeException("Could not retrieve @@lower_case_table_names!");
+
+		int value = rs.getInt(1);
+		switch(value) {
+			case 0:
+				return CaseSensitivity.CASE_SENSITIVE;
+			case 1:
+				return CaseSensitivity.CONVERT_TO_LOWER;
+			case 2:
+				return CaseSensitivity.CONVERT_ON_COMPARE;
+			default:
+				throw new RuntimeException("Unknown value for @@lower_case_table_names: " + value);
+		}
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/bootstrap/AbstractBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/AbstractBootstrapper.java
@@ -2,7 +2,6 @@ package com.zendesk.maxwell.bootstrap;
 
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.AbstractProducer;
-import com.zendesk.maxwell.replication.Replicator;
 import com.zendesk.maxwell.row.RowMap;
 
 import java.io.IOException;
@@ -30,9 +29,9 @@ public abstract class AbstractBootstrapper {
 
 	abstract public boolean shouldSkip(RowMap row) throws SQLException, IOException;
 
-	public abstract void resume(AbstractProducer producer, Replicator replicator) throws SQLException;
+	public abstract void resume(AbstractProducer producer) throws SQLException;
 
 	public abstract boolean isRunning();
 
-	public abstract void work(RowMap row, AbstractProducer producer, Replicator replicator) throws Exception;
+	public abstract void work(RowMap row, AbstractProducer producer, Long currentSchemaID) throws Exception;
 }

--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapTask.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapTask.java
@@ -3,6 +3,8 @@ package com.zendesk.maxwell.bootstrap;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.row.RowMap;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 
 public class BootstrapTask {
@@ -17,11 +19,25 @@ public class BootstrapTask {
 
 	public volatile boolean abort;
 
+
 	public String logString() {
 		String s = String.format("#%d %s.%s", id, database, table);
 		if ( whereClause != null )
 			s += " WHERE " + whereClause;
 		return s;
+	}
+
+	static BootstrapTask valueOf(ResultSet rs) throws SQLException {
+		BootstrapTask task = new BootstrapTask();
+		task.id = rs.getLong("id");
+		task.database = rs.getString("database_name");
+		task.table = rs.getString("table_name");
+		task.whereClause = rs.getString("where_clause");
+		task.startPosition = null;
+		task.complete = rs.getBoolean("is_complete");
+		task.completedAt = rs.getTimestamp("completed_at");
+		task.startedAt = rs.getTimestamp("started_at");
+		return task;
 	}
 
 	public static BootstrapTask valueOf(RowMap row) {

--- a/src/main/java/com/zendesk/maxwell/bootstrap/NoOpBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/NoOpBootstrapper.java
@@ -18,7 +18,7 @@ public class NoOpBootstrapper extends AbstractBootstrapper {
 	}
 
 	@Override
-	public void resume(AbstractProducer producer, Replicator replicator) { }
+	public void resume(AbstractProducer producer) { }
 
 	@Override
 	public boolean isRunning( ) {
@@ -26,6 +26,6 @@ public class NoOpBootstrapper extends AbstractBootstrapper {
 	}
 
 	@Override
-	public void work(RowMap row, AbstractProducer producer, Replicator replicator) {}
+	public void work(RowMap row, AbstractProducer producer, Long currentSchemaID) {}
 
 }

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -1,12 +1,14 @@
 package com.zendesk.maxwell.bootstrap;
 
+import com.zendesk.maxwell.CaseSensitivity;
+import com.zendesk.maxwell.MaxwellMysqlStatus;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.AbstractProducer;
-import com.zendesk.maxwell.replication.Replicator;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.schema.Database;
 import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaCapturer;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 import com.zendesk.maxwell.schema.columndef.TimeColumnDef;
@@ -16,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URISyntaxException;
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -34,19 +37,26 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		return false;
 	}
 
-	public void startBootstrap(BootstrapTask task, AbstractProducer producer, Replicator replicator) throws Exception {
-		performBootstrap(task, producer, replicator);
-		completeBootstrap(task, producer, replicator);
+	public void startBootstrap(BootstrapTask task, AbstractProducer producer, Long currentSchemaID) throws Exception {
+		performBootstrap(task, producer, currentSchemaID);
+		completeBootstrap(task, producer);
 	}
 
-	public void performBootstrap(BootstrapTask task, AbstractProducer producer, Replicator replicator) throws Exception {
+	private Schema captureSchemaForBootstrap(BootstrapTask task) throws SQLException {
+		try ( Connection cx = getConnection() ) {
+			CaseSensitivity s = MaxwellMysqlStatus.captureCaseSensitivity(cx);
+			SchemaCapturer c = new SchemaCapturer(cx, s, task.database, task.table);
+			return c.capture();
+		}
+	}
+
+	public void performBootstrap(BootstrapTask task, AbstractProducer producer, Long currentSchemaID) throws Exception {
 		LOGGER.debug("bootstrapping requested for " + task.logString());
 
-		Schema schema = replicator.getSchema();
+		Schema schema = captureSchemaForBootstrap(task);
 		Database database = findDatabase(schema, task.database);
 		Table table = findTable(task.table, database);
 
-		Long schemaId = replicator.getSchemaId();
 		producer.push(bootstrapStartRowMap(table));
 		LOGGER.info(String.format("bootstrapping started for %s.%s", task.database, task.table));
 
@@ -59,7 +69,7 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 			while ( resultSet.next() ) {
 				RowMap row = bootstrapEventRowMap("bootstrap-insert", table);
 				setRowValues(row, resultSet, table);
-				row.setSchemaId(schemaId);
+				row.setSchemaId(currentSchemaID);
 
 				Scripting scripting = context.getConfig().scripting;
 				if ( scripting != null )
@@ -108,10 +118,6 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		return bootstrapEventRowMap("bootstrap-start", table);
 	}
 
-	private RowMap bootstrapCompleteRowMap(Table table) {
-		return bootstrapEventRowMap("bootstrap-complete", table);
-	}
-
 	private RowMap bootstrapEventRowMap(String type, Table table) {
 		return new RowMap(
 				type,
@@ -122,18 +128,23 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 				null);
 	}
 
-	public void completeBootstrap(BootstrapTask task, AbstractProducer producer, Replicator replicator) throws Exception {
-		Database database = findDatabase(replicator.getSchema(), task.database);
-		ensureTable(task.table, database);
-		Table table = findTable(task.table, database);
+	private RowMap bootstrapEventRowMap(String type, String db, String tbl) {
+		return new RowMap(
+			type,
+			db,
+			tbl,
+			System.currentTimeMillis(),
+			new ArrayList<>(),
+			null);
+	}
 
-		producer.push(bootstrapCompleteRowMap(table));
-
+	public void completeBootstrap(BootstrapTask task, AbstractProducer producer) throws Exception {
+		producer.push(bootstrapEventRowMap("bootstrap-complete", task.database, task.table));
 		LOGGER.info("bootstrapping ended for " + task.logString());
 	}
 
 	@Override
-	public void resume(AbstractProducer producer, Replicator replicator) throws SQLException {
+	public void resume(AbstractProducer producer) throws SQLException {
 		try (Connection connection = context.getMaxwellConnection()) {
 			// This update resets all rows of incomplete bootstraps to their original state.
 			// These updates are treated as fresh bootstrap requests and trigger a restart
@@ -152,11 +163,11 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 	}
 
 	@Override
-	public void work(RowMap row, AbstractProducer producer, Replicator replicator) throws Exception {
+	public void work(RowMap row, AbstractProducer producer, Long currentSchemaID) throws Exception {
 		try {
 			if ( isStartBootstrapRow(row) ) {
 				producer.push(row);
-				startBootstrap(BootstrapTask.valueOf(row), producer, replicator);
+				startBootstrap(BootstrapTask.valueOf(row), producer, currentSchemaID);
 			}
 		} catch ( NoSuchElementException e ) {
 			LOGGER.info(String.format("bootstrapping cancelled for %s.%s", row.getDatabase(), row.getTable()));

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -257,7 +257,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		} else if (!bootstrapper.shouldSkip(row) && !isMaxwellRow(row))
 			producer.push(row);
 		else
-			bootstrapper.work(row, producer, this);
+			bootstrapper.work(row, producer, this.getSchemaId());
 	}
 
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -2,6 +2,8 @@ package com.zendesk.maxwell.schema;
 
 import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
+import com.zendesk.maxwell.util.Sql;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,10 +24,9 @@ public class SchemaCapturer {
 	);
 
 	private final HashSet<String> includeDatabases;
+	private final HashSet<String> includeTables;
 
 	private final CaseSensitivity sensitivity;
-
-	private PreparedStatement tablePreparedStatement;
 
 	private PreparedStatement columnPreparedStatement;
 
@@ -33,15 +34,9 @@ public class SchemaCapturer {
 
 	public SchemaCapturer(Connection c, CaseSensitivity sensitivity) throws SQLException {
 		this.includeDatabases = new HashSet<>();
+		this.includeTables = new HashSet<>();
 		this.connection = c;
 		this.sensitivity = sensitivity;
-
-		String tblSql = "SELECT TABLES.TABLE_NAME, CCSA.CHARACTER_SET_NAME "
-				+ "FROM INFORMATION_SCHEMA.TABLES "
-				+ "JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS CCSA"
-				+ " ON TABLES.TABLE_COLLATION = CCSA.COLLATION_NAME WHERE TABLES.TABLE_SCHEMA = ?";
-
-		tablePreparedStatement = connection.prepareStatement(tblSql);
 
 		String dateTimePrecision = "";
 		if(isMySQLAtLeast56())
@@ -72,19 +67,31 @@ public class SchemaCapturer {
 		this.includeDatabases.add(dbName);
 	}
 
+	public SchemaCapturer(Connection c, CaseSensitivity sensitivity, String dbName, String tblName) throws SQLException {
+		this(c, sensitivity, dbName);
+		this.includeTables.add(tblName);
+	}
+
 	public Schema capture() throws SQLException {
 		LOGGER.debug("Capturing schemas...");
 		ArrayList<Database> databases = new ArrayList<>();
 
-		ResultSet rs = connection.createStatement().executeQuery(
-				"SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA ORDER BY SCHEMA_NAME"
-		);
+		String dbCaptureQuery =
+			"SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA";
+
+		if ( includeDatabases.size() > 0 ) {
+			dbCaptureQuery +=
+				" WHERE SCHEMA_NAME IN " + Sql.inListSQL(includeDatabases.size());
+		}
+		dbCaptureQuery += " ORDER BY SCHEMA_NAME";
+
+		PreparedStatement statement = connection.prepareStatement(dbCaptureQuery);
+		Sql.prepareInList(statement, 1, includeDatabases);
+
+		ResultSet rs = statement.executeQuery();
 		while (rs.next()) {
 			String dbName = rs.getString("SCHEMA_NAME");
 			String charset = rs.getString("DEFAULT_CHARACTER_SET_NAME");
-
-			if (includeDatabases.size() > 0 && !includeDatabases.contains(dbName))
-				continue;
 
 			if (IGNORED_DATABASES.contains(dbName))
 				continue;
@@ -116,8 +123,20 @@ public class SchemaCapturer {
 
 
 	private void captureDatabase(Database db) throws SQLException {
-		tablePreparedStatement.setString(1, db.getName());
-		ResultSet rs = tablePreparedStatement.executeQuery();
+		String tblSql = "SELECT TABLES.TABLE_NAME, CCSA.CHARACTER_SET_NAME "
+			+ "FROM INFORMATION_SCHEMA.TABLES "
+			+ "JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS CCSA"
+			+ " ON TABLES.TABLE_COLLATION = CCSA.COLLATION_NAME WHERE TABLES.TABLE_SCHEMA = ?";
+
+		if ( this.includeTables.size() > 0 ) {
+			tblSql += " AND TABLES.TABLE_NAME IN " + Sql.inListSQL(includeTables.size());
+		}
+
+		PreparedStatement tblQuery = connection.prepareStatement(tblSql);
+		tblQuery.setString(1, db.getName());
+		Sql.prepareInList(tblQuery, 2, includeTables);
+
+		ResultSet rs = tblQuery.executeQuery();
 
 		HashMap<String, Table> tables = new HashMap<>();
 		while (rs.next()) {

--- a/src/main/java/com/zendesk/maxwell/util/Sql.java
+++ b/src/main/java/com/zendesk/maxwell/util/Sql.java
@@ -1,0 +1,18 @@
+package com.zendesk.maxwell.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class Sql {
+	public static String inListSQL(int count) {
+		return "(" + StringUtils.repeat("?", ", ", count) + ")";
+	}
+
+	public static void prepareInList(PreparedStatement s, int offset, Iterable<?> list) throws SQLException {
+		for ( Object o : list ) {
+			s.setObject(offset++, o);
+		}
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
@@ -70,6 +70,14 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
+	public void testTablefilter() throws Exception {
+		SchemaCapturer sc =
+			new SchemaCapturer(server.getConnection(), CaseSensitivity.CASE_SENSITIVE, "shard_1", "ints");
+		Schema schema = sc.capture();
+		assertEquals(1, schema.getDatabases().get(0).getTableList().size());
+	}
+
+	@Test
 	public void testColumns() throws SQLException, InvalidSchemaError {
 		Schema s = capturer.capture();
 


### PR DESCRIPTION
Previously bootstrapper would ask the Replicator for a current copy of
the schema.  This was actually race-condition prone and also not great
for the goal of running bootstraps independent of rows coming through
the replication pipeline.

Instead, we capture the current copy of the schema ala minute.  There's
a bad feature of outputting the "current" schema-id in the bootstrap
that we'll have to keep, inaccurate though it may be.