### PR TITLE
Add SNS producer and updated config

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -90,6 +90,13 @@ option                         | argument                            | descripti
 -------------------------------|-------------------------------------| --------------------------------------------------- | -------
 sqs_queue_uri                  | STRING                              | SQS Queue URI |
 
+## sns producer 
+option                         | argument                            | description                                         | default
+-------------------------------|-------------------------------------| --------------------------------------------------- | -------
+sns_topic                      | STRING                              | The SNS topic to publish to. FIFO topics should end with `.fifo` |
+sns_database_attribute         | BOOLEAN                             | Add `database` as an attribute to the SNS message   | false
+sns_table_attribute            | BOOLEAN                             | Add `table` as an attribute to the SNS message      | false
+
 ## nats producer
 option                         | argument                            | description                                         | default
 -------------------------------|-------------------------------------| --------------------------------------------------- | -------

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -94,8 +94,7 @@ sqs_queue_uri                  | STRING                              | SQS Queue
 option                         | argument                            | description                                         | default
 -------------------------------|-------------------------------------| --------------------------------------------------- | -------
 sns_topic                      | STRING                              | The SNS topic to publish to. FIFO topics should end with `.fifo` |
-sns_database_attribute         | BOOLEAN                             | Add `database` as an attribute to the SNS message   | false
-sns_table_attribute            | BOOLEAN                             | Add `table` as an attribute to the SNS message      | false
+sns_attrs                      | STRING                              | Properties to set as attributes on the SNS message  |  
 
 ## nats producer
 option                         | argument                            | description                                         | default

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -220,6 +220,23 @@ Set the output queue in the `config.properties` by setting the `sqs_queue_uri` p
 
 The producer uses the [AWS SQS SDK](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/AmazonSQSClient.html).
 
