### PR TITLE
Fix potential memory leak caused by blacklist table cache

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/TableCache.java
+++ b/src/main/java/com/zendesk/maxwell/replication/TableCache.java
@@ -14,12 +14,10 @@ public class TableCache {
 		this.maxwellDB = maxwellDB;
 	}
 	private final HashMap<Long, Table> tableMapCache = new HashMap<>();
-	private final HashMap<Long, String> blacklistedTableCache = new HashMap<>();
 
 	public void processEvent(Schema schema, Filter filter, Long tableId, String dbName, String tblName) {
-		if ( !tableMapCache.containsKey(tableId) ) {
+		if ( !tableMapCache.containsKey(tableId) && filter.includes(dbName, tblName)) {
 			if ( filter.isTableBlacklisted(dbName, tblName) ) {
-				blacklistedTableCache.put(tableId, tblName);
 				return;
 			}
 
@@ -42,16 +40,7 @@ public class TableCache {
 		return tableMapCache.get(tableId);
 	}
 
-	public boolean isTableBlacklisted(Long tableId) {
-		return blacklistedTableCache.containsKey(tableId);
-	}
-
-	public String getBlacklistedTableName(Long tableId) {
-		return blacklistedTableCache.get(tableId);
-	}
-
 	public void clear() {
 		tableMapCache.clear();
-		blacklistedTableCache.clear();
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/TableCache.java
+++ b/src/main/java/com/zendesk/maxwell/replication/TableCache.java
@@ -16,7 +16,7 @@ public class TableCache {
 	private final HashMap<Long, Table> tableMapCache = new HashMap<>();
 
 	public void processEvent(Schema schema, Filter filter, Long tableId, String dbName, String tblName) {
-		if ( !tableMapCache.containsKey(tableId) && filter.includes(dbName, tblName)) {
+		if ( !tableMapCache.containsKey(tableId)) {
 			if ( filter.isTableBlacklisted(dbName, tblName) ) {
 				return;
 			}


### PR DESCRIPTION
Maxwell often crashes when temporary tables are created, see this issue: https://github.com/zendesk/maxwell/issues/1245. I want to use blacklist filter to ignore the dynamic created temp tabled. This change is to fix a potential memory leak caused by blacklist table cache. The blacklisted tables would only be added to the cache but without being removed. Since the blacklist table cache is used in no where, I removed it here.
