### PR TITLE
Upgrade jackson-databind to 2.9.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.9.2</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
Hi there! I've been running Maxwell in production, and my vulnerability scanner found a critical vulnerability ([CVE-2019-14379](https://nvd.nist.gov/vuln/detail/CVE-2019-14379)) against the `jackson-databind` version Maxwell is currently using.

This PR bumps the version to 2.9.9.2, which contains a patch for that vulnerability.