### PR TITLE
Redis producer - support both sentinel and traditional Redis connection

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -132,6 +132,8 @@ redis_database                 | INT                      | Database of Redis se
 redis_type                     | [ pubsub &#124; xadd &#124; lpush &#124; rpush ]  | Selects either Redis Pub/Sub, Stream, or List. | pubsub
 redis_key                      | STRING                   | Redis channel/key for Pub/Sub, XADD or LPUSH/RPUSH | maxwell
 redis_stream_json_key          | STRING                   | Redis XADD Stream Message Field Name | message
+redis_sentinels                | STRING                   | Redis sentinels list in format host1:port1,host2:port2,host3:port3... Must be only used with redis_sentinel_master_name
+redis_sentinel_master_name     | STRING                   | Redis sentinel master name. Must be only used with redis_sentinels
 
 
 # formatting

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -248,6 +248,8 @@ Other configurable properties are:
 - `redis_type` - defaults to **pubsub**
 - `redis_key` - defaults to **maxwell**
 - `redis_stream_json_key` - defaults to **message**
+- `redis_sentinels` - doesn't have a default value
+- `redis_sentinel_master_name` - doesn't have a default value
 
 # Custom Producer
 ***

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -139,6 +139,8 @@ public class MaxwellConfig extends AbstractConfig {
 	public int redisDatabase;
 	public String redisKey;
 	public String redisStreamJsonKey;
+	public String redisSentinels;
+	public String redisSentinelMasterName;
 
 	public String redisPubChannel;
 	public String redisListKey;
@@ -337,6 +339,8 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "redis_type", "[pubsub|xadd|lpush|rpush] Selects either pubsub, xadd, lpush, or rpush. Defaults to 'pubsub'" ).withRequiredArg();
 		parser.accepts( "redis_key", "Redis channel/key for Pub/Sub, XADD or LPUSH/RPUSH" ).withRequiredArg();
 		parser.accepts( "redis_stream_json_key", "Redis Stream message field name for JSON message body" ).withRequiredArg();
+		parser.accepts("redis_sentinels", "List of Redis sentinels in format host1:port1,host2:port2,host3:port3. It can be used instead of redis_host and redis_port" ).withOptionalArg();
+		parser.accepts("redis_sentinel_master_name", "Redis sentinel master name. It is used with redis_sentinels" ).withOptionalArg();
 
 		parser.accepts( "redis_pub_channel", "[deprecated]" ).withRequiredArg();
 		parser.accepts( "redis_stream_key", "[deprecated]" ).withRequiredArg();
@@ -464,6 +468,9 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.redisKey			= fetchOption("redis_key", options, properties, "maxwell");
 		this.redisStreamJsonKey	= fetchOption("redis_stream_json_key", options, properties, "message");
+
+		this.redisSentinels = fetchOption("redis_sentinels", options, properties, null);
+		this.redisSentinelMasterName = fetchOption("redis_sentinel_master_name", options, properties, null);
 
 		// deprecated options
 		this.redisPubChannel = fetchOption("redis_pub_channel", options, properties, null);
@@ -746,6 +753,10 @@ public class MaxwellConfig extends AbstractConfig {
 
 			if ( this.redisKey == null ) {
 				usage("please specify --redis_key=KEY");
+			}
+
+			if ((this.redisSentinelMasterName != null && this.redisSentinels == null) || (this.redisSentinels != null && this.redisSentinelMasterName == null)) {
+				usageForOptions("please specify both (or none) of redis_sentinel_master_name and redis_sentinels");
 			}
 		}
 


### PR DESCRIPTION
Hello,
We are preparing High Availability solution for our system that requires Sentinel support (https://redis.io/topics/sentinel) for Redis.
I thought that it would be great to have it in Maxwell, so I created this PR.

Maxwell configuration will have following configuration parameters:
* `redis_sentinels` - as a list of sentinels in format host1:host1,host2:port2,...
* `redis_sentinel_master_name` - as a master name of the sentinel

Both options are non-required (to keep compatibility with `redis_host` and `redis_port`).

I added required information to documentation pages.

Best regards,
Artyom.