### PR TITLE
CVE-2020-8908: updated guava to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.1.1-jre</version>
+      <version>30.1.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
@@ -133,7 +134,7 @@ public class MaxwellKinesisProducer extends AbstractAsyncProducer {
 
 		try {
 			ListenableFuture<UserRecordResult> future = kinesisProducer.addUserRecord(kinesisStream, key, encodedValue);
-			Futures.addCallback(future, callback);
+			Futures.addCallback(future, callback, MoreExecutors.directExecutor());
 		} catch(IllegalArgumentException t) {
 			callback.onFailure(t);
 			logger.error("Database:" + r.getDatabase() + ", Table:" + r.getTable() + ", PK:" + r.getRowIdentity().toConcatString() + ", Size:" + Integer.toString(vsize));


### PR DESCRIPTION
Hi @osheroff 

Our CI found a security vulnerability in the version of guava that is being used. This is a pretty old version so there was a contract change to the `addCallback` function to explicitly require an executor. Before it would use directExecutor by default.

I went through the changelogs and summarized all breaking changes (non-bugfix or function additions) here. Other than the explicit executor, it doesnt look like there is anything more that needs to be done.

In active use on maxwell:
util.concurrent
collect.Iterable

**25.1**
util.concurrent: Added @DoNotCall to Futures methods that do not accept an Executor in preparation for removal. (49a1df6)

**26.0**
concurrent: Removed deprecated Futures methods that implicitly use directExecutor(). (87d87f5)
concurrent: Removed special-casing UndeclaredThrowableException in Futures.transform(). (9466b62)

**27.0**
concurrent: AbstractFuture doesn't expose FluentFuture APIs anymore. (0f8d360)

**28.0**
concurrent: Removed deprecated CheckedFuture and related utilities. (3dd22fe)
concurrent: Removed @Beta from setFuture. (5ec1360)

**29.0**
util.concurrent: Removed @Beta from Service and related classes. (dc46627)
util.concurrent: Deprecated the 1-arg overload of ServiceManager.addListener. (86e3620)
util.concurrent: Changed the return type of ServiceManager.servicesByState() to ImmutableSetMultimap (but also retained a method with the old signature for binary compatibility). (31999ae)

**30.0**
collect: Removed @Beta from Multimaps.toMultimap. (b6b4dc4)
collect: Made the set returned by ImmutableMap<K, V>.keySet() serializable as long as K is serializable, even if V is not (and similarly for values()). (f5a69c3)
collect: Fixed bug in powerSet.equals(otherPowerSet) would erroneously return false if the two power sets' underlying sets were equal but had a different iteration order. (215b1f0)
collect: Eliminated j2objc retain-cycle in SingletonImmutableBiMap. (0ad38b8)

util.concurrent: Removed the deprecated 1-arg ServiceManager.addListener(Listener). Use the 2-arg addListener(Listener, Executor) overload, setting the executor to directExecutor() for equivalent behavior. (dfb0001)
util.concurrent: Changed AbstractFuture.toString() to no longer include the toString() of the result. (2ebf27f)

**30.1.1**
collect: Added @DoNotCall to the mutator methods on immutable types (6ae9532)