### PR TITLE
Mysql NOW function precision support

### DIFF
--- a/src/main/antlr4/imports/column_definitions.g4
+++ b/src/main/antlr4/imports/column_definitions.g4
@@ -115,6 +115,7 @@ length: '(' INTEGER_LITERAL ')';
 int_flags: ( SIGNED | UNSIGNED | ZEROFILL );
 decimal_length: '(' INTEGER_LITERAL ( ',' INTEGER_LITERAL )? ')';
 
-now_function: NOW '(' ')';
+now_function: NOW now_function_length;
+now_function_length: length | '(' ')';
 current_timestamp_length: length | '(' ')';
 localtime_function: (LOCALTIME | LOCALTIMESTAMP) ('(' ')')?;


### PR DESCRIPTION
The now function optionally supports a precision.

https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_now

Maxwell was getting stuck on a binlog event which was creating a table with 
```
`created_at` datetime(6) DEFAULT NOW(6) NOT NULL
```