### PR TITLE
BinlogConnectorReplicator: add heartbeat detection [MELINF-2251]

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -36,6 +36,7 @@ replication_password           | STRING               | password on replication 
 replication_port               | INT                  | port on replication server                          | 3306
 replication_user               | STRING               | user on replication server                          |
 replication_ssl                | [SSL_OPT](#sslopt)   | SSL behavior for replication cx cx                  | DISABLED
+replication_heartbeat          | BOOLEAN              | enable replication heartbeats to detect stale connections | ENABLED
 replication_jdbc_options       | STRING               | mysql jdbc connection options for replication server| [DEFAULT_JDBC_OPTS](#jdbcopts)
 &nbsp;
 schema_host                    | STRING               | server to capture schema from.  See [split server roles](#split-server-roles) | *schema-store host*

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -30,13 +30,13 @@ master_recovery                | BOOLEAN              | enable experimental mast
 gtid_mode                      | BOOLEAN              | enable GTID-based replication                       | false
 recapture_schema               | BOOLEAN              | recapture the latest schema. Not available in config.properties. | false
 max_schemas                    | LONG                 | how many schema deltas to keep before triggering compaction operation | unlimited
+binlog_heartbeat               | BOOLEAN              | enable binlog heartbeats to detect stale connections | DISABLED
 &nbsp;
 replication_host               | STRING               | server to replicate from.  See [split server roles](#split-server-roles) | *schema-store host*
 replication_password           | STRING               | password on replication server                      | (none)
 replication_port               | INT                  | port on replication server                          | 3306
 replication_user               | STRING               | user on replication server                          |
 replication_ssl                | [SSL_OPT](#sslopt)   | SSL behavior for replication cx cx                  | DISABLED
-replication_heartbeat          | BOOLEAN              | enable replication heartbeats to detect stale connections | DISABLED
 replication_jdbc_options       | STRING               | mysql jdbc connection options for replication server| [DEFAULT_JDBC_OPTS](#jdbcopts)
 &nbsp;
 schema_host                    | STRING               | server to capture schema from.  See [split server roles](#split-server-roles) | *schema-store host*

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -36,7 +36,7 @@ replication_password           | STRING               | password on replication 
 replication_port               | INT                  | port on replication server                          | 3306
 replication_user               | STRING               | user on replication server                          |
 replication_ssl                | [SSL_OPT](#sslopt)   | SSL behavior for replication cx cx                  | DISABLED
-replication_heartbeat          | BOOLEAN              | enable replication heartbeats to detect stale connections | ENABLED
+replication_heartbeat          | BOOLEAN              | enable replication heartbeats to detect stale connections | DISABLED
 replication_jdbc_options       | STRING               | mysql jdbc connection options for replication server| [DEFAULT_JDBC_OPTS](#jdbcopts)
 &nbsp;
 schema_host                    | STRING               | server to capture schema from.  See [split server roles](#split-server-roles) | *schema-store host*

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -223,6 +223,9 @@ public class MaxwellConfig extends AbstractConfig {
 				.withRequiredArg().ofType(Integer.class);
 		parser.accepts( "replication_jdbc_options", "additional jdbc connection options: key1=val1&key2=val2" )
 				.withRequiredArg();
+		parser.accepts( "replication_heartbeat", "enable binlog replication heartbeats, default true" )
+				.withRequiredArg().ofType(Boolean.class);
+
 
 		parser.separator();
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -193,6 +193,8 @@ public class MaxwellConfig extends AbstractConfig {
 				.withRequiredArg();
 		parser.accepts( "password", "password for host" )
 				.withRequiredArg();
+		parser.accepts( "binlog_heartbeat", "enable binlog replication heartbeats, default false" )
+				.withOptionalArg().ofType(Boolean.class);
 
 		parser.section("mysql");
 
@@ -223,9 +225,6 @@ public class MaxwellConfig extends AbstractConfig {
 				.withRequiredArg().ofType(Integer.class);
 		parser.accepts( "replication_jdbc_options", "additional jdbc connection options: key1=val1&key2=val2" )
 				.withRequiredArg();
-		parser.accepts( "replication_heartbeat", "enable binlog replication heartbeats, default false" )
-				.withOptionalArg().ofType(Boolean.class);
-
 
 		parser.separator();
 
@@ -895,7 +894,8 @@ public class MaxwellConfig extends AbstractConfig {
 				null,
 				this.maxwellMysql.user,
 				this.maxwellMysql.password,
-				this.maxwellMysql.sslMode
+				this.maxwellMysql.sslMode,
+				this.maxwellMysql.enableHeartbeat
 			);
 
 			this.replicationMysql.jdbcOptions = this.maxwellMysql.jdbcOptions;

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -223,8 +223,8 @@ public class MaxwellConfig extends AbstractConfig {
 				.withRequiredArg().ofType(Integer.class);
 		parser.accepts( "replication_jdbc_options", "additional jdbc connection options: key1=val1&key2=val2" )
 				.withRequiredArg();
-		parser.accepts( "replication_heartbeat", "enable binlog replication heartbeats, default true" )
-				.withRequiredArg().ofType(Boolean.class);
+		parser.accepts( "replication_heartbeat", "enable binlog replication heartbeats, default false" )
+				.withOptionalArg().ofType(Boolean.class);
 
 
 		parser.separator();

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -43,7 +43,7 @@ public class MaxwellMysqlConfig {
 	}
 
 	public MaxwellMysqlConfig(String host, Integer port, String database, String user, String password,
-			SSLMode sslMode) {
+			SSLMode sslMode, boolean enableHeartbeat) {
 		this();
 		this.host = host;
 		this.port = port;
@@ -51,6 +51,7 @@ public class MaxwellMysqlConfig {
 		this.user = user;
 		this.password = password;
 		this.sslMode = sslMode;
+		this.enableHeartbeat = enableHeartbeat;
 	}
 
 	public MaxwellMysqlConfig(MaxwellMysqlConfig c) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -23,6 +23,7 @@ public class MaxwellMysqlConfig {
 	public String user;
 	public String password;
 	public SSLMode sslMode;
+	public boolean enableHeartbeat;
 	public Map<String, String> jdbcOptions = new HashMap<>();
 	public Integer connectTimeoutMS = 5000;
 
@@ -33,6 +34,7 @@ public class MaxwellMysqlConfig {
 		this.user = null;
 		this.password = null;
 		this.sslMode = null;
+		this.enableHeartbeat = true;
 
 		this.jdbcOptions = new HashMap<>();
 		this.jdbcOptions.put("zeroDateTimeBehavior", "convertToNull");

--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlConfig.java
@@ -34,7 +34,7 @@ public class MaxwellMysqlConfig {
 		this.user = null;
 		this.password = null;
 		this.sslMode = null;
-		this.enableHeartbeat = true;
+		this.enableHeartbeat = false;
 
 		this.jdbcOptions = new HashMap<>();
 		this.jdbcOptions.put("zeroDateTimeBehavior", "convertToNull");

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorLivenessMonitor.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorLivenessMonitor.java
@@ -1,0 +1,60 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BinlogConnectorLivenessMonitor implements BinaryLogClient.EventListener, BinaryLogClient.LifecycleListener {
+	private static final Logger LOGGER = LoggerFactory.getLogger(BinlogConnectorLivenessMonitor.class);
+
+	private static long heartbeatInterval = 5000L;
+	private static final float heartbeatIntervalAllowance = 5.0f;
+
+	private final BinaryLogClient client;
+	private long lastEventSeenAt;
+
+	public BinlogConnectorLivenessMonitor(BinaryLogClient client) {
+		this.client = client;
+		this.client.setHeartbeatInterval(heartbeatInterval);
+		this.reset();
+	}
+
+	private void reset() {
+		this.lastEventSeenAt = System.currentTimeMillis();
+	}
+
+	public boolean isAlive() {
+		long lastEventAge = System.currentTimeMillis() - lastEventSeenAt;
+		long maxAllowedEventAge = Math.round(heartbeatInterval * heartbeatIntervalAllowance);
+		boolean alive = lastEventAge <= maxAllowedEventAge;
+		if (!alive) {
+			LOGGER.warn(
+				"Last binlog event seen " + lastEventAge + "ms ago, exceeding " + maxAllowedEventAge + "ms allowance " +
+				"(" + heartbeatInterval + " * " + heartbeatIntervalAllowance + ")");
+		}
+		return alive;
+	}
+
+	@Override
+	public void onEvent(Event event) {
+		this.reset();
+	}
+
+	@Override
+	public void onConnect(BinaryLogClient binaryLogClient) {
+		this.reset();
+	}
+
+	@Override
+	public void onCommunicationFailure(BinaryLogClient binaryLogClient, Exception e) {
+	}
+
+	@Override
+	public void onEventDeserializationFailure(BinaryLogClient binaryLogClient, Exception e) {
+	}
+
+	@Override
+	public void onDisconnect(BinaryLogClient binaryLogClient) {
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -426,6 +426,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 			return;
 		}
 		if (!this.isConnectionAlive()) {
+			client.disconnect();
 			if (this.gtidPositioning) {
 				// When using gtid positioning, reconnecting should take us to the top
 				// of the gtid event.  We throw away any binlog position we have

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -183,6 +183,7 @@ public abstract class AbstractConfig {
 		config.password = fetchStringOption(prefix + "password", options, properties, null);
 		config.user     = fetchStringOption(prefix + "user", options, properties, null);
 		config.port     = fetchIntegerOption(prefix + "port", options, properties, 3306);
+		config.enableHeartbeat = fetchBooleanOption(prefix + "heartbeat", options, properties, config.enableHeartbeat);
 		config.sslMode  = this.getSslModeFromString(fetchStringOption(prefix + "ssl", options, properties, null));
 		config.setJDBCOptions(
 		    fetchStringOption(prefix + "jdbc_options", options, properties, null));

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -183,10 +183,12 @@ public abstract class AbstractConfig {
 		config.password = fetchStringOption(prefix + "password", options, properties, null);
 		config.user     = fetchStringOption(prefix + "user", options, properties, null);
 		config.port     = fetchIntegerOption(prefix + "port", options, properties, 3306);
-		config.enableHeartbeat = fetchBooleanOption(prefix + "heartbeat", options, properties, config.enableHeartbeat);
 		config.sslMode  = this.getSslModeFromString(fetchStringOption(prefix + "ssl", options, properties, null));
 		config.setJDBCOptions(
 		    fetchStringOption(prefix + "jdbc_options", options, properties, null));
+
+		// binlog_heartbeat isn't prefixed, as it only affects replication
+		config.enableHeartbeat = fetchBooleanOption("binlog_heartbeat", options, properties, config.enableHeartbeat);
 		return config;
 	}
 


### PR DESCRIPTION
Since deploying v1.27.x, we've had a small but noticeable uptick in stuck maxwells - no events flowing, but maxwell itself is running with no errors, still reporting metrics etc.

My main suspect is https://github.com/zendesk/maxwell/pull/1548. That disables binlog replicator's dead connection logic because it clashes with maxwell's own functionality. But maxwell's functionality is pretty weak here - it only knows about active failures (i.e. exceptions), if the connection simply goes quiet it won't notice.

After reading https://github.com/shyiko/mysql-binlog-connector-java/issues/118 I think maxwell should use binlog-connector's heartbeating. We still don't want to enable BC's keepalive thread (because it conflicts with our reconnect logic), but we can enable heartbeating and then reimplement the heartbeat detection as part of our existing dead connection detection.

/cc @zendesk/goanna 