### PR TITLE
test C3P0 connection on checkout

### DIFF
--- a/src/main/java/com/zendesk/maxwell/util/C3P0ConnectionPool.java
+++ b/src/main/java/com/zendesk/maxwell/util/C3P0ConnectionPool.java
@@ -28,7 +28,7 @@ public class C3P0ConnectionPool implements ConnectionPool {
 		cpds.setJdbcUrl(url);
 		cpds.setUser(user);
 		cpds.setPassword(password);
-
+		cpds.setTestConnectionOnCheckout(true);
 
 		// the settings below are optional -- c3p0 can work with defaults
 		cpds.setMinPoolSize(1);


### PR DESCRIPTION
This incurs a PING roundtrip for every checkout of a pooled connection.
I think that's going to be absolutely fine.  Fixes issues like:
https://github.com/zendesk/maxwell/issues/1470 from bubbling up