### PR TITLE
[Ready for Review] Proposal for allowing live updates to maxwell filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ config/*.yml
 .classpath
 .project
 .settings/
+.vscode/
 .factorypath
 .sts4-cache/

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -214,6 +214,7 @@ bootstrapper                   | [async &#124; sync &#124; none]                
 init_position                  | FILE:POSITION[:HEARTBEAT]           | ignore the information in maxwell.positions and start at the given binlog position. Not available in config.properties. |
 replay                         | BOOLEAN                             | enable maxwell's read-only "replay" mode: don't store a binlog position or schema changes.  Not available in config.properties. |
 buffer_memory_usage            | FLOAT                               | Determines how much memory the Maxwell event buffer will use from the jvm max memory. Size of the buffer is: buffer_memory_usage * -Xmx" | 0.25
+http_config                    | BOOLEAN                             | enable http config endpoint for config updates without restart | false
 
 
 <p id="loglevel" class="jumptarget">
@@ -268,6 +269,25 @@ environment variable names are case insensitive.  For example, if maxwell is
 started with `--env_config_prefix=FOO_` and the environment contains `FOO_USER=auser`,
 this would be equivalent to passing `--user=auser`.
 
+## via PATCH: /config
+If `http_config` is set to true in config.properties or in the environment,
+the endpoint /config will be exposed. Currently only filter updates are supported,
+and a filter can be updated with a request in the following format
+
+`PATCH: /config`
+```json
+{
+	"filter": "exclude: noisy_db.*"
+}
+```
+
+A get request will return the live config state
+`GET: /config`
+```json
+{
+	"filter": "exclude: noisy_db.*"
+}
+```
 
 ### Deployment scenarios
 ***

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -110,6 +110,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public MaxwellDiagnosticContext.Config diagnosticConfig;
 
+	public boolean enableHttpConfig;
+
 	public String clientID;
 	public Long replicaServerID;
 
@@ -482,6 +484,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "metrics_datadog_port", "the port to publish metrics to when metrics_datadog_type = udp" ).withRequiredArg().ofType(Integer.class);
 		parser.accepts( "http_diagnostic", "enable http diagnostic endpoint: true|false. default: false" ).withOptionalArg().ofType(Boolean.class);
 		parser.accepts( "http_diagnostic_timeout", "the http diagnostic response timeout in ms when http_diagnostic=true. default: 10000" ).withRequiredArg().ofType(Integer.class);
+		parser.accepts( "http_config", "enable http config update endpoint: true|false. default: false" ).withOptionalArg().ofType(Boolean.class);
 		parser.accepts( "metrics_jvm", "enable jvm metrics: true|false. default: false" ).withRequiredArg().ofType(Boolean.class);
 
 		parser.accepts( "help", "display help" ).withOptionalArg().forHelp();
@@ -655,6 +658,8 @@ public class MaxwellConfig extends AbstractConfig {
 		this.diagnosticConfig = new MaxwellDiagnosticContext.Config();
 		this.diagnosticConfig.enable = fetchBooleanOption("http_diagnostic", options, properties, false);
 		this.diagnosticConfig.timeout = fetchLongOption("http_diagnostic_timeout", options, properties, 10000L);
+
+		this.enableHttpConfig = fetchBooleanOption("http_config", options, properties, false);
 
 		this.includeDatabases    = fetchStringOption("include_dbs", options, properties, null);
 		this.excludeDatabases    = fetchStringOption("exclude_dbs", options, properties, null);

--- a/src/main/java/com/zendesk/maxwell/filtering/Filter.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/Filter.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class Filter {
 	static final Logger LOGGER = LoggerFactory.getLogger(Filter.class);
@@ -27,7 +28,14 @@ public class Filter {
 		patterns.addAll(new FilterParser(filterString).parse());
 	}
 
-	public void reset(String filterString) throws InvalidFilterException {
+	@Override
+	public String toString() {
+		return patterns.stream()
+			.map(FilterPattern::toString)
+			.collect(Collectors.joining(", "));
+	}
+
+	public void set(String filterString) throws InvalidFilterException {
 		List<FilterPattern> parsedFilter = new FilterParser(filterString).parse();
 		this.patterns.clear();
 		this.patterns.addAll(parsedFilter);

--- a/src/main/java/com/zendesk/maxwell/filtering/Filter.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/Filter.java
@@ -27,6 +27,12 @@ public class Filter {
 		patterns.addAll(new FilterParser(filterString).parse());
 	}
 
+	public void reset(String filterString) throws InvalidFilterException {
+		List<FilterPattern> parsedFilter = new FilterParser(filterString).parse();
+		this.patterns.clear();
+		this.patterns.addAll(parsedFilter);
+	}
+
 	public boolean isSystemWhitelisted(String database, String table) {
 		return isMaxwellDB(database)
 			&& ("bootstrap".equals(table) || "heartbeats".equals(table));

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
@@ -6,6 +6,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.filtering.InvalidFilterException;
 
@@ -14,10 +17,9 @@ import java.io.PrintWriter;
 import java.util.stream.Collectors;
 
 /**
- * An HTTP servlets which allows for the live reconfiguration of maxwell.
+ * An HTTP servlet which allows for the live reconfiguration of maxwell.
  */
 public class MaxwellConfigServlet extends HttpServlet {
-  private static final long serialVersionUID = 3772654177231086757L;
   private static final ObjectMapper mapper = new ObjectMapper();
   private final MaxwellContext context;
 
@@ -26,29 +28,59 @@ public class MaxwellConfigServlet extends HttpServlet {
     this.context = context;
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class SerializedConfig {
+    public String filter;
+  }
 
-  public static class ConfigRequest {
+  private static class ErrorResponse {
+    public int code;
+    public String message;
 
-    private String filter;
+    public ErrorResponse(int code, String message) {
+      this.code = code;
+      this.message = message;
+    }
 
-    public String getFilter() {
-      return this.filter;
+    public static String getErrorResponseString(int code, String message) throws JsonProcessingException {
+      ErrorResponse errResponse = new ErrorResponse(code, message);
+      return String.format("{\"error\":%s}",  mapper.writeValueAsString(errResponse));
     }
   }
 
-  protected void doPatch(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+  protected void doPatch(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    SerializedConfig sconfig;
     try {
       String reqbody = req.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
-      ConfigRequest creq = mapper.readValue(reqbody, ConfigRequest.class);
-      this.context.getFilter().reset(creq.getFilter());
+      sconfig = mapper.readValue(reqbody, SerializedConfig.class);
+    } catch(Exception e) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      try (PrintWriter writer = resp.getWriter()) {
+        writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST, String.format("error processing body: %s", e.getMessage())));
+      }
+      return;
+    }
+
+    try {
+      applySerializedConfig(sconfig);
 
       resp.setStatus(HttpServletResponse.SC_OK);
+      try (PrintWriter writer = resp.getWriter()) {
+        writer.println(getSerializedConfig());
+      }
     } catch (InvalidFilterException e) {
       resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       try (PrintWriter writer = resp.getWriter()) {
-        writer.println("INVALID FILTER");
+        writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST, String.format("invalid filter: %s", e.getMessage())));
       }
     }
+  }
+
+  @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    resp.setStatus(HttpServletResponse.SC_OK);
+      try (PrintWriter writer = resp.getWriter()) {
+        writer.println(getSerializedConfig());
+      }
   }
 
   @Override
