### PR TITLE
Correct comparision of age against SLO to be ms based

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -36,12 +36,12 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 				if (message != null) {
 					context.setPosition(message.position);
 					long currentTime = System.currentTimeMillis();
-					long age = currentTime - message.sendTimeMS;
+					long endToEndLatency = currentTime - message.eventTimeMS;
 
-					messagePublishTimer.update(age, TimeUnit.MILLISECONDS);
-					messageLatencyTimer.update(Math.max(0L, currentTime - message.eventTimeMS - 500L), TimeUnit.MILLISECONDS);
+					messagePublishTimer.update(currentTime - message.sendTimeMS, TimeUnit.MILLISECONDS);
+					messageLatencyTimer.update(Math.max(0L, endToEndLatency - 500L), TimeUnit.MILLISECONDS);
 
-					if (age > metricsAgeSloMs) {
+					if (endToEndLatency > metricsAgeSloMs) {
 						messageLatencySloViolationCount.inc();
 					}
 				}

--- a/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/AbstractAsyncProducer.java
@@ -14,7 +14,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 	public class CallbackCompleter {
 		private InflightMessageList inflightMessages;
 		private final MaxwellContext context;
-		private final MaxwellConfig config;
+		private final int metricsAgeSloMs;
 		private final Position position;
 		private final boolean isTXCommit;
 		private final long messageID;
@@ -22,7 +22,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 		public CallbackCompleter(InflightMessageList inflightMessages, Position position, boolean isTXCommit, MaxwellContext context, long messageID) {
 			this.inflightMessages = inflightMessages;
 			this.context = context;
-			this.config = context.getConfig();
+			this.metricsAgeSloMs = context.getConfig().metricsAgeSlo * 1000;
 			this.position = position;
 			this.isTXCommit = isTXCommit;
 			this.messageID = messageID;
@@ -41,7 +41,7 @@ public abstract class AbstractAsyncProducer extends AbstractProducer {
 					messagePublishTimer.update(age, TimeUnit.MILLISECONDS);
 					messageLatencyTimer.update(Math.max(0L, currentTime - message.eventTimeMS - 500L), TimeUnit.MILLISECONDS);
 
-					if (age > config.metricsAgeSlo) {
+					if (age > metricsAgeSloMs) {
 						messageLatencySloViolationCount.inc();
 					}
 				}


### PR DESCRIPTION
:pear: @thutrinh @kayison

The config is specified in seconds, but the timestamp compared to is in milliseconds.  This rectifies the issue by converting the specified config value into ms.

cc @zendesk/goanna 