### PR TITLE
guard certain key SQL queries with retry logic.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -54,6 +54,15 @@ public class BootstrapController extends RunLoopProcess  {
 
 	@Override
 	protected void work() throws Exception {
+		try {
+			doWork();
+		} catch ( InterruptedException e ) {
+		} catch ( SQLException e ) {
+			LOGGER.error("got SQLException trying to bootstrap", e);
+		}
+	}
+
+	private void doWork() throws Exception {
 		List<BootstrapTask> tasks = getIncompleteTasks();
 		synchronized(bootstrapMutex) {
 			for ( BootstrapTask task : tasks ) {
@@ -70,9 +79,8 @@ public class BootstrapController extends RunLoopProcess  {
 				}
 			}
 		}
-		try {
-			Thread.sleep(1000);
-		} catch ( InterruptedException e ) {}
+
+		Thread.sleep(1000);
 	}
 
 	private synchronized Long getCurrentSchemaID() {

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -37,7 +37,7 @@ public class MysqlPositionStore {
 		}
 	}
 
-	public void set(Position newPosition) throws SQLException {
+	public void set(Position newPosition) throws SQLException, DuplicateProcessException {
 		if ( newPosition == null )
 			return;
 
@@ -55,7 +55,7 @@ public class MysqlPositionStore {
 				+ "gtid_set = ?, binlog_file = ?, binlog_position=?";
 
 		BinlogPosition binlogPosition = newPosition.getBinlogPosition();
-		try( Connection c = connectionPool.getConnection() ){
+		connectionPool.withSQLRetry(1, (c) -> {
 			PreparedStatement s = c.prepareStatement(sql);
 
 			LOGGER.debug("Writing binlog position to " + c.getCatalog() + ".positions: " + newPosition + ", last heartbeat read: " + heartbeat);
@@ -71,7 +71,7 @@ public class MysqlPositionStore {
 			s.setLong(10, binlogPosition.getOffset());
 
 			s.execute();
-		}
+		});
 	}
 
 	public long heartbeat() throws Exception {
@@ -80,10 +80,10 @@ public class MysqlPositionStore {
 		return heartbeatValue;
 	}
 
-	public synchronized void heartbeat(long heartbeatValue) throws Exception {
-		try ( Connection c = connectionPool.getConnection() ) {
+	public synchronized void heartbeat(long heartbeatValue) throws SQLException, DuplicateProcessException {
+		connectionPool.withSQLRetry(1, (c) ->  {
 			heartbeat(c, heartbeatValue);
-		}
+		});
 	}
 
 	/*
@@ -110,7 +110,7 @@ public class MysqlPositionStore {
 		}
 	}
 
-	private void heartbeat(Connection c, long thisHeartbeat) throws SQLException, DuplicateProcessException, InterruptedException {
+	private void heartbeat(Connection c, long thisHeartbeat) throws SQLException, DuplicateProcessException {
 		if ( lastHeartbeat == null ) {
 			PreparedStatement s = c.prepareStatement("SELECT `heartbeat` from `heartbeats` where server_id = ? and client_id = ?");
 			s.setLong(1, serverID);

--- a/src/main/java/com/zendesk/maxwell/schema/PositionStoreThread.java
+++ b/src/main/java/com/zendesk/maxwell/schema/PositionStoreThread.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.schema;
 
 import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.errors.DuplicateProcessException;
 import com.zendesk.maxwell.replication.Position;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,7 @@ public class PositionStoreThread extends RunLoopProcess implements Runnable {
 		}
 	}
 
-	void storeFinalPosition() throws SQLException {
+	void storeFinalPosition() throws SQLException, DuplicateProcessException {
 		if ( position != null && !position.equals(storedPosition) ) {
 			LOGGER.info("Storing final position: " + position);
 			store.set(position);

--- a/src/main/java/com/zendesk/maxwell/util/C3P0ConnectionPool.java
+++ b/src/main/java/com/zendesk/maxwell/util/C3P0ConnectionPool.java
@@ -1,14 +1,17 @@
 package com.zendesk.maxwell.util;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zendesk.maxwell.errors.DuplicateProcessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import javax.sql.DataSource;
-import java.beans.PropertyVetoException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.NoSuchElementException;
 
 public class C3P0ConnectionPool implements ConnectionPool {
 	private final ComboPooledDataSource cpds;
+	static final Logger LOGGER = LoggerFactory.getLogger(C3P0ConnectionPool.class);
 
 	@Override
 	public Connection getConnection() throws SQLException {
@@ -30,5 +33,24 @@ public class C3P0ConnectionPool implements ConnectionPool {
 		// the settings below are optional -- c3p0 can work with defaults
 		cpds.setMinPoolSize(1);
 		cpds.setMaxPoolSize(5);
+	}
+
+	@Override
+	public void withSQLRetry(int nTries, RetryableSQLFunction<Connection> inner)
+		throws SQLException, DuplicateProcessException, NoSuchElementException {
+		try ( final Connection c = getConnection() ){
+			inner.apply(c);
+			return;
+		} catch (SQLException e) {
+			if ( nTries > 0 ) {
+				LOGGER.error("got SQL Exception: {}, {}, retrying...",
+					e.getLocalizedMessage(),
+					e.getCause().getLocalizedMessage()
+				);
+				withSQLRetry(nTries - 1, inner);
+			} else {
+				throw(e);
+			}
+		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/util/ConnectionPool.java
+++ b/src/main/java/com/zendesk/maxwell/util/ConnectionPool.java
@@ -1,9 +1,20 @@
 package com.zendesk.maxwell.util;
 
+import com.zendesk.maxwell.errors.DuplicateProcessException;
+
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.NoSuchElementException;
 
 public interface ConnectionPool {
+	@FunctionalInterface
+	public interface RetryableSQLFunction<T> {
+		void apply(T t) throws SQLException, NoSuchElementException, DuplicateProcessException;
+	}
+
 	Connection getConnection() throws SQLException;
 	void release();
+
+	void withSQLRetry(int nTries, RetryableSQLFunction<Connection> inner)
+		throws SQLException, NoSuchElementException, DuplicateProcessException;
 }


### PR DESCRIPTION
This prevents a connection hiccup from taking out the whole process, or a bootstrap.

see for example https://github.com/zendesk/maxwell/issues/1418