### PR TITLE
Fix issue #1419 message.publish.age metric

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -39,7 +39,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 					long age = currentTime - message.sendTimeMS;
 
 					messagePublishTimer.update(age, TimeUnit.MILLISECONDS);
-					messageLatencyTimer.update(Math.max(0L, age - 500L), TimeUnit.MILLISECONDS);
+					messageLatencyTimer.update(Math.max(0L, currentTime - message.eventTimeMS - 500L), TimeUnit.MILLISECONDS);
 
 					if (age > config.metricsAgeSlo) {
 						messageLatencySloViolationCount.inc();


### PR DESCRIPTION
Issue https://github.com/zendesk/maxwell/issues/1419
After updating from 1.22.4 to 1.24.0 we saw this metric report unreasonable values: 0 most of the time with a few spikes. This change reverts what appears to be unintentional change to it in SLO violation counter feature https://github.com/zendesk/maxwell/pull/1350