### PR TITLE
fixes, sort of, for some of #1474.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -12,6 +12,7 @@ import com.zendesk.maxwell.schema.Schema;
 import com.zendesk.maxwell.schema.SchemaCapturer;
 import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
+import com.zendesk.maxwell.schema.columndef.DateColumnDef;
 import com.zendesk.maxwell.schema.columndef.TimeColumnDef;
 import com.zendesk.maxwell.scripting.Scripting;
 import org.slf4j.Logger;
@@ -234,6 +235,8 @@ public class SynchronousBootstrapper {
 			// need to explicitly coerce TIME into TIMESTAMP in order to preserve nanoseconds
 			if (columnDefinition instanceof TimeColumnDef)
 				columnValue = getTimestamp(resultSet, columnIndex);
+			else if ( columnDefinition instanceof DateColumnDef)
+				columnValue = resultSet.getString(columnIndex);
 			else
 				columnValue = resultSet.getObject(columnIndex);
 

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -18,7 +18,10 @@ public class DateColumnDef extends ColumnDef {
 
 	@Override
 	public Object asJSON(Object value, MaxwellOutputConfig config) {
-		if ( value instanceof Long && (Long) value == Long.MIN_VALUE ) {
+		if ( value instanceof String ) {
+			// bootstrapper just gives up on bothering with date processing
+			return value;
+		} else if ( value instanceof Long && (Long) value == Long.MIN_VALUE ) {
 			if ( config.zeroDatesAsNull )
 				return null;
 			else

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -20,7 +20,10 @@ public class DateColumnDef extends ColumnDef {
 	public Object asJSON(Object value, MaxwellOutputConfig config) {
 		if ( value instanceof String ) {
 			// bootstrapper just gives up on bothering with date processing
-			return value;
+			if ( config.zeroDatesAsNull && "0000-00-00".equals((String) value) )
+				return null;
+			else
+				return value;
 		} else if ( value instanceof Long && (Long) value == Long.MIN_VALUE ) {
 			if ( config.zeroDatesAsNull )
 				return null;

--- a/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
@@ -176,7 +176,7 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testZeroDates() throws Exception {
 		if (server.supportsZeroDates()) {
-			testColumnType("date", "'0000-00-00'", "0000-00-00", null);
+			testColumnType("date", "'0000-00-00'", "0000-00-00", "0000-00-00");
 			testColumnType("datetime", "'0000-00-00 00:00:00'", "0000-00-00 00:00:00", null);
 			testColumnType("timestamp", "'0000-00-00 00:00:00'", "0000-00-00 00:00:00", null);
 		}

--- a/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/BootstrapIntegrationTest.java
@@ -183,6 +183,11 @@ public class BootstrapIntegrationTest extends MaxwellTestWithIsolatedServer {
 	}
 
 	@Test
+	public void testZeroYearDates() throws Exception {
+		testColumnType("date", "'0000-01-01'", "0000-00-00", "0000-01-01");
+	}
+
+	@Test
 	public void testSubsecondTypes() throws Exception {
 		requireMinimumVersion(server.VERSION_5_6);
 		testColumnType("time(3)", "'01:02:03.123456'","01:02:03.123");


### PR DESCRIPTION
this half-hearted change fixes our processing of dates with a zero-year.
There doesn't seem to be a great way to represent these properly in
java-land, as they're not really valid dates, at least not in the
gregorian calendar.  Maybe the proper solution is to just have a mode of
the binlog-connector where it apes the mysql display function and
returns strings.