### PR TITLE
Fix crash when handling "EXCHANGE PARTITION ..." with qualified table name

### DIFF
--- a/src/main/antlr4/imports/mysql_alter_table.g4
+++ b/src/main/antlr4/imports/mysql_alter_table.g4
@@ -45,7 +45,7 @@ alter_partition_specification:
     | IMPORT PARTITION partition_names TABLESPACE
     | COALESCE PARTITION INTEGER_LITERAL
     | REORGANIZE PARTITION (partition_names INTO skip_parens)?
-    | EXCHANGE PARTITION IDENT WITH TABLE name ((WITH|WITHOUT) VALIDATION)?
+    | EXCHANGE PARTITION IDENT WITH TABLE table_name ((WITH|WITHOUT) VALIDATION)?
     | ANALYZE PARTITION partition_names
     | CHECK PARTITION partition_names
     | OPTIMIZE PARTITION partition_names

--- a/src/test/resources/sql/ddl/mysql-test-partition.sql
+++ b/src/test/resources/sql/ddl/mysql-test-partition.sql
@@ -653,3 +653,5 @@ alter table t66 reorganize partition s1 into (partition p0 values less than (tim
 alter table t66 reorganize partition s1 into (partition p0 values less than (weekday('2006-10-14')), partition p1 values less than maxvalue)
 alter table t66 reorganize partition s1 into (partition p0 values less than (year('2005-10-14')-1990), partition p1 values less than maxvalue)
 alter table t66 reorganize partition s1 into (partition p0 values less than (yearweek('2006-10-14')-200600), partition p1 values less than maxvalue)
+alter table tblA EXCHANGE PARTITION part_1 WITH TABLE part_2
+alter table tblA EXCHANGE PARTITION part_1 WITH TABLE tblB.part_2


### PR DESCRIPTION
Maxwell crashes on "... EXCHANGE PARTITION ..." with qualified table names such as DB_A.TBL_B

Sample stacktrace:

04:45:46,311 ERROR TaskManager - cause:
com.zendesk.maxwell.schema.ddl.MaxwellSQLSyntaxError: .
        at com.zendesk.maxwell.schema.ddl.MysqlParserListener.visitErrorNode(MysqlParserListener.java:93) ~[maxwell-1.24.1.jar:1.24.1]
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:41) ~[antlr4-runtime-4.5.jar:4.5]
        at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:52) ~[antlr4-runtime-4.5.jar:4.5]
        at com.zendesk.maxwell.schema.ddl.SchemaChange.parseSQL(SchemaChange.java:92) ~[maxwell-1.24.1.jar:1.24.1]
        at com.zendesk.maxwell.schema.ddl.SchemaChange.parse(SchemaChange.java:104) ~[maxwell-1.24.1.jar:1.24.1]
        at com.zendesk.maxwell.schema.AbstractSchemaStore.resolveSQL(AbstractSchemaStore.java:49) ~[maxwell-1.24.1.jar:1.24.1]
        at com.zendesk.maxwell.schema.MysqlSchemaStore.processSQL(MysqlSchemaStore.java:102) ~[maxwell-1.24.1.jar:1.24.1]
