### PR TITLE
Add realpath to be able to resolve symlink

### DIFF
--- a/bin/maxwell
+++ b/bin/maxwell
@@ -2,7 +2,7 @@
 
 set -e
 
-base_dir="$(dirname "$0")/.."
+base_dir="$(dirname "$(realpath "$0")")/.."
 lib_dir="$base_dir/lib"
 lib_dir_development="$base_dir/target/lib"
 if [ ! -e "$lib_dir" -a -e "$lib_dir_development" ]; then

--- a/bin/maxwell
+++ b/bin/maxwell
@@ -2,7 +2,14 @@
 
 set -e
 
-base_dir="$(dirname "$(realpath "$0")")/.."
+actual_dir=$0
+if [ -n "$(LC_ALL=C type -t realpath)" ];
+then
+  echo "exists"
+	actual_dir=`realpath "$actual_dir"`
+fi
+
+base_dir="$(dirname "$actual_dir")/.."
 lib_dir="$base_dir/lib"
 lib_dir_development="$base_dir/target/lib"
 if [ ! -e "$lib_dir" -a -e "$lib_dir_development" ]; then

--- a/bin/maxwell
+++ b/bin/maxwell
@@ -5,7 +5,6 @@ set -e
 actual_dir=$0
 if [ -n "$(LC_ALL=C type -t realpath)" ];
 then
-  echo "exists"
 	actual_dir=`realpath "$actual_dir"`
 fi
 


### PR DESCRIPTION
In out scenario we use maxwell via symlink, for eg. `/usr/bin/maxwell`, when using only `dirname` do not get the correct path because of symlink, the realpath will get the real maxwell path to be able to resolve the dependencies when using the symlink created.
