### PR TITLE
Improved the documentation on required AWS permissions

### DIFF
--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -125,10 +125,36 @@ You will need to obtain an IAM user that has the following permissions for the s
 - "kinesis:PutRecord"
 - "kinesis:PutRecords"
 - "kinesis:DescribeStream"
+
+Additionally, the producer will need to be able to produce CloudWatch metrics which requires the following permission applied to the resource `*``:
 - "cloudwatch:PutMetricData"
 
-See the [AWS docs](http://docs.aws.amazon.com/streams/latest/dev/controlling-access.html#kinesis-using-iam-examples) for the latest examples on which permissions are needed.
+The resulting IAM policy document may look like this:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:PutRecord",
+                "kinesis:PutRecords",
+                "kinesis:DescribeStream"
+            ],
+            "Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:PutMetricData"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
 
+See the [AWS docs](http://docs.aws.amazon.com/streams/latest/dev/controlling-access.html#kinesis-using-iam-examples) for the latest examples on which permissions are needed.
 
 The producer uses the [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) class to gain aws credentials.
 See the [AWS docs](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) on how to setup the IAM user with the Default Credential Provider Chain.


### PR DESCRIPTION
Currently, the permissions required for the Kinesis stream and CloudWatch are part of a single list which is misleading.

Assume that there's an existing policy like the following:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "kinesis:PutRecord",
                "kinesis:PutRecords",
                "kinesis:DescribeStream"
            ],
            "Resource": "arn:aws:kinesis:us-east-2:xxx:stream/yyy"
        },
    ]
}
```
If a user running Maxwell sees an message error like the following:
```
User: arn:aws:sts::xxx:assumed-role/yyy is not authorized to perform: cloudwatch:PutMetricData:
```
They will refer to the documentation and realize that they are missing the `cloudwatch:PutMetricData` permisson in the list and add it to the existing statement in the policy:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "kinesis:PutRecord",
                "kinesis:PutRecords",
                "kinesis:DescribeStream",
                "cloudwatch:PutMetricData"
            ],
            "Resource": "arn:aws:kinesis:us-east-2:xxx:stream/yyy"
        },
    ]
}
```
However, this policy is incorrect since the `cloudwatch:PutMetricData` should be applied to a different resource in a different statement:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "kinesis:PutRecord",
                "kinesis:PutRecords",
                "kinesis:DescribeStream"
            ],
            "Resource": "arn:aws:kinesis:us-east-2:xxx:stream/yyy"
        },
        {
            "Effect": "Allow",
            "Action": [
                "cloudwatch:PutMetricData"
            ],
            "Resource": "*"
        }
    ]
}
```