### PR TITLE
Fixed NullPointerException when producer is none

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -348,7 +348,7 @@ public class MaxwellContext {
 				this.producer = new MaxwellRedisProducer(this, this.config.redisPubChannel, this.config.redisListKey, this.config.redisType);
 				break;
 			case "none":
-				this.producer = null;
+				this.producer = new NoneProducer(this);
 				break;
 			default:
 				throw new RuntimeException("Unknown producer type: " + this.config.producerType);

--- a/src/main/java/com/zendesk/maxwell/producer/NoneProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/NoneProducer.java
@@ -1,0 +1,16 @@
+package com.zendesk.maxwell.producer;
+
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.row.RowMap;
+
+public class NoneProducer extends AbstractProducer {
+
+	public NoneProducer(MaxwellContext context) {
+		super(context);
+	}
+
+	@Override
+	public void push(RowMap r) throws Exception {
+		this.context.setPosition(r);
+	}
+}


### PR DESCRIPTION
When the producer is none, the logBanner function will trigger a NullPointerException .

`String producerName = producer.getClass().getSimpleName();`

```
java.lang.NullPointerException: null
	at com.zendesk.maxwell.Maxwell.logBanner(Maxwell.java:147) ~[classes/:?]
	at com.zendesk.maxwell.Maxwell.startInner(Maxwell.java:189) ~[classes/:?]
	at com.zendesk.maxwell.Maxwell.start(Maxwell.java:156) ~[classes/:?]
	at com.zendesk.maxwell.Maxwell.main(Maxwell.java:243) ~[classes/:?]
```