### PR TITLE
Fix fallback publishing for broker-side rejections

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -222,11 +222,7 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	void drainDeadLetterQueue() {
 		if (this.deadLetterQueue != null) {
 			Pair<ProducerRecord<String, String>, KafkaCallback> pair;
-			while (true) {
-				pair = deadLetterQueue.poll();
-				if (pair == null) {
-					break;
-				}
+			while ((pair = deadLetterQueue.poll()) != null) {
 				sendAsync(pair.getLeft(), pair.getRight());
 			}
 		}

--- a/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
@@ -88,7 +88,7 @@ public class KafkaCallbackTest {
 		verifyZeroInteractions(cc);
 
 		ArgumentCaptor<KafkaCallback> cbCaptor = ArgumentCaptor.forClass(KafkaCallback.class);
-		verify(producer).sendFallbackAsync(eq("dead_letters"), eq(id), cbCaptor.capture(), any(), eq(error));
+		verify(producer).enqueueFallbackRow(eq("dead_letters"), eq(id), cbCaptor.capture(), any(), eq(error));
 		Assert.assertEquals(null, cbCaptor.getValue().getFallbackTopic());
 		cbCaptor.getValue().onCompletion(recordMetadata, null);
 		verify(cc).markCompleted();
@@ -114,7 +114,7 @@ public class KafkaCallbackTest {
 		verifyZeroInteractions(cc);
 
 		ArgumentCaptor<KafkaCallback> cbCaptor = ArgumentCaptor.forClass(KafkaCallback.class);
-		verify(producer).sendFallbackAsync(eq("dead_letters"), eq(id), cbCaptor.capture(), any(), eq(error));
+		verify(producer).enqueueFallbackRow(eq("dead_letters"), eq(id), cbCaptor.capture(), any(), eq(error));
 		Assert.assertEquals(null, cbCaptor.getValue().getFallbackTopic());
 		cbCaptor.getValue().onCompletion(recordMetadata, null);
 		verify(cc).markCompleted();

--- a/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KafkaCallbackTest.java
@@ -41,7 +41,7 @@ public class KafkaCallbackTest {
 
 		return new KafkaCallback(cc, position, id, "value",
 				new Counter(), new Counter(), new Meter(), new Meter(),
-				context.getConfig().deadLetterTopic, context, producer);
+				"maxwell", context.getConfig().deadLetterTopic, context, producer);
 	}
 
 	@Test

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
@@ -5,25 +5,16 @@ import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.monitoring.NoOpMetrics;
 import com.zendesk.maxwell.row.RowIdentity;
 import org.apache.kafka.clients.producer.Producer;
-import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.*;
 
 public class MaxwellKafkaProducerWorkerTest {
-	static class VolatileRef<T> {
-		public volatile T value;
-	}
-
 	@Test
 	public void constructNewWorkerWithNullTopic() throws TimeoutException {
 		MaxwellContext context = mock(MaxwellContext.class);
@@ -39,33 +30,24 @@ public class MaxwellKafkaProducerWorkerTest {
 	}
 
 	@Test
-	public void performsFallbackPublishOnAnotherThread() throws InterruptedException {
+	public void fallbackPublishIsDeferred() {
 		MaxwellContext context = mock(MaxwellContext.class);
-		when(context.getConfig()).thenReturn(config);
-		when(context.getMetrics()).thenReturn(new NoOpMetrics());
 		MaxwellConfig config = new MaxwellConfig();
+		when(context.getConfig()).thenReturn(config);
+		config.deadLetterTopic = "maxwell.errors";
+		when(context.getMetrics()).thenReturn(new NoOpMetrics());
 		Producer<String,String> producer = (Producer<String,String>) mock(Producer.class);
 		KafkaCallback callback = mock(KafkaCallback.class);
 		String kafkaTopic = "maxwell";
 		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable", Collections.emptyList());
 		MaxwellKafkaProducerWorker worker = new MaxwellKafkaProducerWorker(context, kafkaTopic, null, producer);
 
-		Thread thisThread = Thread.currentThread();
-		VolatileRef<Thread> publishThread = new VolatileRef<>();
-		CountDownLatch ready = new CountDownLatch(1);
-
-		when(producer.send(any(), any())).thenAnswer((Answer<Void>) invocationOnMock -> {
-			publishThread.value = Thread.currentThread();
-			ready.countDown();
-			return null;
-		});
-
 		worker.sendFallbackAsync("maxwell.errors", rowId, callback, null, new Exception("The broker is grumpy"));
 		verify(callback, never()).onCompletion(any(), isNotNull());
+		verify(producer, never()).send(any(), any());
 
-		Assert.assertTrue(ready.await(5L, TimeUnit.SECONDS));
-		Assert.assertNotNull(publishThread.value);
-		Assert.assertNotEquals(thisThread, publishThread.value);
+		worker.drainDeadLetterQueue();
+		verify(producer, times(1)).send(any(), any());
 		worker.close();
 	}
 }

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
@@ -42,7 +42,7 @@ public class MaxwellKafkaProducerWorkerTest {
 		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable", Collections.emptyList());
 		MaxwellKafkaProducerWorker worker = new MaxwellKafkaProducerWorker(context, kafkaTopic, null, producer);
 
-		worker.sendFallbackAsync("maxwell.errors", rowId, callback, null, new Exception("The broker is grumpy"));
+		worker.enqueueFallbackRow("maxwell.errors", rowId, callback, null, new Exception("The broker is grumpy"));
 		verify(callback, never()).onCompletion(any(), isNotNull());
 		verify(producer, never()).send(any(), any());
 

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellKafkaProducerWorkerTest.java
@@ -3,15 +3,26 @@ package com.zendesk.maxwell.producer;
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.monitoring.NoOpMetrics;
+import com.zendesk.maxwell.row.RowIdentity;
+import org.apache.kafka.clients.producer.Producer;
+import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.stubbing.Answer;
 
+import java.util.Collections;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.Mockito.*;
 
 public class MaxwellKafkaProducerWorkerTest {
+	static class VolatileRef<T> {
+		public volatile T value;
+	}
 
 	@Test
 	public void constructNewWorkerWithNullTopic() throws TimeoutException {
@@ -24,6 +35,37 @@ public class MaxwellKafkaProducerWorkerTest {
 		String kafkaTopic = null;
 		//shouldn't throw NPE
 		MaxwellKafkaProducerWorker worker = new MaxwellKafkaProducerWorker(context, kafkaProperties, kafkaTopic, null);
+		worker.close();
+	}
+
+	@Test
+	public void performsFallbackPublishOnAnotherThread() throws InterruptedException {
+		MaxwellContext context = mock(MaxwellContext.class);
+		when(context.getConfig()).thenReturn(config);
+		when(context.getMetrics()).thenReturn(new NoOpMetrics());
+		MaxwellConfig config = new MaxwellConfig();
+		Producer<String,String> producer = (Producer<String,String>) mock(Producer.class);
+		KafkaCallback callback = mock(KafkaCallback.class);
+		String kafkaTopic = "maxwell";
+		RowIdentity rowId = new RowIdentity("MyDatabase", "MyTable", Collections.emptyList());
+		MaxwellKafkaProducerWorker worker = new MaxwellKafkaProducerWorker(context, kafkaTopic, null, producer);
+
+		Thread thisThread = Thread.currentThread();
+		VolatileRef<Thread> publishThread = new VolatileRef<>();
+		CountDownLatch ready = new CountDownLatch(1);
+
+		when(producer.send(any(), any())).thenAnswer((Answer<Void>) invocationOnMock -> {
+			publishThread.value = Thread.currentThread();
+			ready.countDown();
+			return null;
+		});
+
+		worker.sendFallbackAsync("maxwell.errors", rowId, callback, null, new Exception("The broker is grumpy"));
+		verify(callback, never()).onCompletion(any(), isNotNull());
+
+		Assert.assertTrue(ready.await(5L, TimeUnit.SECONDS));
+		Assert.assertNotNull(publishThread.value);
+		Assert.assertNotEquals(thisThread, publishThread.value);
 		worker.close();
 	}
 }


### PR DESCRIPTION
The initial code was tested (and worked fine) for client-side rejections, like a message whose size exceeds `max.request.size`.

However, when the broker rejects a message, the exception comes back via a different path. This is harder to manually test, since all the easy ways of making large messages in MySQL compress well, and therefore won't trigger any size issues if you're using compression 🤦‍♂️ .

Specifically, the `KafkaCallback` will be invoked on `kafka-producer-network-thread`. It turns out that calling `send()` from kafka's own network thread is a Bad Plan, and will result in a `TimeoutException` "Failed to update metadata after <...> ms". I'm assuming it's stuck trying to reacquire some lock which it already holds.

This PR pushes the publish onto a background thread (a single threaded executor which is only used for this purpose, and only created the first time it's needed). This isn't particularly elegant, but I couldn't think of a better approach (@osheroff chime in if you have ideas!).

I considered pushing a message onto the worker's `queue`, but:
 - we'd need to combine RowMap with some other type representing a fallback message
 - I think that too can deadlock, since the queue is bounded and in some cases (client rejection) we'd block the thread which reads the queue with a push to the same queue.

We could push the executor up to MaxwellContext for general "do thing in background" support, but if nothing else uses it there's probably not much point yet.

/cc @zendesk/goanna 