+# SNS
+***
+
+## AWS Credentials
+You will need to obtain an IAM user that has the permission to access the SQS service. The SQS producer also uses [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) to get AWS credentials.
+
+See the [AWS docs](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) on how to setup the IAM user with the Default Credential Provider Chain.
+
+In case you need to set up a different region also along with credentials then default one, see the [AWS docs](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html#setup-credentials-setting-region).
+
+## Options
+Set the topic arn in the `config.properties` by setting the `sns_topic` property to the topic name. FIFO topics should have a `.fifo` suffix. 
+
+Optionally, you can enable `sns_table_attribute` and/or `sns_database_attribute` values to have maxwell attach `table` and`database` attributes to the message for subscription filtering
+
+The producer uses the [AWS SNS SDK](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sns/AmazonSNSClient.html).
+
 # Nats
 ***
 The configurable properties for nats are:

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -233,7 +233,7 @@ In case you need to set up a different region also along with credentials then d
 ## Options
 Set the topic arn in the `config.properties` by setting the `sns_topic` property to the topic name. FIFO topics should have a `.fifo` suffix. 
 
-Optionally, you can enable `sns_table_attribute` and/or `sns_database_attribute` values to have maxwell attach `table` and`database` attributes to the message for subscription filtering
+Optionally, you can enable `sns_table_attribute` and/or `sns_database_attribute` values to have maxwell attach `table` and `database` attributes to the message for subscription filtering
 
 The producer uses the [AWS SNS SDK](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sns/AmazonSNSClient.html).
 

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -224,7 +224,7 @@ The producer uses the [AWS SQS SDK](http://docs.aws.amazon.com/AWSJavaSDK/latest
 ***
 
 ## AWS Credentials
-You will need to obtain an IAM user that has the permission to access the SQS service. The SQS producer also uses [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) to get AWS credentials.
+You will need to obtain an IAM user that has the permission to access the SNS topic. The SNS producer also uses [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) to get AWS credentials.
 
 See the [AWS docs](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) on how to setup the IAM user with the Default Credential Provider Chain.
 

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -233,7 +233,7 @@ In case you need to set up a different region also along with credentials then d
 ## Options
 Set the topic arn in the `config.properties` by setting the `sns_topic` property to the topic name. FIFO topics should have a `.fifo` suffix. 
 
-Optionally, you can enable `sns_table_attribute` and/or `sns_database_attribute` values to have maxwell attach `table` and `database` attributes to the message for subscription filtering
+Optionally, you can enable `sns_attrs` to have maxwell attach various attributes to the message for subscription filtering. (Only `database` and `table` are currently supported)
 
 The producer uses the [AWS SNS SDK](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sns/AmazonSNSClient.html).
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -125,3 +125,10 @@ bin/maxwell --user='maxwell' --password='XXXXXX' --host='127.0.0.1' \
 bin/maxwell --user='maxwell' --password='XXXXXX' --host='127.0.0.1' \
     --producer=redis --redis_host=redis.hostname
 ```
+
+## SNS
+
+```
+bin/maxwell --user='maxwell' --password='XXXXXX' --host='127.0.0.1' \
+    --producer=sns --sns_topic=sns.topic
+```

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -130,5 +130,5 @@ bin/maxwell --user='maxwell' --password='XXXXXX' --host='127.0.0.1' \
 
 ```
 bin/maxwell --user='maxwell' --password='XXXXXX' --host='127.0.0.1' \
-    --producer=sns --sns_topic=sns.topic
+    --producer=sns --sns_topic=sns.topic --sns_attrs=database,table
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,11 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sns</artifactId>
+      <version>1.11.955</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sqs</artifactId>
       <version>1.11.955</version>
     </dependency>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -338,6 +338,10 @@ public class MaxwellConfig extends AbstractConfig {
 				.withOptionalArg();
 		parser.accepts( "sqs_queue_uri", "SQS Queue uri" )
 				.withRequiredArg();
+		parser.accepts("sns_topic", "SNS Topic ARN")
+				.withRequiredArg();
+		parser.accepts("sns_attrs", "Fields to add as message attributes")
+				.withOptionalArg();
 		parser.separator();
 		parser.addToSection("producer_partition_by");
 		parser.addToSection("producer_partition_columns");
@@ -844,6 +848,8 @@ public class MaxwellConfig extends AbstractConfig {
 			usageForOptions("please specify a stream name for kinesis", "kinesis_stream");
 		} else if (this.producerType.equals("sqs") && this.sqsQueueUri == null) {
 			usageForOptions("please specify a queue uri for sqs", "sqs_queue_uri");
+		} else if (this.producerType.equals("sns") && this.snsTopic == null) {
+			usageForOptions("please specify a topic ARN for SNS", "sns_topic");
 		} else if (this.producerType.equals("pubsub")) {
 			if (this.pubsubRequestBytesThreshold <= 0L)
 				usage("--pubsub_request_bytes_threshold must be > 0");

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -66,6 +66,10 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public String sqsQueueUri;
 
+	public String snsTopic;
+	public boolean snsTableAttribute;
+	public boolean snsDatabaseAttribute;
+
 	public String pubsubProjectId;
 	public String pubsubTopic;
 	public String ddlPubsubTopic;
@@ -620,6 +624,9 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.sqsQueueUri = fetchStringOption("sqs_queue_uri", options, properties, null);
 
+		this.snsTopic = fetchStringOption("sns_topic", options, properties, null);
+		this.snsDatabaseAttribute = fetchBooleanOption("sns_database_attribute", options, properties, false);
+		this.snsTableAttribute = fetchBooleanOption("sns_table_attribute", options, properties, false);
 		this.outputFile = fetchStringOption("output_file", options, properties, null);
 
 		this.metricsPrefix = fetchStringOption("metrics_prefix", options, properties, "MaxwellMetrics");

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -67,8 +67,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public String sqsQueueUri;
 
 	public String snsTopic;
-	public boolean snsTableAttribute;
-	public boolean snsDatabaseAttribute;
+	public String snsAttrs;
 
 	public String pubsubProjectId;
 	public String pubsubTopic;
@@ -186,7 +185,7 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.separator();
 
-		parser.accepts( "producer", "producer type: stdout|file|kafka|kinesis|nats|pubsub|sqs|rabbitmq|redis|custom" )
+		parser.accepts( "producer", "producer type: stdout|file|kafka|kinesis|nats|pubsub|sns|sqs|rabbitmq|redis|custom" )
 				.withRequiredArg();
 		parser.accepts( "client_id", "unique identifier for this maxwell instance, use when running multiple maxwells" )
 				.withRequiredArg();
@@ -625,8 +624,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.sqsQueueUri = fetchStringOption("sqs_queue_uri", options, properties, null);
 
 		this.snsTopic = fetchStringOption("sns_topic", options, properties, null);
-		this.snsDatabaseAttribute = fetchBooleanOption("sns_database_attribute", options, properties, false);
-		this.snsTableAttribute = fetchBooleanOption("sns_table_attribute", options, properties, false);
+		this.snsAttrs = fetchStringOption("sns_attrs", options, properties, null);
 		this.outputFile = fetchStringOption("output_file", options, properties, null);
 
 		this.metricsPrefix = fetchStringOption("metrics_prefix", options, properties, "MaxwellMetrics");

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -385,6 +385,9 @@ public class MaxwellContext {
 			case "sqs":
 				this.producer = new MaxwellSQSProducer(this, this.config.sqsQueueUri);
 				break;
+			case "sns":
+				this.producer = new MaxwellSNSProducer(this, this.config.snsTopic);
+				break;
 			case "nats":
 				this.producer = new NatsProducer(this);
 				break;

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -1,0 +1,100 @@
+package com.zendesk.maxwell.producer;
+
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.sns.AmazonSNSAsync;
+import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
+import com.amazonaws.services.sns.model.MessageAttributeValue;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.replication.Position;
+import com.zendesk.maxwell.row.RowMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MaxwellSNSProducer extends AbstractAsyncProducer {
+
+	private AmazonSNSAsync client;
+	private String topic;
+
+	public MaxwellSNSProducer(MaxwellContext context, String topic) {
+		super(context);
+		this.topic = topic;
+		this.client = AmazonSNSAsyncClientBuilder.defaultClient();
+	}
+
+	public void setClient(AmazonSNSAsync client) {
+		this.client = client;
+	}
+
+	@Override
+	public void sendAsync(RowMap r, CallbackCompleter cc) throws Exception {
+		String value = r.toJSON();
+		// Publish a message to an Amazon SNS topic.
+		final PublishRequest publishRequest = new PublishRequest(topic, value);
+		Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
+		if (context.getConfig().snsTableAttribute) {
+			messageAttributes.put(
+					"table",
+					new MessageAttributeValue().withStringValue(r.getTable())
+			);
+		}
+		if (this.context.getConfig().snsDatabaseAttribute) {
+			messageAttributes.put(
+					"database",
+					new MessageAttributeValue().withStringValue(r.getDatabase())
+			);
+		}
+		if ( topic.endsWith(".fifo")) {
+			publishRequest.setMessageGroupId(r.getDatabase());
+		}
+		publishRequest.setMessageAttributes(messageAttributes);
+
+		SNSCallback callback = new SNSCallback(cc, r.getNextPosition(), value, context);
+		client.publishAsync(publishRequest, callback);
+	}
+
+}
+
+class SNSCallback implements AsyncHandler<PublishRequest, PublishResult> {
+	public static final Logger logger = LoggerFactory.getLogger(SNSCallback.class);
+
+	private final AbstractAsyncProducer.CallbackCompleter cc;
+	private final Position position;
+	private final String json;
+	private MaxwellContext context;
+
+	public SNSCallback(AbstractAsyncProducer.CallbackCompleter cc, Position position, String json,
+			MaxwellContext context) {
+		this.cc = cc;
+		this.position = position;
+		this.json = json;
+		this.context = context;
+	}
+
+	@Override
+	public void onError(Exception t) {
+		logger.error(t.getClass().getSimpleName() + " @ " + position + " -- ");
+		logger.error(t.getLocalizedMessage());
+		logger.error("Exception during put", t);
+
+		if (!context.getConfig().ignoreProducerError) {
+			context.terminate(new RuntimeException(t));
+		} else {
+			cc.markCompleted();
+		}
+	};
+
+	@Override
+	public void onSuccess(PublishRequest request, PublishResult result) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("-> MessageId: " + result.getMessageId());
+		}
+		cc.markCompleted();
+	}
+
+}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -39,14 +39,14 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 		Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
 		if (context.getConfig().snsTableAttribute) {
 			messageAttributes.put(
-					"table",
-					new MessageAttributeValue().withStringValue(r.getTable())
+				"table",
+				new MessageAttributeValue().withStringValue(r.getTable())
 			);
 		}
 		if (this.context.getConfig().snsDatabaseAttribute) {
 			messageAttributes.put(
-					"database",
-					new MessageAttributeValue().withStringValue(r.getDatabase())
+				"database",
+				new MessageAttributeValue().withStringValue(r.getDatabase())
 			);
 		}
 		if ( topic.endsWith(".fifo")) {

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -26,6 +26,7 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 	public MaxwellSNSProducer(MaxwellContext context, String topic) {
 		super(context);
 		this.topic = topic;
+		System.out.println(topic);
 		this.client = AmazonSNSAsyncClientBuilder.defaultClient();
 	}
 
@@ -45,15 +46,20 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 			for (String element: configuredAttributes.split(",")) {
 				switch (element) {
 					case "database":
-						messageAttributes.put("database", new MessageAttributeValue().withStringValue(r.getDatabase()));
+						messageAttributes.put(
+							"database",
+							new MessageAttributeValue().withDataType("String").withStringValue(r.getDatabase())
+						);
 						break;
 					case "table":
-						messageAttributes.put("table", new MessageAttributeValue().withStringValue(r.getTable()));
+						messageAttributes.put(
+							"table",
+							new MessageAttributeValue().withDataType("String").withStringValue(r.getTable())
+						);
 						break;
 				}
 			}
 		}
-
 
 		if ( topic.endsWith(".fifo")) {
 			publishRequest.setMessageGroupId(r.getDatabase());

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -26,7 +26,6 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 	public MaxwellSNSProducer(MaxwellContext context, String topic) {
 		super(context);
 		this.topic = topic;
-		System.out.println(topic);
 		this.client = AmazonSNSAsyncClientBuilder.defaultClient();
 	}
 

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -2,7 +2,6 @@ package com.zendesk.maxwell.producer;
 
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.sns.AmazonSNSAsync;
-import com.amazonaws.services.sns.AmazonSNSAsyncClient;
 import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
 import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishRequest;

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
@@ -94,12 +94,11 @@ public class MaxwellSNSProducerTest {
 
 	@Test
 	public void ensureMessageGroupIdOnFifo() throws Exception {
-		final String topic = "topic.fifo";
 		AmazonSNSAsyncClient client = Mockito.mock(AmazonSNSAsyncClient.class);
 		MaxwellContext context = mock(MaxwellContext.class);
 		when(context.getConfig()).thenReturn(new MaxwellConfig());
 		when(context.getMetrics()).thenReturn(new NoOpMetrics());
-		MaxwellSNSProducer producer = new MaxwellSNSProducer(context, topic);
+		MaxwellSNSProducer producer = new MaxwellSNSProducer(context, FIFO_TOPIC);
 		producer.setClient(client);
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
 		when(client.publishAsync(any())).thenReturn(mockedFuture);

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
@@ -1,0 +1,95 @@
+package com.zendesk.maxwell.producer;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSAsync;
+import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
+import com.amazonaws.services.sns.model.MessageAttributeValue;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import com.zendesk.maxwell.MaxwellConfig;
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.monitoring.NoOpMetrics;
+import com.zendesk.maxwell.replication.BinlogPosition;
+import com.zendesk.maxwell.replication.Position;
+import com.zendesk.maxwell.row.RowMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+public class MaxwellSNSProducerTest {
+
+	private static final long TIMESTAMP_MILLISECONDS = 1496712943447L;
+	private static final String TOPIC = "topic";
+	private static final String FIFO_TOPIC = "topic.fifo";
+	private static final Position POSITION = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
+	private static final Future<PublishResult> mockedFuture = Mockito.mock(Future.class);
+	@Rule
+	public final EnvironmentVariables environmentVariables
+			= new EnvironmentVariables();
+
+	@Captor ArgumentCaptor<PublishRequest> arguments;
+	RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", TIMESTAMP_MILLISECONDS, new ArrayList<String>(), POSITION);
+
+	@Before
+	public void beforeEach() {
+		environmentVariables.set("AWS_ACCESS_KEY_ID", "AKIACCESSKEY");
+		environmentVariables.set("AWS_SECRET_ACCESS_KEY", "SUPERSECRETKEY");
+		environmentVariables.set("AWS_REGION", "us-west-2");
+		environmentVariables.set("AWS_EC2_METADATA_DISABLED", "true");
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void publishesRecord() throws Exception {
+		AmazonSNSAsyncClient client = Mockito.mock(AmazonSNSAsyncClient.class);
+		MaxwellContext context = mock(MaxwellContext.class);
+		MaxwellConfig config = new MaxwellConfig();
+		when(context.getConfig()).thenReturn(config);
+		when(context.getMetrics()).thenReturn(new NoOpMetrics());
+		MaxwellSNSProducer producer = new MaxwellSNSProducer(context, TOPIC);
+		producer.setClient(client);
+		String payload = rowMap.toJSON();
+		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
+		when(client.publishAsync(any())).thenReturn(mockedFuture);
+		producer.sendAsync(rowMap, cc);
+		Mockito.verify(client, times(1)).publishAsync(arguments.capture(), any());
+		Assert.assertEquals(arguments.getValue().getTopicArn(), TOPIC);
+		Assert.assertEquals(arguments.getValue().getMessage(), payload);
+	}
+
+	@Test
+	public void setsMessageAttributes() throws Exception {
+		AmazonSNSAsyncClient client = Mockito.mock(AmazonSNSAsyncClient.class);
+		MaxwellContext context = mock(MaxwellContext.class);
+		MaxwellConfig config = new MaxwellConfig();
+		config.snsTableAttribute = true;
+		config.snsDatabaseAttribute = true;
+		when(context.getConfig()).thenReturn(config);
+		when(context.getMetrics()).thenReturn(new NoOpMetrics());
+		MaxwellSNSProducer producer = new MaxwellSNSProducer(context, TOPIC);
+		producer.setClient(client);
+		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
+		when(client.publishAsync(any())).thenReturn(mockedFuture);
+		producer.sendAsync(rowMap, cc);
+		Mockito.verify(client, times(1)).publishAsync(arguments.capture(), any());
+		Map<String, MessageAttributeValue> attributes = arguments.getValue().getMessageAttributes();
+		Assert.assertNotNull(attributes.getOrDefault("table", null));
+		Assert.assertEquals("MyTable", attributes.get("table").getStringValue());
+		Assert.assertNotNull(attributes.getOrDefault("database", null));
+		Assert.assertEquals("MyDatabase", attributes.get("database").getStringValue());
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
@@ -75,8 +75,7 @@ public class MaxwellSNSProducerTest {
 		AmazonSNSAsyncClient client = Mockito.mock(AmazonSNSAsyncClient.class);
 		MaxwellContext context = mock(MaxwellContext.class);
 		MaxwellConfig config = new MaxwellConfig();
-		config.snsTableAttribute = true;
-		config.snsDatabaseAttribute = true;
+		config.snsAttrs = "database,table";
 		when(context.getConfig()).thenReturn(config);
 		when(context.getMetrics()).thenReturn(new NoOpMetrics());
 		MaxwellSNSProducer producer = new MaxwellSNSProducer(context, TOPIC);


### PR DESCRIPTION
AWS SNS topics now support FIFO ordering and strict delivery. This allows maxwell to publish messages to an SNS topic, with optional `table` and `database` message attributes for subscription filtering

https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-sns-introduces-fifo-topics-with-strict-ordering-and-deduplication-of-messages/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zendesk/maxwell/1667)
<!-- Reviewable:end -->
