### PR TITLE
fix double reconnect

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -147,9 +147,10 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 			At some point I presume shyko will fix it and we can remove this.
 		 */
 
-		if ( this.gtidPositioning ) {
-			this.client.setKeepAlive(false);
-		}
+		 /*
+		   the logic for this must be applied to all scenarios, as otherwise we will have competing keepalive logic
+		 */
+		this.client.setKeepAlive(false);
 
 		EventDeserializer eventDeserializer = new EventDeserializer();
 		eventDeserializer.setCompatibilityMode(


### PR DESCRIPTION
This addresses the issue logged in #1543 
Both mysql-binlog-connector and maxwell had logic handling reconnection after disconnect. This caused the thread to have an uncaught IllegalStateException, putting maxwell into a bad state.

This PR allows for only maxwell to have logic that attempts to reconnect after connection failure.