### PR TITLE
fix - using the correct var to define redis channel when using rpush.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
@@ -61,7 +61,7 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 				jedis.lpush(channel, messageStr);
 				break;
 			case "rpush":
-				jedis.rpush(this.channel, messageStr);
+				jedis.rpush(channel, messageStr);
 				break;
 			case "xadd":
 				Map<String, String> message = new HashMap<>();


### PR DESCRIPTION
When we try to use `rpush` as `redis_type`, it wasn't replacing the `%{table}` and `%{database}` vars 
in the `redis_key` because it was using `this.channel` and not the local var `channel`. 

This was not happening when using `lpush`, only with `rpush`