### PR TITLE
Add stackdriver metrics logging to maxwell using opencensus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockito.version>3.7.7</mockito.version>
+    <opencensus.version>0.28.3</opencensus.version>
   </properties>
 
   <profiles>
@@ -331,6 +332,28 @@
       <groupId>org.jgroups</groupId>
       <artifactId>jgroups-raft</artifactId>
       <version>1.0.0.Final</version>
+    </dependency>
+    <!-- OpenCensus used for pushing metrics to stackdriver -->
+    <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-contrib-dropwizard</artifactId>      
+        <version>${opencensus.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-api</artifactId>
+        <version>${opencensus.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-impl</artifactId>
+        <version>${opencensus.version}</version>
+        <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
+        <version>${opencensus.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -460,7 +460,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.section("metrics");
 
 		parser.accepts( "metrics_prefix", "the prefix maxwell will apply to all metrics" ).withRequiredArg();
-		parser.accepts( "metrics_type", "how maxwell metrics will be reported, at least one of slf4j|jmx|http|datadog" ).withRequiredArg();
+		parser.accepts( "metrics_type", "how maxwell metrics will be reported, at least one of slf4j|jmx|http|datadog|stackdriver" ).withRequiredArg();
 		parser.accepts( "metrics_slf4j_interval", "the frequency metrics are emitted to the log, in seconds, when slf4j reporting is configured" ).withRequiredArg();
 		parser.accepts( "metrics_age_slo", "the threshold in seconds for message age service level objective" ).withRequiredArg().ofType(Integer.class);
 		parser.accepts( "http_port", "the port the server will bind to when http reporting is configured" ).withRequiredArg().ofType(Integer.class);


### PR DESCRIPTION
This will add stackdriver logging for logging the maxwell metrics. Unfortunately there is no ready available dropwizard reporter for stackdriver. 

In order to keep the implementation simple I opted for using the opencensus stackdriver exporter. The downside of the solution is that we need to add opencensus as an external dependency. In my opinion this outweighs having to maintain our own dropwizard stackdriver exporter.
