### PR TITLE
Remove race condition from bootstrapper integration tests

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -4,7 +4,6 @@ import com.zendesk.maxwell.producer.AbstractProducer;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.row.RowMapBuffer;
 import com.zendesk.maxwell.util.RunLoopProcess;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import snaq.db.ConnectionPool;

--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -83,21 +83,6 @@ public class BootstrapController extends RunLoopProcess  {
 		this.currentSchemaID = schemaID;
 	}
 
-	public boolean hasIncompleteTasks() {
-		try ( Connection cx = maxwellConnectionPool.getConnection() ) {
-			PreparedStatement s = cx.prepareStatement("select count(id) from bootstrap where is_complete = 0 and client_id = ?");
-			s.setString(1, this.clientID);
-
-			ResultSet rs = s.executeQuery();
-
-			while (rs.next()) {
-				return rs.getInt(1) > 0;
-			}
-		} catch (Exception ex){}
-
-		return false;
-	}
-
 	private List<BootstrapTask> getIncompleteTasks() throws SQLException {
 		ArrayList<BootstrapTask> list = new ArrayList<>();
 		try ( Connection cx = maxwellConnectionPool.getConnection() ) {

--- a/src/main/java/com/zendesk/maxwell/producer/BufferedProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/BufferedProducer.java
@@ -4,7 +4,6 @@ import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;
 
-import java.sql.SQLException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -257,20 +257,23 @@ public class MaxwellTestSupport {
 				// For sanity testing, we wait another 2s to verify that no additional changes were pending.
 				// This slows down the test suite, so only enable when debugging.
 				boolean checkHasNoPendingChanges = false;
+				
 				if (checkHasNoPendingChanges) {
+
 					long deadline = System.currentTimeMillis() + 2000;
-					while(true) {
+
+					do {
 						RowMap extraRow = maxwell.poll(100);
+
 						if (extraRow instanceof HeartbeatRowMap) {
 							continue;
 						}
+
 						if (extraRow != null) {
 							maxwell.context.terminate(new RuntimeException("getRowsWithReplicator expected no further rows, saw: " + extraRow.toJSON()));
 						}
-						if (System.currentTimeMillis() > deadline) {
-							break;
-						}
-					}
+
+					} while(System.currentTimeMillis() <= deadline);
 				}
 				break;
 			}

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -134,13 +134,9 @@ public class MaxwellTestSupport {
 		return Position.capture(c, inGtidMode());
 	}
 
-
 	private static void clearSchemaStore(MysqlIsolatedServer mysql) throws Exception {
 		mysql.execute("drop database if exists maxwell");
 	}
-
-	//public static List<RowMap> getRowsWithReplicator(final MysqlIsolatedServer mysql, Filter filter, final String queries[], final String before[]) throws Exception {
-	//}
 
 	public static List<RowMap> getRowsWithReplicator(
 		final MysqlIsolatedServer mysql,
@@ -221,7 +217,6 @@ public class MaxwellTestSupport {
 		}
 
 		callback.afterReplicatorStart(mysql);
-		BootstrapController bootstrapController = maxwell.context.getBootstrapController(null);
 
 		long finalHeartbeat = maxwell.context.getPositionStore().heartbeat();
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -325,18 +325,16 @@ public class MaxwellTestSupport {
 		assumeTrue(server.getVersion().atLeast(minimum));
 	}
 
-	private static int getIncompleteBootstrapTaskCount(Maxwell maxwell, String clientID) {
+	private static int getIncompleteBootstrapTaskCount(Maxwell maxwell, String clientID) throws SQLException {
 		try ( Connection cx = maxwell.context.getMaxwellConnection() ) {
 			PreparedStatement s = cx.prepareStatement("select count(id) from bootstrap where is_complete = 0 and client_id = ?");
 			s.setString(1, clientID);
 
 			ResultSet rs = s.executeQuery();
 
-			while (rs.next()) {
+			if (rs.next()) {
 				return rs.getInt(1);
 			}
-		} catch(SQLException ex) {
-			maxwell.context.terminate(new RuntimeException("failed to get incomplete task count"));
 		}
 
 		return 0;


### PR DESCRIPTION
Previously the MaxwellTestSupport would interrupt the thread running Maxwell as an attempt to speed up the tests.
Unfortunately the all bootstrap tasks don't always complete before the threat is interrupted causing non deterministic results.

Now, we don't interrupt the test. Instead we introduce a way to detect that the bootstrap tasks have all been completed, before performing the asserts.

@zendesk/goanna @osheroff 