### PR TITLE
Use replication JDBC options in bootstrap utility

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
@@ -36,16 +36,8 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 
 
 	public String getConnectionURI() {
-		URIBuilder uriBuilder = new URIBuilder();
-		uriBuilder.setScheme("jdbc:mysql");
-		uriBuilder.setHost(mysql.host);
-		uriBuilder.setPort(mysql.port);
-		uriBuilder.setPath("/" + schemaDatabaseName);
-		for (Map.Entry<String, String> jdbcOption : mysql.jdbcOptions.entrySet()) {
-			uriBuilder.addParameter(jdbcOption.getKey(), jdbcOption.getValue());
-		}
 		try {
-			return uriBuilder.build().toString();
+			return getConfigConnectionURI(mysql);
 		} catch (URISyntaxException e) {
 			LOGGER.error(e.getMessage(), e);
 			throw new RuntimeException("Unable to generate bootstrap's jdbc connection URI", e);
@@ -53,7 +45,24 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 	}
 
 	public String getReplicationConnectionURI( ) {
-		return "jdbc:mysql://" + replicationMysql.host + ":" + replicationMysql.port;
+		try {
+			return getConfigConnectionURI(replicationMysql);
+		} catch (URISyntaxException e) {
+			LOGGER.error(e.getMessage(), e);
+			throw new RuntimeException("Unable to generate bootstrap's replication jdbc connection URI", e);
+		}
+	}
+
+	private String getConfigConnectionURI(MaxwellMysqlConfig config) throws URISyntaxException {
+		URIBuilder uriBuilder = new URIBuilder();
+		uriBuilder.setScheme("jdbc:mysql");
+		uriBuilder.setHost(config.host);
+		uriBuilder.setPort(config.port);
+		uriBuilder.setPath("/" + schemaDatabaseName);
+		for (Map.Entry<String, String> jdbcOption : config.jdbcOptions.entrySet()) {
+			uriBuilder.addParameter(jdbcOption.getKey(), jdbcOption.getValue());
+		}
+		return uriBuilder.build().toString();
 	}
 
 	protected OptionParser buildOptionParser() {


### PR DESCRIPTION
Hello!

The database I am using has different timezone other than UTC. I configured Maxwell's `config.properties` to account for this in the JDBC connection, but noticed that the bootstrap utility was not reading these values properly: 

```
Caused by: java.sql.SQLException: The server time zone value 'CDT' is unrecognized or represents more than one time zone. You must configure either the server or JDBC driver (via the serverTimezone configuration property) to use a more specifc time zone value if you want to utilize time zone support
```

It looks like it was reading `jdbc_options` correctly, but not `replication_jdbc_options`. This change fixes that so that the replication URI is generated similarly to the connection URI. 

Cheers!