### PR TITLE
Add aws-java-sdk-sts@1.11.782 to support EKS IRSA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,11 @@
       <version>1.11.782</version>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>1.11.782</version>
+    </dependency>
+    <dependency>
       <groupId>me.tongfei</groupId>
       <artifactId>progressbar</artifactId>
       <version>0.6.0</version>


### PR DESCRIPTION
In order to support usage of EKS IRSA, the aws-java-sdk-sts module has to be included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zendesk/maxwell/1536)
<!-- Reviewable:end -->
