### PR TITLE
Added dynamic channel support for Redis.

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -228,8 +228,12 @@ kafka.acks=1
 #redis_port=6379
 #redis_auth=redis_auth
 #redis_database=0
+# this can be static, e.g. 'maxwell', or dynamic, e.g. namespace_%{database}_%{table}
 #redis_pub_channel=maxwell
+# this can be static, e.g. 'maxwell', or dynamic, e.g. namespace_%{database}_%{table}
 #redis_list_key=maxwell
+# this can be static, e.g. 'maxwell', or dynamic, e.g. namespace_%{database}_%{table}
+#redis_stream_key=maxwell
 # Valid values for redis_type = pubsub|lpush. Defaults to pubsub
 #redis_type=pubsub
 

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -234,6 +234,11 @@ For more details on these options, you are encouraged to the read official Rabbi
 ***
 Set the output stream in `config.properties` by setting the `redis_pub_channel` property for redis_type = pubsub, `redis_stream_key` property for redis_type = xadd, or set the `redis_list_key` property when using redis_type = lpush.
 
+Maxwell writes to a Redis channel named "maxwell" by default. It can be static,
+e.g. 'maxwell', or dynamic, e.g. `namespace_%{database}_%{table}`. In the
+latter case 'database' and 'table' will be replaced with the values for the row
+being processed. This can be changed with the `redis_pub_channel`, `redis_list_key` and `redis_stream_key` option.
+
 Other configurable properties are:
 
 - `redis_host` - defaults to **localhost**

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.producer;
 
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.row.RowIdentity;
 import com.zendesk.maxwell.row.RowMap;
 import com.zendesk.maxwell.util.StoppableTask;
 import org.slf4j.Logger;
@@ -14,6 +15,7 @@ import java.util.Map;
 public class MaxwellRedisProducer extends AbstractProducer implements StoppableTask {
 	private static final Logger logger = LoggerFactory.getLogger(MaxwellRedisProducer.class);
 	private final String channel;
+	private final boolean interpolateChannel;
 	private final String redisType;
 	private final Jedis jedis;
 
@@ -35,6 +37,7 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 			channel = this.context.getConfig().redisPubChannel;
 		}
 
+		this.interpolateChannel = channel.contains("%{");
 		this.redisType = redisType;
 
 		jedis = new Jedis(context.getConfig().redisHost, context.getConfig().redisPort);
@@ -49,12 +52,22 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 		}
 	}
 
+	private String generateChannel(RowIdentity pk){
+		if (interpolateChannel) {
+			return channel.replaceAll("%\\{database}", pk.getDatabase()).replaceAll("%\\{table}", pk.getTable());
+		}
+
+		return channel;
+	}
+
 	private void sendToRedis(RowMap msg) throws Exception {
 		String messageStr = msg.toJSON(outputConfig);
 
+		String channel = this.generateChannel(msg.getRowIdentity());
+
 		switch (redisType) {
 			case "lpush":
-				jedis.lpush(this.channel, messageStr);
+				jedis.lpush(channel, messageStr);
 				break;
 			case "xadd":
 				Map<String, String> message = new HashMap<>();
@@ -75,11 +88,11 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 				//      	CDC events will natively emit second precision timestamp
 				// TODO configuration option for if we want the msg timestamp to become the message ID
 				//			Requires completion of previous TODO
-				jedis.xadd(this.channel, StreamEntryID.NEW_ENTRY, message);
+				jedis.xadd(channel, StreamEntryID.NEW_ENTRY, message);
 				break;
 			case "pubsub":
 			default:
-				jedis.publish(this.channel, messageStr);
+				jedis.publish(channel, messageStr);
 				break;
 		}
 


### PR DESCRIPTION
It is similar behaviour that Kafka topics have.
It can be used, for example, for implementing reliable queues that will be parallel instead of putting all changes to single redis list.