### PR TITLE
Update ignore_producer_error documentation to include pubsub

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -45,7 +45,7 @@ producer_ack_timeout           | [PRODUCER_ACK_TIMEOUT](#ack_timeout) | time in 
 producer_partition_by          | [PARTITION_BY](#partition_by)       | input to kafka/kinesis partition function           | database
 producer_partition_columns     | STRING                              | if partitioning by 'column', a comma separated list of columns |
 producer_partition_by_fallback | [PARTITION_BY_FALLBACK](#partition_by_fallback) | required when producer_partition_by=column.  Used when the column is missing |
-ignore_producer_error          | BOOLEAN              | When false, Maxwell will terminate on kafka/kinesis publish errors (aside from RecordTooLargeException). When true, errors are only logged. See also dead_letter_topic | true
+ignore_producer_error          | BOOLEAN              | When false, Maxwell will terminate on kafka/kinesis/pubsub publish errors (aside from RecordTooLargeException). When true, errors are only logged. See also dead_letter_topic | true
 &nbsp;
 **"file" producer options**
 output_file                    | STRING                              | output file for `file` producer                     |


### PR DESCRIPTION
Documentation is out of date for `ignore_producer_error` since this also holds for pubsub. 

See: 
https://github.com/zendesk/maxwell/blob/61774521effe05e99e0da7d31fc55ee9a247d1bb/src/main/java/com/zendesk/maxwell/producer/MaxwellPubsubProducer.java#L80-L83
