### PR TITLE
add the ability to have the type in the routing key for rabbitmq prod…

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
@@ -6,6 +6,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.MessageProperties;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.row.RowMap;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,15 +61,14 @@ public class RabbitmqProducer extends AbstractProducer {
 	}
 
 	private String getRoutingKeyFromTemplate(RowMap r) {
-		String table = r.getTable();
-
-		if ( table == null )
-			table = "";
+		String table = StringUtils.defaultString(r.getTable(), StringUtils.EMPTY);
+		String type = StringUtils.defaultString(r.getRowType(), StringUtils.EMPTY);
 
 		return context
 				.getConfig()
 				.rabbitmqRoutingKeyTemplate
 				.replace("%db%", r.getDatabase())
-				.replace("%table%", table);
+				.replace("%table%", table)
+				.replace("%type%", type);
 	}
 }


### PR DESCRIPTION
…ucer

This is rather a cheeky PR, its a small tweak to an existing feature for the RabbitMQ routing keys.

It would be really helpful for our team to have the ability to include the type of message in the routing key as we route our messages in the format [system].[entity(table)].[event(type)].