### PR TITLE
Bump jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,12 +217,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.10</version>
+      <version>2.11.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.4</version>
+      <version>2.11.2</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
Fixes some snyk reported licencing issues

This replaces the auto generated PRs raised by snyk which tried to bump the two jackson deps separately.
- #1556 
- #1557 