### PR TITLE
Bump drop wizard metrics to support Java versions 10+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>3.1.0</version>
+      <version>4.1.1</version>
     </dependency>
     <dependency>
       <groupId>redis.clients</groupId>
@@ -257,7 +257,12 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-servlets</artifactId>
-      <version>3.1.0</version>
+      <version>4.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jmx</artifactId>
+      <version>4.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
@@ -1,6 +1,6 @@
 package com.zendesk.maxwell.monitoring;
 
-import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.jmx.JmxReporter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;


### PR DESCRIPTION
If deploying on a later JVM such as `openjre:11-bionic` docker image, publishing metrics is not supported. This is fixed in a later version of `metrics-servlets` and `metrics-core`