### PR TITLE
Use meter for counts instead of Counter

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -41,8 +41,9 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 					messagePublishTimer.update(age, TimeUnit.MILLISECONDS);
 					messageLatencyTimer.update(Math.max(0L, age - 500L), TimeUnit.MILLISECONDS);
 
+					messageLatencySloCount.mark();
 					if (age > config.metricsAgeSlo) {
-						messageLatencySloViolationCount.inc();
+						messageLatencySloViolationCount.mark();
 					}
 				}
 			}

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractProducer.java
@@ -19,7 +19,8 @@ public abstract class AbstractProducer {
 	protected final Meter failedMessageMeter;
 	protected final Timer messagePublishTimer;
 	protected final Timer messageLatencyTimer;
-	protected final Counter messageLatencySloViolationCount;
+	protected final Meter messageLatencySloCount;
+	protected final Meter messageLatencySloViolationCount;
 
 	public AbstractProducer(MaxwellContext context) {
 		this.context = context;
@@ -34,7 +35,8 @@ public abstract class AbstractProducer {
 		this.failedMessageMeter = metricRegistry.meter(metrics.metricName("messages", "failed", "meter"));
 		this.messagePublishTimer = metricRegistry.timer(metrics.metricName("message", "publish", "time"));
 		this.messageLatencyTimer = metricRegistry.timer(metrics.metricName("message", "publish", "age"));
-		this.messageLatencySloViolationCount = metricRegistry.counter(metrics.metricName("message", "publish", "age", "slo_violation"));
+		this.messageLatencySloViolationCount = metricRegistry.meter(metrics.metricName("message", "publish", "age", "slo_violation", "meter"));
+		this.messageLatencySloCount = metricRegistry.meter(metrics.metricName("message", "publish", "age", "slo", "meter"));
 	}
 
 	abstract public void push(RowMap r) throws Exception;


### PR DESCRIPTION
### Problem
When recording slo violation metrics the dropwizards `Counter` actually sends gauge metrics through to datadog. This causes issues when using these metrics in an SLO monitor which require count or rate metrics.

### Solution
- Using dropwizards `Meter` resolves this issue as a count  is emitted to Datadog.
- Changed how we report slo metrics slightly. Instead of using the `message.published.age` metric count as the complete set of messages I have added a new metric `message.published.age.slo.meter`. This makes it easy to only plot relevant values.

Reference https://github.com/coursera/metrics-datadog/issues/45

The referenced issue also mentioned a version downgrade for metrics-datadog. I tried it locally and the version didn't seem to make a difference.