@@ -60,4 +92,15 @@ public class MaxwellConfigServlet extends HttpServlet {
     }
   }
 
+  private String getSerializedConfig() throws JsonProcessingException {
+    SerializedConfig sconfig = new SerializedConfig();
+    sconfig.filter = this.context.getFilter().toString();
+    return mapper.writeValueAsString(sconfig);
+  }
+
+  private void applySerializedConfig(SerializedConfig sconfig) throws InvalidFilterException {
+    if (sconfig.filter != null) {
+      context.getFilter().set(sconfig.filter);
+    }
+  }
 }

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
@@ -120,7 +120,10 @@ public class MaxwellConfigServlet extends HttpServlet {
 
 	private String getSerializedConfig() throws JsonProcessingException {
 		SerializedConfig sconfig = new SerializedConfig();
-		sconfig.filter = this.context.getFilter().toString();
+		String filterstring = this.context.getFilter().toString();
+		if (!filterstring.equals("")) {
+			sconfig.filter = filterstring;
+		}
 		return mapper.writeValueAsString(sconfig);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
@@ -6,7 +6,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.zendesk.maxwell.MaxwellContext;
@@ -20,99 +19,101 @@ import java.io.PrintWriter;
 import java.util.stream.Collectors;
 
 /**
- * An HTTP servlet which allows for the live reconfiguration of maxwell.
- * If property provided for update is null, it will be ignored.
+ * An HTTP servlet which allows for the live reconfiguration of maxwell. If
+ * property provided for update is null, it will be ignored.
  */
 public class MaxwellConfigServlet extends HttpServlet {
-  private static final java.lang.String CONTENT_TYPE = "application/json";
-  private static final ObjectMapper mapper = new ObjectMapper();
-  static final Logger LOGGER = LoggerFactory.getLogger(MaxwellConfigServlet.class);
-  private final MaxwellContext context;
+	private static final java.lang.String CONTENT_TYPE = "application/json";
+	private static final ObjectMapper mapper = new ObjectMapper();
+	static final Logger LOGGER = LoggerFactory.getLogger(MaxwellConfigServlet.class);
+	private final MaxwellContext context;
 
+	public MaxwellConfigServlet(MaxwellContext context) {
+		super();
+		this.context = context;
+	}
 
-  public MaxwellConfigServlet(MaxwellContext context) {
-    super();
-    this.context = context;
-  }
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	private static class SerializedConfig {
+		public String filter;
+	}
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  private static class SerializedConfig {
-    public String filter;
-  }
+	private static class ErrorResponse {
+		public int code;
+		public String message;
 
-  private static class ErrorResponse {
-    public int code;
-    public String message;
+		public ErrorResponse(int code, String message) {
+			this.code = code;
+			this.message = message;
+		}
 
-    public ErrorResponse(int code, String message) {
-      this.code = code;
-      this.message = message;
-    }
+		public static String getErrorResponseString(int code, String message) throws JsonProcessingException {
+			ErrorResponse errResponse = new ErrorResponse(code, message);
+			return String.format("{\"error\":%s}", mapper.writeValueAsString(errResponse));
+		}
+	}
 
-    public static String getErrorResponseString(int code, String message) throws JsonProcessingException {
-      ErrorResponse errResponse = new ErrorResponse(code, message);
-      return String.format("{\"error\":%s}",  mapper.writeValueAsString(errResponse));
-    }
-  }
+	protected void doPatch(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+		SerializedConfig sconfig;
+		try {
+			String reqbody = req.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+			sconfig = mapper.readValue(reqbody, SerializedConfig.class);
+		} catch (Exception e) {
+			resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			resp.setContentType(CONTENT_TYPE);
+			try (PrintWriter writer = resp.getWriter()) {
+				writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST,
+						String.format("error processing body: %s", e.getMessage())));
+			}
+			return;
+		}
 
-  protected void doPatch(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    SerializedConfig sconfig;
-    try {
-      String reqbody = req.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
-      sconfig = mapper.readValue(reqbody, SerializedConfig.class);
-    } catch(Exception e) {
-      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-      resp.setContentType(CONTENT_TYPE);
-      try (PrintWriter writer = resp.getWriter()) {
-        writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST, String.format("error processing body: %s", e.getMessage())));
-      }
-      return;
-    }
+		try {
+			applySerializedConfig(sconfig);
 
-    try {
-      applySerializedConfig(sconfig);
+			resp.setStatus(HttpServletResponse.SC_OK);
+			resp.setContentType(CONTENT_TYPE);
+			try (PrintWriter writer = resp.getWriter()) {
+				writer.println(getSerializedConfig());
+			}
+		} catch (InvalidFilterException e) {
+			resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			resp.setContentType(CONTENT_TYPE);
+			try (PrintWriter writer = resp.getWriter()) {
+				writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST,
+						String.format("invalid filter: %s", e.getMessage())));
+			}
+		}
+	}
 
