### PR TITLE
Upgrade jackson-databind due to a vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.1</version>
+      <version>2.9.10.2</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
See #1426 
This change upgrades jackson-databind from 2.9.20.1 to 2.9.10.2 due to a reported vulnerability that affects the current version Maxwell is using.