### PR TITLE
Filter column names fix

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
+++ b/src/main/java/com/zendesk/maxwell/schema/TableColumnList.java
@@ -26,7 +26,7 @@ public class TableColumnList implements Iterable<ColumnDef> {
 		if ( columnNames == null ) {
 			columnNames = new HashSet<>();
 			for ( ColumnDef cf : columns )
-				columnNames.add(cf.getName().toLowerCase().intern());
+				columnNames.add(cf.getName().intern());
 		}
 		return columnNames;
 	}
@@ -53,7 +53,7 @@ public class TableColumnList implements Iterable<ColumnDef> {
 		columns.add(index, definition);
 
 		if ( columnNames != null )
-			columnNames.add(definition.getName().toLowerCase());
+			columnNames.add(definition.getName());
 
 		renumberColumns();
 	}
@@ -62,7 +62,7 @@ public class TableColumnList implements Iterable<ColumnDef> {
 		ColumnDef c = columns.remove(index);
 
 		if ( columnNames != null )
-			columnNames.remove(c.getName().toLowerCase());
+			columnNames.remove(c.getName());
 		renumberColumns();
 		return c;
 	}


### PR DESCRIPTION
Fix column based filters (either by column name or by column value) by using the original column names, instead of lower case version, when getting table's column list from TableColumnList class. The column list is used in Filter.couldIncludeFromColumnFilters() method and only there, which forces the method to always use lower case version of the column. On the other hand, the Filter.includes() method uses the original column names as reported by "RowMap.getData()" method. This leads to inconsistent syntex requirement for the filters, which in turn brakes column based filtering.