-      resp.setStatus(HttpServletResponse.SC_OK);
-      resp.setContentType(CONTENT_TYPE);
-      try (PrintWriter writer = resp.getWriter()) {
-        writer.println(getSerializedConfig());
-      }
-    } catch (InvalidFilterException e) {
-      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-      resp.setContentType(CONTENT_TYPE);
-      try (PrintWriter writer = resp.getWriter()) {
-        writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST, String.format("invalid filter: %s", e.getMessage())));
-      }
-    }
-  }
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+		resp.setStatus(HttpServletResponse.SC_OK);
+		resp.setContentType(CONTENT_TYPE);
+		try (PrintWriter writer = resp.getWriter()) {
+			writer.println(getSerializedConfig());
+		}
+	}
 
-  @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    resp.setStatus(HttpServletResponse.SC_OK);
-    resp.setContentType(CONTENT_TYPE);
-      try (PrintWriter writer = resp.getWriter()) {
-        writer.println(getSerializedConfig());
-      }
-  }
+	@Override
+	public void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		if (request.getMethod().equalsIgnoreCase("PATCH")) {
+			doPatch(request, response);
+		} else {
+			super.service(request, response);
+		}
+	}
 
-  @Override
-  public void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-    if (request.getMethod().equalsIgnoreCase("PATCH")) {
-      doPatch(request, response);
-    } else {
-      super.service(request, response);
-    }
-  }
+	private String getSerializedConfig() throws JsonProcessingException {
+		SerializedConfig sconfig = new SerializedConfig();
+		sconfig.filter = this.context.getFilter().toString();
+		return mapper.writeValueAsString(sconfig);
+	}
 
