### PR TITLE
updated amazon-kinesis-producer library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
-      <version>0.12.8</version>
+      <version>0.14.0</version>
     </dependency>
     <dependency>
         <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
I have been encountering [this issue](https://github.com/awslabs/amazon-kinesis-producer/issues/49) on production, which was [fixed in 0.12.9](https://github.com/awslabs/amazon-kinesis-producer/releases/tag/v0.12.9) (Improve exception handling in the credential update threads).

Could we update to the latest version of amazon-kinesis-producer library to bring in these changes?