### PR TITLE
Scheduling bootstrap tasks in the future

### DIFF
--- a/docs/docs/bootstrapping.md
+++ b/docs/docs/bootstrapping.md
@@ -40,6 +40,12 @@ Note that if a Maxwell client_id has been set you should specify the client id.
 mysql> insert into maxwell.bootstrap (database_name, table_name, client_id) values ('fooDB', 'barTable', 'custom_maxwell_client_id');
 ```
 
+You can schedule bootstrap tasks in the future, setting the `started_at` column value to the time you want to run. Every time maxwell will start bootstrap tasks with this value is `NULL` or in the past. 
+```
+mysql> insert into maxwell.bootstrap (database_name, table_name, client_id, started_at) values ('fooDB', 'barTable', 'custom_maxwell_client_id', '2020-05-18 12:30:00');
+```
+
+
 ### Async vs Sync bootstrapping
 ***
 The Maxwell replicator is single threaded; events are captured by one thread from the binlog and replicated to Kafka one message at a time.

--- a/docs/docs/bootstrapping.md
+++ b/docs/docs/bootstrapping.md
@@ -40,7 +40,8 @@ Note that if a Maxwell client_id has been set you should specify the client id.
 mysql> insert into maxwell.bootstrap (database_name, table_name, client_id) values ('fooDB', 'barTable', 'custom_maxwell_client_id');
 ```
 
-You can schedule bootstrap tasks in the future, setting the `started_at` column value to the time you want to run. Every time maxwell will start bootstrap tasks with this value is `NULL` or in the past. 
+You can schedule bootstrap tasks to be run in the future by setting the started_at column. Maxwell will wait until this time to start the bootstrap.
+
 ```
 mysql> insert into maxwell.bootstrap (database_name, table_name, client_id, started_at) values ('fooDB', 'barTable', 'custom_maxwell_client_id', '2020-05-18 12:30:00');
 ```

--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -94,7 +94,7 @@ public class BootstrapController extends RunLoopProcess  {
 	private List<BootstrapTask> getIncompleteTasks() throws SQLException {
 		ArrayList<BootstrapTask> list = new ArrayList<>();
 		try ( Connection cx = maxwellConnectionPool.getConnection() ) {
-			PreparedStatement s = cx.prepareStatement("select * from bootstrap where is_complete = 0 and client_id = ? and (started_at is null or started_at <= now()) order by -started_at desc, id");
+			PreparedStatement s = cx.prepareStatement("select * from bootstrap where is_complete = 0 and client_id = ? and (started_at is null or started_at <= now()) order by isnull(started_at), started_at asc, id asc");
 			s.setString(1, this.clientID);
 
 			ResultSet rs = s.executeQuery();

--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -94,7 +94,7 @@ public class BootstrapController extends RunLoopProcess  {
 	private List<BootstrapTask> getIncompleteTasks() throws SQLException {
 		ArrayList<BootstrapTask> list = new ArrayList<>();
 		try ( Connection cx = maxwellConnectionPool.getConnection() ) {
-			PreparedStatement s = cx.prepareStatement("select * from bootstrap where is_complete = 0 and client_id = ? order by id");
+			PreparedStatement s = cx.prepareStatement("select * from bootstrap where is_complete = 0 and client_id = ? and (started_at is null or started_at <= now()) order by -started_at desc, id");
 			s.setString(1, this.clientID);
 
 			ResultSet rs = s.executeQuery();


### PR DESCRIPTION
Hi @osheroff ,

I'm sending this simple pull request (with docs) base on one need we have here and I think this can be useful for other maxwell users.

When we have to trigger multiple bootstraps, one at a time (to lower the throughput in our redis, and to avoid new updates get in the end of a long queue), we have to insert one by one in the bootstrap table. We even have to trigger bootstraps at night, when users are not using our app exhaustively so we can get the most of our infrastructure.

This pull requests add the possibility to schedule bootstrap tasks in the future, it is a very simple change that query the bootstrap table getting only rows that "started_at" is null (current behaviour) or if started_at is in the past.

So, user can add big bootstrap tasks ahead of time, or even break the bootstrap tasks in smaller ones and schedule them 1 per hour/day/whatever he wants to. (it will starts the tasks ordered by their start time).

Important to say that the actual behaviour will be the same if users don't use this feature.

Maybe you might want to check the docs I've wrote on this feature, since my english is not that great! 

:)