### PR TITLE
add source clear to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ env:
     - GTID_MODE=1
       MYSQL_VERSION=5.7
     - MYSQL_VERSION=8.0
+addons:
+    srcclr: true


### PR DESCRIPTION
Source Clear helps us to find vulnerabilities in third party components ( open source libraries) which we consume in our code base.

This uses the travis ci integration of source clear to run its tests.

If forking this project and running a travis build, please remove these lines to pass the build if there is no Source Clear configurations (environment variables in Travis).