### PR TITLE
Upgrade mysql-connector-java to 8.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.47</version>
+      <version>8.0.17</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-//import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException;
 
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.recovery.RecoveryInfo;

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -1,14 +1,11 @@
 package com.zendesk.maxwell.schema;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException;
+//import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException;
 
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.recovery.RecoveryInfo;
@@ -109,7 +106,7 @@ public class MysqlPositionStore {
 		try {
 			s.execute();
 			return thisHeartbeat;
-		} catch ( MySQLIntegrityConstraintViolationException e ) {
+		} catch ( SQLIntegrityConstraintViolationException e ) {
 			throw new DuplicateProcessException("Found heartbeat row for client,position while trying to insert.  Is another maxwell running?");
 		}
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -6,7 +6,6 @@ import java.util.*;
 import java.io.IOException;
 
 import com.github.shyiko.mysql.binlog.GtidSet;
-import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.zendesk.maxwell.CaseSensitivity;
@@ -117,7 +116,7 @@ public class MysqlSavedSchema {
 			connection.setAutoCommit(false);
 			this.schemaID = saveSchema(connection);
 			connection.commit();
-		} catch ( MySQLIntegrityConstraintViolationException e ) {
+		} catch ( SQLIntegrityConstraintViolationException e ) {
 			connection.rollback();
 
 			connection.setAutoCommit(true);


### PR DESCRIPTION
Hola!
As we decided to use maxwell as an embedded library together with spring boot 2 we've faced with conflicting dependencies: spring boot data uses mysql connection 8.X+ while maxwell still relies on 5.X. As a result - `ClassNotFoundException` because 8.X+ driver deprecated and removed `MySQLIntegrityConstraintViolationException`.
This small PR just upgrades mysql driver to `8.0.17` and replaces deprecated exception with one that comes from the `java.sql` package.