### PR TITLE
Redis Producer Options #1307

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -91,8 +91,10 @@ redis_port                     | INT                      | Port of Redis server
 redis_auth                     | STRING                   | Authentication key for a password-protected Redis server
 redis_database                 | INT                      | Database of Redis server | 0
 redis_pub_channel              | STRING                   | Redis Pub/Sub channel | maxwell
+redis_stream_key               | STRING                   | Redis XADD Stream Key | maxwell
+redis_stream_json_key          | STRING                   | Redis XADD Stream Message Field Name | message
 redis_list_key                 | STRING                   | Redis LPUSH List Key | maxwell
-redis_type                     | [ pubsub &#124; lpush ]  | Selects either Redis Pub/Sub or LPUSH. | pubsub
+redis_type                     | [ pubsub &#124; xadd &#124; lpush &#124; rpush ]  | Selects either Redis Pub/Sub, Stream, or List. | pubsub
 &nbsp;
 **formatting**
 output_binlog_position         | BOOLEAN  | records include binlog position     | false

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -206,7 +206,7 @@ For more details on these options, you are encouraged to the read official Rabbi
 
 ### Redis
 ***
-Set the output stream in `config.properties` by setting the `redis_pub_channel` property for redis_type = pubsub or set the `redis_list_key` property when using redis_type = lpush.
+Set the output stream in `config.properties` by setting the `redis_pub_channel` property for redis_type = pubsub, `redis_stream_key` property for redis_type = xadd, or set the `redis_list_key` property when using redis_type = lpush.
 
 Other configurable properties are:
 
@@ -215,7 +215,10 @@ Other configurable properties are:
 - `redis_auth` - defaults to **null**
 - `redis_database` - defaults to **0**
 - `redis_type` - defaults to **pubsub**
+- `redis_pub_channel` - defaults to **maxwell**
 - `redis_list_key` - defaults to **maxwell**
+- `redis_stream_key` - defaults to **maxwell**
+- `redis_stream_json_key` - defaults to **message**
 
 ### Custom Producer
 ***

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.9.0</version>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -124,6 +124,8 @@ public class MaxwellConfig extends AbstractConfig {
 	public int redisDatabase;
 	public String redisPubChannel;
 	public String redisListKey;
+	public String redisStreamKey;
+	public String redisStreamJsonKey;
 	public String redisType;
 	public String javascriptFile;
 	public Scripting scripting;
@@ -283,8 +285,10 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "redis_auth", "Authentication key for a password-protected Redis server" ).withRequiredArg();
 		parser.accepts( "redis_database", "Database of Redis server" ).withRequiredArg();
 		parser.accepts( "redis_pub_channel", "Redis Pub/Sub channel for publishing records" ).withRequiredArg();
-		parser.accepts( "redis_list_key", "Redis LPUSH List Key for adding to a queue" ).withRequiredArg();
-		parser.accepts( "redis_type", "[pubsub|lpush] Selects either Redis Pub/Sub or LPUSH. Defaults to 'pubsub'" ).withRequiredArg();
+		parser.accepts( "redis_stream_key", "Redis XADD Stream key for publishing records" ).withRequiredArg();
+		parser.accepts( "redis_stream_json_key", "Redis Stream message field name for JSON message body" ).withRequiredArg();
+		parser.accepts( "redis_list_key", "Redis LPUSH/RPUSH List Key for adding to a queue" ).withRequiredArg();
+		parser.accepts( "redis_type", "[pubsub|xadd|lpush|rpush] Selects either pubsub, xadd, lpush, or rpush. Defaults to 'pubsub'" ).withRequiredArg();
 
 		parser.accepts( "__separator_10" );
 
@@ -409,6 +413,8 @@ public class MaxwellConfig extends AbstractConfig {
 		this.redisDatabase		= Integer.parseInt(fetchOption("redis_database", options, properties, "0"));
 		this.redisPubChannel	= fetchOption("redis_pub_channel", options, properties, "maxwell");
 		this.redisListKey		= fetchOption("redis_list_key", options, properties, "maxwell");
+		this.redisStreamKey		= fetchOption("redis_stream_key", options, properties, "maxwell");
+		this.redisStreamJsonKey	= fetchOption("redis_stream_json_key", options, properties, "message");
 		this.redisType			= fetchOption("redis_type", options, properties, "pubsub");
 
 		String kafkaBootstrapServers = fetchOption("kafka.bootstrap.servers", options, properties, null);

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -348,7 +348,7 @@ public class MaxwellContext {
 				this.producer = new RabbitmqProducer(this);
 				break;
 			case "redis":
-				this.producer = new MaxwellRedisProducer(this, this.config.redisPubChannel, this.config.redisListKey, this.config.redisType);
+				this.producer = new MaxwellRedisProducer(this, this.config.redisType);
 				break;
 			case "none":
 				this.producer = new NoneProducer(this);

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
@@ -18,7 +18,7 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 	private final Jedis jedis;
 
 	@Deprecated
-    public MaxwellRedisProducer(MaxwellContext context, String redisPubChannel, String redisListKey, String redisType) {
+	public MaxwellRedisProducer(MaxwellContext context, String redisPubChannel, String redisListKey, String redisType) {
 		this(context, redisType);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
@@ -6,42 +6,98 @@ import com.zendesk.maxwell.util.StoppableTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntryID;
 import redis.clients.jedis.exceptions.JedisConnectionException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MaxwellRedisProducer extends AbstractProducer implements StoppableTask {
 	private static final Logger logger = LoggerFactory.getLogger(MaxwellRedisProducer.class);
 	private final String channel;
-	private final String listkey;
-	private final String redistype;
+	private final String redisType;
 	private final Jedis jedis;
 
-	public MaxwellRedisProducer(MaxwellContext context, String redisPubChannel, String redisListKey, String redisType) {
+	@Deprecated
+    public MaxwellRedisProducer(MaxwellContext context, String redisPubChannel, String redisListKey, String redisType) {
+		this(context, redisType);
+	}
+
+	public MaxwellRedisProducer(MaxwellContext context, String redisType) {
 		super(context);
 
-		channel = redisPubChannel;
-		listkey = redisListKey;
-		redistype = redisType;
+		if (this.context.getConfig().redisListKey != null) {
+			channel = context.getConfig().redisListKey;
+		}
+		else if (this.context.getConfig().redisStreamKey != null) {
+			channel = context.getConfig().redisStreamKey;
+		}
+		else {
+			channel = this.context.getConfig().redisPubChannel;
+		}
+
+		this.redisType = redisType;
 
 		jedis = new Jedis(context.getConfig().redisHost, context.getConfig().redisPort);
 		jedis.connect();
+
 		if (context.getConfig().redisAuth != null) {
 			jedis.auth(context.getConfig().redisAuth);
 		}
+
 		if (context.getConfig().redisDatabase > 0) {
 			jedis.select(context.getConfig().redisDatabase);
 		}
 	}
 
-	private void sendToRedis(String msg) {
-		switch (redistype) {
+	private void sendToRedis(RowMap msg) throws Exception {
+		String messageStr = msg.toJSON(outputConfig);
+
+		switch (redisType) {
 			case "lpush":
-				jedis.lpush(this.listkey, msg);
+				jedis.lpush(this.channel, messageStr);
+				break;
+			case "xadd":
+				Map<String, String> message = new HashMap<>();
+
+				String jsonKey = this.context.getConfig().redisStreamJsonKey;
+				
+				if (jsonKey == null) {
+					// TODO dot notated map impl in RowMap.toJson
+					throw new IllegalArgumentException("Stream requires key name for serialized JSON value");
+				}
+				else {
+					message.put(jsonKey, messageStr);
+				}
+
+				// TODO timestamp resolution coercion
+				// 			Seconds or milliseconds, never mixing precision
+				//      	DML events will natively emit millisecond precision timestamps
+				//      	CDC events will natively emit second precision timestamp
+				// TODO configuration option for if we want the msg timestamp to become the message ID
+				//			Requires completion of previous TODO
+				jedis.xadd(this.channel, new StreamEntryID(), message);
 				break;
 			case "pubsub":
 			default:
-				jedis.publish(this.channel, msg);
+				jedis.publish(this.channel, messageStr);
 				break;
 		}
+
+		if (logger.isDebugEnabled()) {
+			switch (redisType) {
+				case "lpush":
+					logger.debug("->  queue:" + channel + ", msg:" + msg);
+					break;
+				case "xadd":
+					logger.debug("->  stream:" + channel + ", msg:" + msg);
+					break;
+				case "pubsub":
+				default:
+					logger.debug("->  channel:" + channel + ", msg:" + msg);
+					break;
+			}
+		}
+
 		this.succeededMessageCount.inc();
 		this.succeededMessageMeter.mark();
 	}
@@ -53,10 +109,9 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 			return;
 		}
 
-		String msg = r.toJSON(outputConfig);
 		for (int cxErrors = 0; cxErrors < 2; cxErrors++) {
 			try {
-				sendToRedis(msg);
+				this.sendToRedis(r);
 				break;
 			} catch (Exception e) {
 				if (e instanceof JedisConnectionException) {
@@ -77,18 +132,6 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 
 		if (r.isTXCommit()) {
 			context.setPosition(r.getNextPosition());
-		}
-
-		if (logger.isDebugEnabled()) {
-			switch (redistype) {
-				case "lpush":
-					logger.debug("->  queue:" + listkey + ", msg:" + msg);
-					break;
-				case "pubsub":
-				default:
-					logger.debug("->  channel:" + channel + ", msg:" + msg);
-					break;
-			}
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
@@ -75,7 +75,7 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 				//      	CDC events will natively emit second precision timestamp
 				// TODO configuration option for if we want the msg timestamp to become the message ID
 				//			Requires completion of previous TODO
-				jedis.xadd(this.channel, new StreamEntryID(), message);
+				jedis.xadd(this.channel, StreamEntryID.NEW_ENTRY, message);
 				break;
 			case "pubsub":
 			default:


### PR DESCRIPTION
1. Bumping version of Jedis from 2.9.0 to 3.1.0.
2. Adds support for streams through **redis_type = xadd**
3. Adds configuration option **redis_stream_key** for the stream name
4. Adds configuration option **redis_stream_json_key** for the message field name
5. Treats **redis_stream_key**, **redis_pubsub_channel**, and **redis_list_key** as "channel" internally, based on **redis_type**.
6. Adds documentation for the new options
7. Creates a new, simplified constructor, in favor of reading configuration options from the **MaxwellContext** that is passed into **MaxwellRedisProducer**.
8. Deprecates old constructor for backwards compatibility. **No functionality has changed**
9. Delegates control of serialization to sendToRedis() by changing signature from **sendToRedis(String msg)** to **sendToRedis(RowMap msg)**
10. Moves the debug code into sendToRedis, does not change behavior

Note that stream messages are encoded as 1D arrays but interpreted as K(even)/V(odd) pairs in many client implementations in accordance with the Redis official documentation, for at least some basic support, all it needs to do is set one field with the message JSON. In the future it would be **nice to have** additional support for flattened, dot-notated object K/V mapped message bodies.

Addresses issue #1307 