### PR TITLE
stop giving maxwell rows to the javascript filter

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -187,7 +187,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		rowCounter.inc();
 		rowMeter.mark();
 
-		if ( scripting != null )
+		if ( scripting != null && !isMaxwellRow(row))
 			scripting.invoke(row);
 
 		processRow(row);


### PR DESCRIPTION
in doing some javascript-filter work I found that maxwell was passing us rows from `maxwell.positoins`.  I found this irritating.