### PR TITLE
Effect adds kafka random partitioning feature

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -632,11 +632,11 @@ public class MaxwellConfig extends AbstractConfig {
 			this.producerPartitionFallback = this.kafkaPartitionFallback;
 		}
 
-		String[] validPartitionBy = {"database", "table", "primary_key", "transaction_id", "column"};
+		String[] validPartitionBy = {"database", "table", "primary_key", "transaction_id", "column", "random"};
 		if ( this.producerPartitionKey == null ) {
 			this.producerPartitionKey = "database";
 		} else if ( !ArrayUtils.contains(validPartitionBy, this.producerPartitionKey) ) {
-			usageForOptions("please specify --producer_partition_by=database|table|primary_key|transaction_id|column", "producer_partition_by");
+			usageForOptions("please specify --producer_partition_by=database|table|primary_key|transaction_id|column|random", "producer_partition_by");
 		} else if ( this.producerPartitionKey.equals("column") && StringUtils.isEmpty(this.producerPartitionColumns) ) {
 			usageForOptions("please specify --producer_partition_columns=column1 when using producer_partition_by=column", "producer_partition_columns");
 		} else if ( this.producerPartitionKey.equals("column") && StringUtils.isEmpty(this.producerPartitionFallback) ) {

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -41,9 +41,9 @@ class KafkaCallback implements Callback {
 	private Meter failedMessageMeter;
 
 	public KafkaCallback(AbstractAsyncProducer.CallbackCompleter cc, Position position, RowIdentity key, String json,
-						 Counter producedMessageCount, Counter failedMessageCount, Meter producedMessageMeter,
-						 Meter failedMessageMeter, String topic, String fallbackTopic, MaxwellContext context,
-						 MaxwellKafkaProducerWorker producer) {
+	                     Counter producedMessageCount, Counter failedMessageCount, Meter producedMessageMeter,
+	                     Meter failedMessageMeter, String topic, String fallbackTopic, MaxwellContext context,
+	                     MaxwellKafkaProducerWorker producer) {
 		this.cc = cc;
 		this.position = position;
 		this.key = key;
@@ -60,7 +60,7 @@ class KafkaCallback implements Callback {
 
 	@Override
 	public void onCompletion(RecordMetadata md, Exception e) {
-		if (e != null) {
+		if ( e != null ) {
 			this.failedMessageCount.inc();
 			this.failedMessageMeter.mark();
 
@@ -95,8 +95,8 @@ class KafkaCallback implements Callback {
 		// When publishing a fallback record, make a callback
 		// with no fallback topic to avoid infinite loops
 		KafkaCallback cb = new KafkaCallback(cc, position, key, json,
-				succeededMessageCount, failedMessageCount, succeededMessageMeter,
-				failedMessageMeter, topic, null, context, producer);
+			succeededMessageCount, failedMessageCount, succeededMessageMeter,
+			failedMessageMeter, topic, null, context, producer);
 		producer.enqueueFallbackRow(fallbackTopic, key, cb, md, e);
 	}
 
@@ -148,10 +148,10 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	private Thread thread;
 	private StoppableTaskState taskState;
 	private String deadLetterTopic;
-	private final ConcurrentLinkedQueue<Pair<ProducerRecord<String, String>, KafkaCallback>> deadLetterQueue;
+	private final ConcurrentLinkedQueue<Pair<ProducerRecord<String,String>, KafkaCallback>> deadLetterQueue;
 
 	public static MaxwellKafkaPartitioner makeDDLPartitioner(String partitionHashFunc, String partitionKey) {
-		if (partitionKey.equals("table")) {
+		if ( partitionKey.equals("table") ) {
 			return new MaxwellKafkaPartitioner(partitionHashFunc, "table", null, "database");
 		} else {
 			return new MaxwellKafkaPartitioner(partitionHashFunc, "database", null, null);
@@ -159,10 +159,11 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	}
 
 	public MaxwellKafkaProducerWorker(MaxwellContext context, String kafkaTopic, ArrayBlockingQueue<RowMap> queue,
-									  Producer<String, String> producer) {
+		Producer<String,String> producer)
+	{
 		super(context);
 
-		if (kafkaTopic == null) {
+		if ( kafkaTopic == null ) {
 			this.topic = "maxwell";
 		} else {
 			this.topic = kafkaTopic;
@@ -178,11 +179,11 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 		this.partitioner = new MaxwellKafkaPartitioner(hash, partitionKey, partitionColumns, partitionFallback);
 
 		this.ddlPartitioner = makeDDLPartitioner(hash, partitionKey);
-		this.ddlTopic = context.getConfig().ddlKafkaTopic;
+		this.ddlTopic =  context.getConfig().ddlKafkaTopic;
 		this.deadLetterTopic = context.getConfig().deadLetterTopic;
 		this.deadLetterQueue = new ConcurrentLinkedQueue<>();
 
-		if (context.getConfig().kafkaKeyFormat.equals("hash"))
+		if ( context.getConfig().kafkaKeyFormat.equals("hash") )
 			keyFormat = KeyFormat.HASH;
 		else
 			keyFormat = KeyFormat.ARRAY;
@@ -192,15 +193,16 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 	}
 
 	public MaxwellKafkaProducerWorker(MaxwellContext context, Properties kafkaProperties, String kafkaTopic,
-									  ArrayBlockingQueue<RowMap> queue) {
+		ArrayBlockingQueue<RowMap> queue)
+	{
 		this(context, kafkaTopic, queue,
-				new KafkaProducer<String, String>(kafkaProperties, new StringSerializer(), new StringSerializer()));
+			new KafkaProducer<String,String>(kafkaProperties, new StringSerializer(), new StringSerializer()));
 	}
 
 	@Override
 	public void run() {
 		this.thread = Thread.currentThread();
-		while (true) {
+		while ( true ) {
 			try {
 				drainDeadLetterQueue();
 				RowMap row = queue.take();
@@ -209,7 +211,7 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 					return;
 				}
 				this.push(row);
-			} catch (Exception e) {
+			} catch ( Exception e ) {
 				taskState.stopped();
 				context.terminate(e);
 				return;
@@ -233,8 +235,8 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 		}
 	}
 
-	private String generateTopic(String topic, RowIdentity pk) {
-		if (interpolateTopic)
+	private String generateTopic(String topic, RowIdentity pk){
+		if ( interpolateTopic )
 			return topic.replaceAll("%\\{database\\}", pk.getDatabase()).replaceAll("%\\{table\\}", pk.getTable());
 		else
 			return topic;
@@ -282,7 +284,7 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 
 			// javascript topic override
 			topic = r.getKafkaTopic();
-			if (topic == null) {
+			if ( topic == null ) {
 				topic = generateTopic(this.topic, pk);
 			}
 			LOGGER.debug("context.getConfig().producerPartitionKey = " + context.getConfig().producerPartitionKey);

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/AbstractMaxwellPartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/AbstractMaxwellPartitioner.java
@@ -6,11 +6,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.zendesk.maxwell.producer.partitioners.PartitionBy.RANDOM;
+
 public abstract class AbstractMaxwellPartitioner {
 	List<String> partitionColumns = new ArrayList<String>();
 	private final PartitionBy partitionBy, partitionByFallback;
 
 	private PartitionBy partitionByForString(String key) {
+
+
 		if ( key == null )
 			return PartitionBy.DATABASE;
 
@@ -25,6 +29,8 @@ public abstract class AbstractMaxwellPartitioner {
 				return PartitionBy.TRANSACTION_ID;
 			case "column":
 				return PartitionBy.COLUMN;
+			case "random":
+				return RANDOM;
 			default:
 				throw new RuntimeException("Unknown partitionBy string: " + key);
 		}
@@ -66,6 +72,8 @@ public abstract class AbstractMaxwellPartitioner {
 					return s;
 				else
 					return getHashString(r, partitionByFallback);
+			case RANDOM:
+				return "";
 		}
 		return null; // thx java
 	}

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/PartitionBy.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/PartitionBy.java
@@ -5,5 +5,6 @@ public enum PartitionBy {
 	TABLE,
 	PRIMARY_KEY,
 	TRANSACTION_ID,
-	COLUMN
+	COLUMN,
+	RANDOM
 }


### PR DESCRIPTION
Added data to be written into kafka partitions in a polling manner. After specifying --producer_partition_by = 'random' in the configuration file, the data is fed into kafka partitions in a polling manner to avoid the problem of Spark-kafka data skew