### PR TITLE
Fixed problem with bootstrap on a read-only replication host.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -58,7 +58,7 @@ public class SynchronousBootstrapper {
 		producer.push(bootstrapStartRowMap(table));
 		LOGGER.info(String.format("bootstrapping started for %s.%s", task.database, task.table));
 
-		try ( Connection connection = getConnection();
+		try ( Connection connection = getMaxwellConnection();
 			  Connection streamingConnection = getStreamingConnection()) {
 			setBootstrapRowToStarted(task.id, connection);
 			ResultSet resultSet = getAllRows(task.database, task.table, table, task.whereClause, streamingConnection);
@@ -108,6 +108,12 @@ public class SynchronousBootstrapper {
 
 	protected Connection getStreamingConnection() throws SQLException, URISyntaxException {
 		Connection conn = DriverManager.getConnection(context.getConfig().replicationMysql.getConnectionURI(), context.getConfig().replicationMysql.user, context.getConfig().replicationMysql.password);
+		conn.setCatalog(context.getConfig().databaseName);
+		return conn;
+	}
+
+	protected Connection getMaxwellConnection() throws SQLException {
+		Connection conn = context.getMaxwellConnection();
 		conn.setCatalog(context.getConfig().databaseName);
 		return conn;
 	}


### PR DESCRIPTION
When we try to bootstrap a table with Maxwell with a host and replication host that are different and the replication host is read-only we had this exception :

 java.sql.SQLException: The MySQL server is running with the --read-only option so it cannot execute this statement
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:965)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3978)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3914)
	at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2530)
	at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2683)
	at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2495)
	at com.mysql.jdbc.PreparedStatement.executeInternal(PreparedStatement.java:1903)
	at com.mysql.jdbc.PreparedStatement.executeUpdateInternal(PreparedStatement.java:2124)
	at com.mysql.jdbc.PreparedStatement.executeUpdateInternal(PreparedStatement.java:2058)
	at com.mysql.jdbc.PreparedStatement.executeLargeUpdate(PreparedStatement.java:5158)
	at com.mysql.jdbc.PreparedStatement.executeUpdate(PreparedStatement.java:2043)
	at snaq.db.CachedPreparedStatement.executeUpdate(CachedPreparedStatement.java:151)
	at com.zendesk.maxwell.bootstrap.SynchronousBootstrapper.setBootstrapRowToStarted(SynchronousBootstrapper.java:176)
	at com.zendesk.maxwell.bootstrap.SynchronousBootstrapper.performBootstrap(SynchronousBootstrapper.java:63)
	at com.zendesk.maxwell.bootstrap.SynchronousBootstrapper.startBootstrap(SynchronousBootstrapper.java:39)
	at com.zendesk.maxwell.bootstrap.BootstrapController.work(BootstrapController.java:65)
	at com.zendesk.maxwell.util.RunLoopProcess.runLoop(RunLoopProcess.java:34)
	at com.zendesk.maxwell.MaxwellContext.lambda$getBootstrapController$0(MaxwellContext.java:392)
	at java.lang.Thread.run(Thread.java:748)
	

The problem is that the method getConnection() of the SynchronousBootstrapper use the context.getReplicationConnection() to update the Maxwell schema's bootstrap table.

