### PR TITLE
Log some info relating to output stream caches in RowMapBuffer

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -269,6 +269,7 @@ public class Maxwell implements Runnable {
 				}
 			});
 
+			LOGGER.info("Starting Maxwell. maxMemory: " + Runtime.getRuntime().maxMemory() + " bufferMemoryUsage: " + config.bufferMemoryUsage);
 			maxwell.start();
 		} catch ( SQLException e ) {
 			// catch SQLException explicitly because we likely don't care about the stacktrace

--- a/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
@@ -55,7 +55,7 @@ public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 		this.outputStreamCacheSize += r.getApproximateSize();
 		if ( this.outputStreamCacheSize > FlushOutputStreamBytes ) {
 			resetOutputStreamCaches();
-			LOGGER.info("outputStreamCacheSize: " + this.outputStreamCacheSize + ", memorySize: " + this.memorySize);
+			LOGGER.debug("outputStreamCacheSize: " + this.outputStreamCacheSize + ", memorySize: " + this.memorySize);
 			this.outputStreamCacheSize = 0;
 		}
 

--- a/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
@@ -1,10 +1,13 @@
 package com.zendesk.maxwell.row;
 
 import com.zendesk.maxwell.util.ListWithDiskBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
+	static final Logger LOGGER = LoggerFactory.getLogger(RowMapBuffer.class);
 	private static long FlushOutputStreamBytes = 10000000;
 	private Long xid;
 	private Long xoffset = 0L;
@@ -52,6 +55,7 @@ public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 		this.outputStreamCacheSize += r.getApproximateSize();
 		if ( this.outputStreamCacheSize > FlushOutputStreamBytes ) {
 			resetOutputStreamCaches();
+			LOGGER.info("outputStreamCacheSize: " + this.outputStreamCacheSize + ", memorySize: " + this.memorySize);
 			this.outputStreamCacheSize = 0;
 		}
 

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -36,7 +36,7 @@ public class ListWithDiskBuffer<T> {
 	}
 
 	protected void resetOutputStreamCaches() throws IOException {
-		LOGGER.info("Resetting OutputStream caches. elementsInFile: " + elementsInFile + ", maxInMemoryElements: " + maxInMemoryElements);
+		LOGGER.info("Resetting OutputStream caches. elementsInFile: " + elementsInFile);
 		os.reset();
 	}
 

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -36,7 +36,7 @@ public class ListWithDiskBuffer<T> {
 	}
 
 	protected void resetOutputStreamCaches() throws IOException {
-		LOGGER.info("Resetting OutputStream caches. elementsInFile: " + elementsInFile);
+		LOGGER.debug("Resetting OutputStream caches. elementsInFile: " + elementsInFile);
 		os.reset();
 	}
 

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -36,6 +36,7 @@ public class ListWithDiskBuffer<T> {
 	}
 
 	protected void resetOutputStreamCaches() throws IOException {
+		LOGGER.info("Resetting OutputStream caches. elementsInFile: " + elementsInFile + ", maxInMemoryElements: " + maxInMemoryElements);
 		os.reset();
 	}
 


### PR DESCRIPTION
This will give us some extra insight into the internals of `RowMapBuufer` when large transactions being processed cause an overflow to disk.

/cc @zendesk/goanna 