### PR TITLE
issue #1499, fix regression in error reporting

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -35,7 +35,6 @@ public class Maxwell implements Runnable {
 	protected Maxwell(MaxwellContext context) throws SQLException, URISyntaxException {
 		this.config = context.getConfig();
 		this.context = context;
-		this.context.probeConnections();
 	}
 
 	public void run() {

--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtility.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtility.java
@@ -131,7 +131,7 @@ public class MaxwellBootstrapUtility {
 		}
 	}
 
-	private ConnectionPool getConnectionPool(MaxwellBootstrapUtilityConfig config) {
+	private ConnectionPool getConnectionPool(MaxwellBootstrapUtilityConfig config) throws SQLException {
 		String connectionURI = config.getConnectionURI();
 		return new C3P0ConnectionPool(connectionURI, config.mysql.user, config.mysql.password);
 	}

--- a/src/main/java/com/zendesk/maxwell/util/C3P0ConnectionPool.java
+++ b/src/main/java/com/zendesk/maxwell/util/C3P0ConnectionPool.java
@@ -23,7 +23,7 @@ public class C3P0ConnectionPool implements ConnectionPool {
 		cpds.close();
 	}
 
-	public C3P0ConnectionPool(String url, String user, String password) throws SQLException {
+	public C3P0ConnectionPool(String url, String user, String password) {
 		cpds = new ComboPooledDataSource();
 		cpds.setJdbcUrl(url);
 		cpds.setUser(user);
@@ -33,17 +33,15 @@ public class C3P0ConnectionPool implements ConnectionPool {
 		// the settings below are optional -- c3p0 can work with defaults
 		cpds.setMinPoolSize(1);
 		cpds.setMaxPoolSize(5);
-
-		probePool();
 	}
 
-	private void probePool() throws SQLException {
+	public void probe() throws SQLException {
 		cpds.setAcquireRetryAttempts(1);
 		try ( Connection c = getConnection() ) {
 			cpds.setAcquireRetryAttempts(30);
 		} catch ( SQLException e ) {
 			// the sql exception thrown here is worthless, it's just
-			// "coudln't get connection from pool."  dig it out.
+			// "coudln't get connection from pool."  dig out the goods.
 			Throwable t = cpds.getLastAcquisitionFailureDefaultUser();
 			if ( t instanceof SQLException ) {
 				throw((SQLException) t);

--- a/src/main/java/com/zendesk/maxwell/util/ConnectionPool.java
+++ b/src/main/java/com/zendesk/maxwell/util/ConnectionPool.java
@@ -15,6 +15,7 @@ public interface ConnectionPool {
 	Connection getConnection() throws SQLException;
 	void release();
 
+	void probe() throws SQLException;
 	void withSQLRetry(int nTries, RetryableSQLFunction<Connection> inner)
 		throws SQLException, NoSuchElementException, DuplicateProcessException;
 }


### PR DESCRIPTION
C3p0 is playing a coy game with its error reporting, hiding the true error from us.  This puts in an early check of the connection pool to see if it's alive so we can show the user an error better.