-  private String getSerializedConfig() throws JsonProcessingException {
-    SerializedConfig sconfig = new SerializedConfig();
-    sconfig.filter = this.context.getFilter().toString();
-    return mapper.writeValueAsString(sconfig);
-  }
-
-  private void applySerializedConfig(SerializedConfig sconfig) throws InvalidFilterException {
-    if (sconfig.filter != null) {
-      context.getFilter().set(sconfig.filter);
-      LOGGER.info("updated filter: " + sconfig.filter);
-    }
-  }
+	private void applySerializedConfig(SerializedConfig sconfig) throws InvalidFilterException {
+		if (sconfig.filter != null) {
+			context.getFilter().set(sconfig.filter);
+			LOGGER.info("updated filter: " + sconfig.filter);
+		}
+	}
 }

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
@@ -53,7 +53,7 @@ public class MaxwellConfigServlet extends HttpServlet {
 		}
 	}
 
-	protected void doPatch(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+	private void handleConfigUpdateRequest(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		SerializedConfig sconfig;
 		try {
 			String reqbody = req.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
@@ -84,6 +84,20 @@ public class MaxwellConfigServlet extends HttpServlet {
 						String.format("invalid filter: %s", e.getMessage())));
 			}
 		}
+	}
+
+	@Override
+	protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+		this.handleConfigUpdateRequest(req, resp);
+	}
+
+	@Override
+	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+		this.handleConfigUpdateRequest(req, resp);
+	}
+
+	protected void doPatch(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+		this.handleConfigUpdateRequest(req, resp);
 	}
 
 	@Override

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
@@ -18,10 +18,13 @@ import java.util.stream.Collectors;
 
 /**
  * An HTTP servlet which allows for the live reconfiguration of maxwell.
+ * If property provided for update is null, it will be ignored.
  */
 public class MaxwellConfigServlet extends HttpServlet {
+  private static final java.lang.String CONTENT_TYPE = "application/json";
   private static final ObjectMapper mapper = new ObjectMapper();
   private final MaxwellContext context;
+
 
   public MaxwellConfigServlet(MaxwellContext context) {
     super();
@@ -55,6 +58,7 @@ public class MaxwellConfigServlet extends HttpServlet {
       sconfig = mapper.readValue(reqbody, SerializedConfig.class);
     } catch(Exception e) {
       resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      resp.setContentType(CONTENT_TYPE);
       try (PrintWriter writer = resp.getWriter()) {
         writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST, String.format("error processing body: %s", e.getMessage())));
       }
@@ -65,11 +69,13 @@ public class MaxwellConfigServlet extends HttpServlet {
       applySerializedConfig(sconfig);
 
       resp.setStatus(HttpServletResponse.SC_OK);
+      resp.setContentType(CONTENT_TYPE);
       try (PrintWriter writer = resp.getWriter()) {
         writer.println(getSerializedConfig());
       }
     } catch (InvalidFilterException e) {
       resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      resp.setContentType(CONTENT_TYPE);
       try (PrintWriter writer = resp.getWriter()) {
         writer.println(ErrorResponse.getErrorResponseString(HttpServletResponse.SC_BAD_REQUEST, String.format("invalid filter: %s", e.getMessage())));
       }
@@ -78,6 +84,7 @@ public class MaxwellConfigServlet extends HttpServlet {
 
   @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     resp.setStatus(HttpServletResponse.SC_OK);
+    resp.setContentType(CONTENT_TYPE);
       try (PrintWriter writer = resp.getWriter()) {
         writer.println(getSerializedConfig());
       }

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
@@ -1,0 +1,63 @@
+package com.zendesk.maxwell.monitoring;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zendesk.maxwell.MaxwellContext;
+import com.zendesk.maxwell.filtering.InvalidFilterException;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.stream.Collectors;
+
+/**
+ * An HTTP servlets which allows for the live reconfiguration of maxwell.
+ */
+public class MaxwellConfigServlet extends HttpServlet {
+  private static final long serialVersionUID = 3772654177231086757L;
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private final MaxwellContext context;
+
+  public MaxwellConfigServlet(MaxwellContext context) {
+    super();
+    this.context = context;
+  }
+
+
+  public static class ConfigRequest {
+
+    private String filter;
+
+    public String getFilter() {
+      return this.filter;
+    }
+  }
+
+  protected void doPatch(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    try {
+      String reqbody = req.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+      ConfigRequest creq = mapper.readValue(reqbody, ConfigRequest.class);
+      this.context.getFilter().reset(creq.getFilter());
+
+      resp.setStatus(HttpServletResponse.SC_OK);
+    } catch (InvalidFilterException e) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      try (PrintWriter writer = resp.getWriter()) {
+        writer.println("INVALID FILTER");
+      }
+    }
+  }
+
+  @Override
+  public void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    if (request.getMethod().equalsIgnoreCase("PATCH")) {
+      doPatch(request, response);
+    } else {
+      super.service(request, response);
+    }
+  }
+
+}

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellConfigServlet.java
@@ -12,6 +12,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.filtering.InvalidFilterException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.stream.Collectors;
@@ -23,6 +26,7 @@ import java.util.stream.Collectors;
 public class MaxwellConfigServlet extends HttpServlet {
   private static final java.lang.String CONTENT_TYPE = "application/json";
   private static final ObjectMapper mapper = new ObjectMapper();
+  static final Logger LOGGER = LoggerFactory.getLogger(MaxwellConfigServlet.class);
   private final MaxwellContext context;
 
 
@@ -108,6 +112,7 @@ public class MaxwellConfigServlet extends HttpServlet {
   private void applySerializedConfig(SerializedConfig sconfig) throws InvalidFilterException {
     if (sconfig.filter != null) {
       context.getFilter().set(sconfig.filter);
+      LOGGER.info("updated filter: " + sconfig.filter);
     }
   }
 }

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
@@ -26,7 +26,7 @@ public class MaxwellHTTPServer {
 	public static void startIfRequired(MaxwellContext context) throws IOException {
 		MaxwellMetrics.Registries metricsRegistries = getMetricsRegistries(context);
 		MaxwellDiagnosticContext diagnosticContext = getDiagnosticContext(context);
-		if (metricsRegistries != null || diagnosticContext != null) {
+		if (metricsRegistries != null || diagnosticContext != null || context.getConfig().enableHttpConfig) {
 			LOGGER.info("Maxwell http server starting");
 			int port = context.getConfig().httpPort;
 			String httpBindAddress = context.getConfig().httpBindAddress;
@@ -101,6 +101,9 @@ class MaxwellHTTPServerWorker implements StoppableTask, Runnable {
 			handler.addServlet(new ServletHolder(new io.prometheus.client.exporter.MetricsServlet()), "/prometheus");
 			handler.addServlet(new ServletHolder(new HealthCheckServlet(metricsRegistries.healthCheckRegistry)), "/healthcheck");
 			handler.addServlet(new ServletHolder(new PingServlet()), "/ping");
+		}
+
+		if (this.context.getConfig().enableHttpConfig) {
 			handler.addServlet(new ServletHolder(new MaxwellConfigServlet(this.context)), "/config");
 		}
 

--- a/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
+++ b/src/test/java/com/zendesk/maxwell/filtering/FilterTest.java
@@ -129,6 +129,38 @@ public class FilterTest {
 	}
 
 	@Test
+	public void TestSetValidFilter() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+		f.set("blacklist: seria.*");
+		assertEquals(f.toString(), "blacklist: seria.*");
+	}
+
+	@Test
+	public void TestSetInvalidFilter() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+		try {
+			f.set("bl: seria.*");
+		} catch (InvalidFilterException e) {
+			// do nothing
+		}
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+	}
+
+	@Test
+	public void TestToString() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+	}
+
+	@Test
+	public void TestEmptyToString() throws Exception {
+		Filter f = new Filter("");
+		assertEquals(f.toString(), "");
+	}
+
+	@Test
 	public void TestOldFiltersExcludeDB() throws Exception {
 		Filter f = Filter.fromOldFormat("maxwell", null, "foo, /bar/", null, null, null, null, null);
 		List<FilterPattern> rules = f.getRules();

--- a/src/test/java/com/zendesk/maxwell/monitoring/MaxwellHttpConfigIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/monitoring/MaxwellHttpConfigIntegrationTest.java
@@ -56,7 +56,7 @@ public class MaxwellHttpConfigIntegrationTest extends MaxwellTestWithIsolatedSer
 						// test get
 						HttpResponse<String> cfg = getConfig();
 						Assert.assertEquals(cfg.statusCode(), 200);
-						Assert.assertEquals(cfg.body(), "{\"filter\":\"\"}\n");
+						Assert.assertEquals(cfg.body(), "{\"filter\":null}\n");
 
 						// test valid post
 						updateConfig("PUT", "exclude: *.*, blacklist: bad_db.*");

--- a/src/test/java/com/zendesk/maxwell/monitoring/MaxwellHttpConfigIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/monitoring/MaxwellHttpConfigIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.zendesk.maxwell.monitoring;
+
+import com.zendesk.maxwell.*;
+import com.zendesk.maxwell.row.RowMap;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.*;
+import java.util.List;
+
+public class MaxwellHttpConfigIntegrationTest extends MaxwellTestWithIsolatedServer {
+
+	private HttpResponse<String> getConfig() throws IOException, InterruptedException {
+		HttpClient client = HttpClient.newHttpClient();
+		HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://localhost:22222/config"))
+		.build();
+		return client.send(request, HttpResponse.BodyHandlers.ofString());
+	}
+
+	private HttpResponse<String> patchConfig(String filter) throws IOException, InterruptedException {
+		HttpClient client = HttpClient.newHttpClient();
+		HttpRequest request = HttpRequest.newBuilder()
+		.method("PATCH", HttpRequest.BodyPublishers.ofString(String.format("{\"filter\":\"%s\"}", filter)))
+    .uri(URI.create("http://localhost:22222/config"))
+		.build();
+		return client.send(request, HttpResponse.BodyHandlers.ofString());
+	}
+
+	private boolean probeHTTP() {
+		try {
+			// Create a neat value object to hold the URL
+			URL url = new URL("http://localhost:22222/config");
+
+			HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+			InputStream responseStream = connection.getInputStream();
+
+			responseStream.read();
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+
+	}
+	@Test
+	public void testHTTPEndpoint() throws Exception {
+		MaxwellTestSupportCallback cb = new MaxwellTestSupportCallback() {
+			@Override
+			public void beforeTerminate(MysqlIsolatedServer mysql) throws Exception {
+				for ( int i = 0 ; i < 5; i++ ) {
+					if ( probeHTTP() ) {
+						// test get
+						HttpResponse<String> cfg = getConfig();
+						Assert.assertEquals(cfg.statusCode(), 200);
+						Assert.assertEquals(cfg.body(), "{\"filter\":\"\"}\n");
+
+						// test valid patch
+						patchConfig("exclude: *.*, blacklist: bad_db.*");
+						cfg = getConfig();
+						Assert.assertEquals(cfg.statusCode(), 200);
+						Assert.assertEquals(cfg.body(), "{\"filter\":\"exclude: *.*, blacklist: bad_db.*\"}\n");
+
+						// test invalid patch
+						cfg = patchConfig("\"{");
+						Assert.assertEquals(cfg.statusCode(), 400);
+						Assert.assertEquals(cfg.body(), "{\"error\":{\"code\":400,\"message\":\"error processing body: Unexpected character ('{' (code 123)): was expecting comma to separate Object entries\\n at [Source: (String)\\\"{\\\"filter\\\":\\\"\\\"{\\\"}\\\"; line: 1, column: 14]\"}}\n");
+						cfg = getConfig();
+						Assert.assertEquals(cfg.body(), "{\"filter\":\"exclude: *.*, blacklist: bad_db.*\"}\n");
+
+						// test invalid filter in patch
+						cfg = patchConfig("bl: *.*");
+						Assert.assertEquals(cfg.statusCode(), 400);
+						Assert.assertEquals(cfg.body(), "{\"error\":{\"code\":400,\"message\":\"invalid filter: Unknown filter keyword: bl\"}}\n");
+						cfg = getConfig();
+						Assert.assertEquals(cfg.body(), "{\"filter\":\"exclude: *.*, blacklist: bad_db.*\"}\n");
+						return;
+					}
+					try { Thread.sleep(1000); } catch ( InterruptedException e ) {
+					}
+				}
+				Assert.assertFalse("failed to connect to http server after 5 seconds!", false);
+			}
+		};
+		MaxwellTestSupport.getRowsWithReplicator(server, cb, (config) -> {
+			config.httpPort = 22222;
+			config.enableHttpConfig = true;
+		});
+
+	}
+}


### PR DESCRIPTION
We are also having issues with wanting to quickly turn on and off maxwell filters. I saw with issue #1615 that we were not the only ones having this issue. My proposal is pretty simple: expose an http endpoint `PATCH: /config` that would allow a user to supply a json containing the new filter, and update it live.

```JSON
{
  "filter":"exclude: dynamic_db.*"
}
```

I have some sample code here with it working, @osheroff please let me know if this is an avenue that you think we could pursue, and I will add tests and move the servlet outside of the metricsRegistries group.