### PR TITLE
Bump up jackson-databind version  to 2.9.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.9.3</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
Bump up com.fasterxml.jackson.core:jackson-databind version in maxwell to 2.9.9.3 for security patch