### PR TITLE
high availability via jgroups-raft

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -164,7 +164,14 @@ filter                         | STRING            | filter rules, eg `exclude: 
 option                         | argument                            | description                                         | default
 -------------------------------|-------------------------------------| --------------------------------------------------- | -------
 encrypt                        | [ none &#124; data &#124; all ]     | encrypt mode: none = no encryption. "data": encrypt the `data` field only. `all`: encrypt entire maxwell message | none
-secret_key                     | STRING                              | specify the encryption key to be used               | null
+secret_key                     | string                              | specify the encryption key to be used               | null
+
+# high availability
+option                         | argument                            | description                                         | default
+-------------------------------|-------------------------------------| --------------------------------------------------- | -------
+ha                             |                                     | enable maxwell client HA                            |
+jgroups_config                 | string                              | location of xml configuration file for jGroups      | $PWD/raft.xml
+raft_member_id                 | string                              | uniquely identify this node within jgroups-raft cluster |
 
 # monitoring / metrics
 option                         | argument                            | description                                         | default

--- a/docs/docs/high_availability.md
+++ b/docs/docs/high_availability.md
@@ -1,0 +1,60 @@
+# High Availabilty
+
+As v1.29.0, Maxwell contains experiemental (alpha quality) client-side HA.
+Support for performing leader elections is done via
+[jgroups-raft](https://github.com/belaban/jgroups-raft).
+
+## Getting started
+
+First, copy `raft.xml.example` to `raft.xml`.  Edit to your liking, paying attention to:
+
+```
+    <raft.RAFT members="A,B,C" raft_id="${raft_id:undefined}"/>
+```
+
+Note that because we are using a RAFT-based leader election, we will have to spin up at least
+3 maxwell client nodes.
+
+
+Now start each of your HA maxwell nodes like this:
+
+```bash
+host1: $ bin/maxwell --ha --raft_member_id=A
+host2: $ bin/maxwell --ha --raft_member_id=B
+host3: $ bin/maxwell --ha --raft_member_id=C
+```
+
+if all goes well, the 3 nodes will communicate via multicast/UDP, elect one to
+be the cluster leader, and away you will go.  If one node is terminated or
+partitioned, a new election will be held to replace it.
+
+
+## Getting deeper
+
+More advanced (especially inter-DC) configurations may be implemented by
+editing `raft.xml`; you'll probably need to get the nodes to communicate with
+each other via TCP instead of UDP, and maybe tunnel through a firewall or two,
+good stuff like that.  It's of course out of scope for this document, so
+[check out the jgroups
+documentation](http://www.jgroups.org/manual/html/user-advanced.html), but if
+you come up with something good drop me a line.
+
+## Common problems
+
+Something I encountered right out of the gate was this:
+
+```
+12:37:53,135 WARN  UDP - failed to join /224.0.75.75:7500 on utun0: java.net.SocketException: Can't assign requested address
+```
+
+which can be worked around by forcing the JVM onto an ipv4 stack:
+
+```
+JAVA_OPTS="-Djava.net.preferIPv4Stack=true" bin/maxwell --ha --raft_member_id=B
+```
+
+
+
+
+
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
     - 'Data Format': 'dataformat.md'
     - 'Encryption': 'encryption.md'
     - 'Monitoring': 'monitoring.md'
+    - 'High Availability': 'high_availability.md'
     - 'Embedding': 'embedding.md'
     - 'Internals': 'schemas.md'
     - 'Compatibility': 'compat.md'

--- a/pom.xml
+++ b/pom.xml
@@ -317,12 +317,12 @@
     <dependency>
       <groupId>io.atomix</groupId>
       <artifactId>atomix</artifactId>
-      <version>3.0.6</version>
+      <version>3.1.6</version>
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>
       <artifactId>atomix-raft</artifactId>
-      <version>3.0.6</version>
+      <version>3.1.6</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,16 @@
       <artifactId>simpleclient_servlet</artifactId>
       <version>0.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix</artifactId>
+      <version>3.0.6</version>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix-raft</artifactId>
+      <version>3.0.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
     <dependency>
       <groupId>org.jgroups</groupId>
       <artifactId>jgroups-raft</artifactId>
-      <version>0.5.3-SNAPSHOT</version>
+      <version>1.0.0.Final</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -314,15 +314,11 @@
       <artifactId>simpleclient_servlet</artifactId>
       <version>0.5.0</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.jgroups/jgroups-raft -->
     <dependency>
-      <groupId>io.atomix</groupId>
-      <artifactId>atomix</artifactId>
-      <version>3.1.6</version>
-    </dependency>
-    <dependency>
-      <groupId>io.atomix</groupId>
-      <artifactId>atomix-raft</artifactId>
-      <version>3.1.6</version>
+      <groupId>org.jgroups</groupId>
+      <artifactId>jgroups-raft</artifactId>
+      <version>0.5.3-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/raft.xml.example
+++ b/raft.xml.example
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+    <UDP mcast_addr="228.8.8.8" mcast_port="${jgroups.udp.mcast_port:45588}"/>
+    <PING />
+    <MERGE3 />
+    <FD_SOCK/>
+    <FD_ALL/>
+    <VERIFY_SUSPECT timeout="1500"/>
+    <pbcast.NAKACK2 xmit_interval="500"/>
+    <UNICAST3 xmit_interval="500"/>
+    <pbcast.STABLE desired_avg_gossip="50000" max_bytes="4M"/>
+    <raft.NO_DUPES/>
+    <pbcast.GMS print_local_addr="true" join_timeout="2000"/>
+    <UFC max_credits="2M" min_threshold="0.4"/>
+    <MFC max_credits="2M" min_threshold="0.4"/>
+    <FRAG2 frag_size="60K"/>
+    <raft.ELECTION election_min_interval="500" election_max_interval="1000" heartbeat_interval="250"/>
+    <raft.RAFT members="A,B,C" raft_id="${raft_id:undefined}"/>
+    <raft.REDIRECT/>
+</config>

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -189,7 +189,7 @@ public class Maxwell implements Runnable {
 		Leadership<String> leadership = election.run(memberID);
 
 		// Check if the current node is the leader
-		String currentLeader = leadership.leader().id());
+		String currentLeader = leadership.leader().id();
 		LOGGER.info("current HA leader: " + currentLeader);
 		if (currentLeader.equals(memberID)) {
 			System.out.println("I am the leader!");

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -189,8 +189,9 @@ public class Maxwell implements Runnable {
 		Leadership<String> leadership = election.run(memberID);
 
 		// Check if the current node is the leader
-		LOGGER.info("current HA leader: " + leadership.leader());
-		if (leadership.leader().equals(memberID)) {
+		String currentLeader = leadership.leader().id());
+		LOGGER.info("current HA leader: " + currentLeader);
+		if (currentLeader.equals(memberID)) {
 			System.out.println("I am the leader!");
 		}
 

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -187,12 +187,14 @@ public class Maxwell implements Runnable {
 		Leadership<String> leadership = election.run(atomix.getMembershipService().getLocalMember().id().toString());
 
 		// Check if the current node is the leader
+		System.out.println(leadership.leader());
 		if (leadership.leader().equals(atomix.getMembershipService().getLocalMember().id())) {
 			System.out.println("I am the leader!");
 		}
 
 		// Listen for changes in leadership
 		election.addListener(event -> {
+			System.out.println(leadership.leader());
 			if (event.newLeadership().leader().equals(atomix.getMembershipService().getLocalMember().id())) {
 				System.out.println("I am the leader!");
 			}

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -182,9 +182,9 @@ public class Maxwell implements Runnable {
 		atomix.start().join();
 
 		// Get or create a leader election
-		LeaderElection<MemberId> election = atomix.getLeaderElection(this.config.clientID + "-election");
+		LeaderElection<String> election = atomix.getLeaderElection(this.config.clientID + "-election");
 
-		Leadership<MemberId> leadership = election.run(atomix.getMembershipService().getLocalMember().id());
+		Leadership<String> leadership = election.run(atomix.getMembershipService().getLocalMember().id().toString());
 
 		// Check if the current node is the leader
 		if (leadership.leader().equals(atomix.getMembershipService().getLocalMember().id())) {

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -46,14 +46,9 @@ public class Maxwell implements Runnable {
 		}
 	}
 
-	public void restart() {
-		try {
-			this.context = new MaxwellContext(config);
-		} catch ( Exception e ) {
-			throw new RuntimeException(e);
-		}
-
-		run();
+	public void restart() throws Exception {
+		this.context = new MaxwellContext(config);
+		start();
 	}
 
 	public void terminate() {
@@ -180,7 +175,7 @@ public class Maxwell implements Runnable {
 	protected void onReplicatorEnd() {}
 
 
-	private void start() throws Exception {
+	public void start() throws Exception {
 		try {
 			this.startInner();
 		} catch ( Exception e) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -14,9 +14,6 @@ import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.scripting.Scripting;
 import com.zendesk.maxwell.util.AbstractConfig;
 import com.zendesk.maxwell.util.MaxwellOptionParser;
-import joptsimple.BuiltinHelpFormatter;
-import joptsimple.OptionDescriptor;
-import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -152,9 +149,8 @@ public class MaxwellConfig extends AbstractConfig {
 	public Scripting scripting;
 
 	public boolean haMode;
-	public String atomixConf;
-	public String atomixMemberID;
-	public String atomixAddress;
+	public String jgroupsConf;
+	public String raftMemberID;
 
 	public MaxwellConfig() { // argv is only null in tests
 		this.customProducerProperties = new Properties();
@@ -228,10 +224,9 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "max_schemas", "Maximum schemas to keep before triggering a compaction operation.  Default: unlimited" ).withRequiredArg();
 		parser.section("operation");
 
-		parser.accepts( "ha", "enable high-availability mode via Atomix" ).withOptionalArg();
-		parser.accepts( "atomix_config", "location of atomix.conf configuration file" ).withRequiredArg();
-		parser.accepts( "atomix_member_id", "atomix memberID parameter" ).withRequiredArg();
-		parser.accepts( "atomix_address", "local address to this atomix node, given as x.x.x.x:PORT" ).withRequiredArg();
+		parser.accepts( "ha", "enable high-availability mode via jgroups-raft" ).withOptionalArg();
+		parser.accepts( "jgroups_config", "location of jgroups xml configuration file" ).withRequiredArg();
+		parser.accepts( "raft_member_id", "raft memberID" ).withRequiredArg();
 
 		parser.accepts( "bootstrapper", "bootstrapper type: async|sync|none. default: async" ).withRequiredArg();
 		parser.accepts( "init_position", "initial binlog position, given as BINLOG_FILE:POSITION[:HEARTBEAT]" ).withRequiredArg();
@@ -630,9 +625,8 @@ public class MaxwellConfig extends AbstractConfig {
 		}
 
 		this.haMode = fetchBooleanOption("ha", options, properties, false);
-		this.atomixConf = fetchOption("atomix_config", options, properties, "atomix.conf");
-		this.atomixMemberID = fetchOption("atomix_member_id", options, properties, null);
-		this.atomixAddress = fetchOption("atomix_address", options, properties, null);
+		this.jgroupsConf = fetchOption("jgroups_config", options, properties, "raft.xml");
+		this.raftMemberID = fetchOption("raft_member_id", options, properties, null);
 	}
 
 	private Properties parseFile(String filename, Boolean abortOnMissing) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -151,6 +151,9 @@ public class MaxwellConfig extends AbstractConfig {
 	public String javascriptFile;
 	public Scripting scripting;
 
+	public boolean haMode;
+	public String atomixConf;
+
 	public MaxwellConfig() { // argv is only null in tests
 		this.customProducerProperties = new Properties();
 		this.kafkaProperties = new Properties();
@@ -222,6 +225,9 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.separator();
 		parser.accepts( "max_schemas", "Maximum schemas to keep before triggering a compaction operation.  Default: unlimited" ).withRequiredArg();
 		parser.section("operation");
+
+		parser.accepts( "ha", "enable high-availability mode via Atomix" ).withOptionalArg();
+		parser.accepts( "atomix_config", "location of atomix.conf configuration file" ).withRequiredArg();
 
 		parser.accepts( "bootstrapper", "bootstrapper type: async|sync|none. default: async" ).withRequiredArg();
 		parser.accepts( "init_position", "initial binlog position, given as BINLOG_FILE:POSITION[:HEARTBEAT]" ).withRequiredArg();
@@ -619,6 +625,8 @@ public class MaxwellConfig extends AbstractConfig {
 			outputConfig.secretKey = fetchOption("secret_key", options, properties, null);
 		}
 
+		this.haMode = fetchBooleanOption("ha", options, properties, false);
+		this.atomixConf = fetchOption("atomix_config", options, properties, "atomix.conf");
 	}
 
 	private Properties parseFile(String filename, Boolean abortOnMissing) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -86,9 +86,6 @@ public class MaxwellConfig extends AbstractConfig {
 	public MaxwellOutputConfig outputConfig;
 	public String log_level;
 
-	public MetricRegistry metricRegistry;
-	public HealthCheckRegistry healthCheckRegistry;
-
 	public int httpPort;
 	public String httpBindAddress;
 	public String httpPathPrefix;
@@ -162,8 +159,6 @@ public class MaxwellConfig extends AbstractConfig {
 		this.masterRecovery = false;
 		this.gtidMode = false;
 		this.bufferedProducerSize = 200;
-		this.metricRegistry = new MetricRegistry();
-		this.healthCheckRegistry = new HealthCheckRegistry();
 		this.outputConfig = new MaxwellOutputConfig();
 		setup(null, null); // setup defaults
 	}
@@ -224,9 +219,9 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "max_schemas", "Maximum schemas to keep before triggering a compaction operation.  Default: unlimited" ).withRequiredArg();
 		parser.section("operation");
 
-		parser.accepts( "ha", "enable high-availability mode via jgroups-raft" ).withOptionalArg();
+		parser.accepts( "ha", "enable high-availability mode via jgroups-raft" );
 		parser.accepts( "jgroups_config", "location of jgroups xml configuration file" ).withRequiredArg();
-		parser.accepts( "raft_member_id", "raft memberID" ).withRequiredArg();
+		parser.accepts( "raft_member_id", "raft memberID.  (may also be specified in raft.xml)" ).withRequiredArg();
 
 		parser.accepts( "bootstrapper", "bootstrapper type: async|sync|none. default: async" ).withRequiredArg();
 		parser.accepts( "init_position", "initial binlog position, given as BINLOG_FILE:POSITION[:HEARTBEAT]" ).withRequiredArg();

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -153,6 +153,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public boolean haMode;
 	public String atomixConf;
+	public String atomixMemberID;
+	public String atomixAddress;
 
 	public MaxwellConfig() { // argv is only null in tests
 		this.customProducerProperties = new Properties();
@@ -228,6 +230,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "ha", "enable high-availability mode via Atomix" ).withOptionalArg();
 		parser.accepts( "atomix_config", "location of atomix.conf configuration file" ).withRequiredArg();
+		parser.accepts( "atomix_member_id", "atomix memberID parameter" ).withRequiredArg();
+		parser.accepts( "atomix_address", "local address to this atomix node, given as x.x.x.x:PORT" ).withRequiredArg();
 
 		parser.accepts( "bootstrapper", "bootstrapper type: async|sync|none. default: async" ).withRequiredArg();
 		parser.accepts( "init_position", "initial binlog position, given as BINLOG_FILE:POSITION[:HEARTBEAT]" ).withRequiredArg();
@@ -627,6 +631,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.haMode = fetchBooleanOption("ha", options, properties, false);
 		this.atomixConf = fetchOption("atomix_config", options, properties, "atomix.conf");
+		this.atomixMemberID = fetchOption("atomix_member_id", options, properties, null);
+		this.atomixAddress = fetchOption("atomix_address", options, properties, null);
 	}
 
 	private Properties parseFile(String filename, Boolean abortOnMissing) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -86,6 +86,9 @@ public class MaxwellConfig extends AbstractConfig {
 	public MaxwellOutputConfig outputConfig;
 	public String log_level;
 
+	public MetricRegistry metricRegistry;
+	public HealthCheckRegistry healthCheckRegistry;
+
 	public int httpPort;
 	public String httpBindAddress;
 	public String httpPathPrefix;

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -68,7 +68,10 @@ public class MaxwellContext {
 		this.config.validate();
 		this.taskManager = new TaskManager();
 
-		this.metricRegistry = new MetricRegistry();
+		this.metricRegistry = config.metricRegistry;
+		if ( this.metricRegistry == null )
+			this.metricRegistry = new MetricRegistry();
+
 		this.metrics = new MaxwellMetrics(config, this.metricRegistry);
 
 		this.replicationConnectionPool = new C3P0ConnectionPool(
@@ -115,7 +118,9 @@ public class MaxwellContext {
 		List<MaxwellDiagnostic> diagnostics = new ArrayList<>(Collections.singletonList(new BinlogConnectorDiagnostic(this)));
 		this.diagnosticContext = new MaxwellDiagnosticContext(config.diagnosticConfig, diagnostics);
 
-		this.healthCheckRegistry = new HealthCheckRegistry();
+		this.healthCheckRegistry = config.healthCheckRegistry;
+		if ( this.healthCheckRegistry == null )
+			this.healthCheckRegistry = new HealthCheckRegistry();
 	}
 
 	public MaxwellConfig getConfig() {

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -174,7 +174,7 @@ public class MaxwellContext {
 		}
 	}
 
-	private void shutdown(AtomicBoolean complete) {
+	public void shutdown(AtomicBoolean complete) {
 		try {
 			taskManager.stop(this.error);
 			this.replicationConnectionPool.release();

--- a/src/main/java/com/zendesk/maxwell/MaxwellHA.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellHA.java
@@ -1,0 +1,67 @@
+package com.zendesk.maxwell;
+
+import org.jgroups.JChannel;
+import org.jgroups.protocols.raft.RaftLeaderException;
+import org.jgroups.protocols.raft.Role;
+import org.jgroups.protocols.raft.StateMachine;
+import org.jgroups.raft.RaftHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class MaxwellHA {
+	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellHA.class);
+
+	private final Maxwell maxwell;
+	private final String jgroupsConf, raftMemberID, clientID;
+	private boolean hasRun = false;
+	private AtomicBoolean isRaftLeader = new AtomicBoolean(false);
+
+	public MaxwellHA(Maxwell maxwell, String jgroupsConf, String raftMemberID, String clientID) {
+		this.maxwell = maxwell;
+		this.jgroupsConf = jgroupsConf;
+		this.raftMemberID = raftMemberID;
+		this.clientID = clientID;
+	}
+
+	public void startHA() throws Exception {
+		JChannel ch=new JChannel(jgroupsConf);
+		RaftHandle handle=new RaftHandle(ch, null);
+		if ( raftMemberID != null )
+			handle.raftId(raftMemberID);
+		else
+			LOGGER.warn("--raft_member_id not specified, using values from " + jgroupsConf);
+
+		handle.addRoleListener(role -> {
+			if(role == Role.Leader) {
+				LOGGER.info("won HA election, starting maxwell");
+				isRaftLeader.set(true);
+
+				if ( hasRun )
+					maxwell.restart();
+				else {
+					maxwell.run();
+					hasRun = true;
+				}
+
+				isRaftLeader.set(false);
+			} else if ( this.isRaftLeader.get() ) {
+				LOGGER.info("Unable to find consensus, stepping down HA leadership");
+				maxwell.terminate();
+				isRaftLeader.set(false);
+			} else {
+				LOGGER.info("lost HA election, current leader: " + handle.leader());
+			}
+		});
+
+		ch.connect(this.clientID);
+		LOGGER.info("enter HA group, current leader: " +  handle.leader());
+
+		Thread.sleep(Long.MAX_VALUE);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/MaxwellHA.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellHA.java
@@ -29,6 +29,20 @@ public class MaxwellHA {
 		this.clientID = clientID;
 	}
 
+	private void run() {
+		try {
+			if (hasRun)
+				maxwell.restart();
+			else
+				maxwell.start();
+
+			hasRun = true;
+		} catch ( Exception e ) {
+			LOGGER.error("Maxwell terminating due to exception:", e);
+			System.exit(1);
+		}
+	}
+
 	public void startHA() throws Exception {
 		JChannel ch=new JChannel(jgroupsConf);
 		RaftHandle handle=new RaftHandle(ch, null);
@@ -42,12 +56,7 @@ public class MaxwellHA {
 				LOGGER.info("won HA election, starting maxwell");
 				isRaftLeader.set(true);
 
-				if ( hasRun )
-					maxwell.restart();
-				else {
-					maxwell.run();
-					hasRun = true;
-				}
+				run();
 
 				isRaftLeader.set(false);
 			} else if ( this.isRaftLeader.get() ) {

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
@@ -50,8 +50,8 @@ public class MaxwellHTTPServer {
 		MaxwellConfig config = context.getConfig();
 		String reportingType = config.metricsReportingType;
 		if (reportingType != null && reportingType.contains(reportingTypeHttp)) {
-			config.healthCheckRegistry.register("MaxwellHealth", new MaxwellHealthCheck(context.getProducer()));
-			return new MaxwellMetrics.Registries(config.metricRegistry, config.healthCheckRegistry);
+			context.healthCheckRegistry.register("MaxwellHealth", new MaxwellHealthCheck(context.getProducer()));
+			return new MaxwellMetrics.Registries(context.metricRegistry, context.healthCheckRegistry);
 		} else {
 			return null;
 		}

--- a/src/test/java/com/zendesk/maxwell/EmbeddedMaxwellTest.java
+++ b/src/test/java/com/zendesk/maxwell/EmbeddedMaxwellTest.java
@@ -30,6 +30,8 @@ public class EmbeddedMaxwellTest extends MaxwellTestWithIsolatedServer {
 		HealthCheckRegistry healthChecks = new HealthCheckRegistry();
 		final BlockingQueue<RowMap> rowBuffer = new LinkedBlockingQueue<>();
 		config.metricsReportingType = "embedded";
+		config.metricRegistry = metrics;
+		config.healthCheckRegistry = healthChecks;
 		config.metricsPrefix = "prefix";
 		config.producerFactory = new ProducerFactory() {
 			@Override
@@ -45,9 +47,6 @@ public class EmbeddedMaxwellTest extends MaxwellTestWithIsolatedServer {
 				latch.countDown();
 			}
 		};
-		maxwell.context.metricRegistry = metrics;
-		maxwell.context.healthCheckRegistry = healthChecks;
-
 		new Thread(maxwell).start();
 		latch.await();
 

--- a/src/test/java/com/zendesk/maxwell/EmbeddedMaxwellTest.java
+++ b/src/test/java/com/zendesk/maxwell/EmbeddedMaxwellTest.java
@@ -30,8 +30,6 @@ public class EmbeddedMaxwellTest extends MaxwellTestWithIsolatedServer {
 		HealthCheckRegistry healthChecks = new HealthCheckRegistry();
 		final BlockingQueue<RowMap> rowBuffer = new LinkedBlockingQueue<>();
 		config.metricsReportingType = "embedded";
-		config.metricRegistry = metrics;
-		config.healthCheckRegistry = healthChecks;
 		config.metricsPrefix = "prefix";
 		config.producerFactory = new ProducerFactory() {
 			@Override
@@ -47,6 +45,9 @@ public class EmbeddedMaxwellTest extends MaxwellTestWithIsolatedServer {
 				latch.countDown();
 			}
 		};
+		maxwell.context.metricRegistry = metrics;
+		maxwell.context.healthCheckRegistry = healthChecks;
+
 		new Thread(maxwell).start();
 		latch.await();
 


### PR DESCRIPTION
While many maxwell users at this point probably have rolled their own singleton-cluster-management solution (via kubernetes, consul, etcd,  etc, etc), having a baked-in HA story has been an oft-requested feature.  For many it's simply not feasible to tell them "go implement a giant PAAS architecture in order to pick up some high-availability".  

so here's a fairly dirty and cheap HA story using @belaban's excellent [jgroups-raft](https://github.com/belaban/jgroups-raft).  

Note that the implementation of the *lock* is imperfect (as according to https://github.com/belaban/jgroups-raft/issues/79) and http://belaban.blogspot.com/2020/11/i-hate-distributed-locks.html; in order to do this *correctly* we'd probably want to move the data in `maxwell`.`positions` into the raft cluster itself, and require a successful `write()` operation to the RAFT cluster to make progress.

Note also that at least for now, I don't care about the possibility of two simultaneous singletons; (a) the overlap will be brief, as the old, partitioned leader will soon notice the lack of quorum and step down, and (b) if the maxwell clients are configured correctly the server will enforce a singleton anyway when it checks the uniqueness of the server_id.  

Also; I tried atomix first in all of this.  It did not pass muster.  It did not pass much.  

cc @zendesk/goanna @timbertson (i think goanna is the Zendesk side of maxwell maint these days? )
