### PR TITLE
support start transaction ddl for mysql 8.0

### DIFF
--- a/src/main/antlr4/imports/mysql_create_table.g4
+++ b/src/main/antlr4/imports/mysql_create_table.g4
@@ -44,6 +44,7 @@ table_creation_option:
 	| creation_tablespace
 	| creation_union
 	| creation_encryption
+	| start_start_transaction
 	| partition_by;
 
 
@@ -72,4 +73,5 @@ creation_storage_option: STORAGE (DISK | MEMORY | DEFAULT);
 creation_tablespace: TABLESPACE string;
 creation_union: UNION '='? '(' name (',' name)* ')';
 creation_encryption: ENCRYPTION '='? string_literal;
+start_start_transaction: START_TRANSACTION;
 

--- a/src/main/antlr4/imports/mysql_literal_tokens.g4
+++ b/src/main/antlr4/imports/mysql_literal_tokens.g4
@@ -221,6 +221,7 @@ WITH: W I T H;
 WITHOUT: W I T H O U T;
 YEAR: Y E A R;
 ZEROFILL: Z E R O F I L L;
+START_TRANSACTION: S T A R T ' ' T R A N S A C T I O N;
 fragment A: [Aa];
 fragment B: [Bb];
 fragment C: [Cc];


### PR DESCRIPTION
When the "create table xx as select * from xxx" statement is executed, the SQL parsing error will occur, and the affected version is MySQL 8.0. 

The error recurred as follows， for example:
step 1: start maxwell
./bin/maxwell --password 123456

step 2: DDL
mysql> create table test as select * from t_test limit 5;

then error occurs, detail following:

23:55:48,939 ERROR MysqlParserListener - (parse (statement (create_table (create_table_preamble CREATE TABLE (table_name (name (id test)))) (create_specifications ( (create_specification (column_definition (name (id id)) (data_type (signed_type int (column_options (default_value DEFAULT (literal_with_weirdo_multistring NULL))))))) , (create_specification (column_definition (name (id name)) (data_type (string_type varchar (length ( 200 )) (column_options (default_value DEFAULT (literal_with_weirdo_multistring NULL))))))) )))) START TRANSACTION)
23:55:48,940 ERROR SchemaChange - Error parsing SQL: 'CREATE TABLE test (
id int DEFAULT NULL,
name varchar(200) DEFAULT NULL
) START TRANSACTION'
23:55:48,940 INFO ContextHandler - Started o.e.j.s.ServletContextHandler@332ada20{/,null,AVAILABLE}
23:55:48,940 ERROR AbstractSchemaStore - Error on bin log position Position[BinlogPosition[binlog.000007:20809], lastHeartbeat=1619536894013]

