### PR TITLE
Add env_config option for config.properties alternative

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -182,8 +182,6 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "env_config", "json object encoded config in an environment variable, alternative to config option" )
 				.availableUnless("config")
 				.withRequiredArg();
-		parser.accepts( "config_prefix", "prefix of maxwell configuration variables inside of the properties file, case insensitive" )
-				.withRequiredArg();
 
 		parser.separator();
 
@@ -493,14 +491,13 @@ public class MaxwellConfig extends AbstractConfig {
 		OptionSet options = parser.parse(argv);
 
 		final Properties properties;
-		final String configPrefix = options.has("config_prefix") ? (String) options.valueOf("config_prefix") : null;
 
 		if (options.has("config")) {
-			properties = getPrefixedFilteredProperties(parseFile((String) options.valueOf("config"), true), configPrefix);
+			properties = parseFile((String) options.valueOf("config"), true);
 		} else if (options.has("env_config")) {
-			properties = getPrefixedFilteredProperties(readPropertiesEnv((String) options.valueOf("env_config")), configPrefix);
+			properties = readPropertiesEnv((String) options.valueOf("env_config"));
 		} else {
-			properties = getPrefixedFilteredProperties(parseFile(DEFAULT_CONFIG_FILE, false), configPrefix);
+			properties = parseFile(DEFAULT_CONFIG_FILE, false);
 		}
 
 		String envConfigPrefix = fetchStringOption("env_config_prefix", options, properties, null);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -179,8 +179,7 @@ public class MaxwellConfig extends AbstractConfig {
 		final MaxwellOptionParser parser = new MaxwellOptionParser();
 		parser.accepts( "config", "location of config.properties file" )
 				.withRequiredArg();
-		parser.accepts( "env_config", "json object encoded config in an environment variable, alternative to config option" )
-				.availableUnless("config")
+		parser.accepts( "env_config", "json object encoded config in an environment variable" )
 				.withRequiredArg();
 
 		parser.separator();
@@ -494,10 +493,18 @@ public class MaxwellConfig extends AbstractConfig {
 
 		if (options.has("config")) {
 			properties = parseFile((String) options.valueOf("config"), true);
-		} else if (options.has("env_config")) {
-			properties = readPropertiesEnv((String) options.valueOf("env_config"));
 		} else {
 			properties = parseFile(DEFAULT_CONFIG_FILE, false);
+		}
+
+		if (options.has("env_config")) {
+			Properties envConfigProperties = readPropertiesEnv((String) options.valueOf("env_config"));
+			for (Map.Entry<Object, Object> entry : envConfigProperties.entrySet()) {
+				Object key = entry.getKey();
+				if (properties.put(key, entry.getValue()) != null) {
+					LOGGER.debug("Replaced config key {} with value from env_config", key);
+				}
+			}
 		}
 
 		String envConfigPrefix = fetchStringOption("env_config_prefix", options, properties, null);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -506,7 +506,15 @@ public class MaxwellConfig extends AbstractConfig {
 			String prefix = envConfigPrefix.toLowerCase();
 			System.getenv().entrySet().stream()
 					.filter(map -> map.getKey().toLowerCase().startsWith(prefix))
-					.forEach(config -> properties.put(config.getKey().toLowerCase().replaceFirst(prefix, ""), config.getValue()));
+					.forEach(config -> {
+						String rawKey = config.getKey();
+						String newKey = rawKey.toLowerCase().replaceFirst(prefix, "");
+						if (properties.put(newKey, config.getValue()) != null) {
+							LOGGER.debug("Got env variable {} and replacing config key {}", rawKey, newKey);
+						} else {
+							LOGGER.debug("Got env variable {} as config key {}", rawKey, newKey);
+						}
+					});
 		}
 
 		if (options.has("help"))

--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
@@ -63,8 +63,6 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 		parser.accepts( "env_config", "json object encoded config in an environment variable, alternative to config option" )
 				.availableUnless("config")
 				.withRequiredArg();
-		parser.accepts( "config_prefix", "prefix of maxwell configuration variables inside of the properties file, case insensitive" )
-				.withRequiredArg();
 		parser.accepts( "__separator_1", "" );
 		parser.accepts( "database", "database that contains the table to bootstrap").withRequiredArg();
 		parser.accepts( "table", "table to bootstrap").withRequiredArg();
@@ -113,14 +111,13 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 		OptionSet options = buildOptionParser().parse(argv);
 
 		final Properties properties;
-		final String configPrefix = options.has("config_prefix") ? (String) options.valueOf("config_prefix") : null;
 
 		if (options.has("config")) {
-			properties = getPrefixedFilteredProperties(parseFile((String) options.valueOf("config"), true), configPrefix);
+			properties = parseFile((String) options.valueOf("config"), true);
 		} else if (options.has("env_config")) {
-			properties = getPrefixedFilteredProperties(readPropertiesEnv((String) options.valueOf("env_config")), configPrefix);
+			properties = readPropertiesEnv((String) options.valueOf("env_config"));
 		} else {
-			properties = getPrefixedFilteredProperties(parseFile(DEFAULT_CONFIG_FILE, false), configPrefix);
+			properties = parseFile(DEFAULT_CONFIG_FILE, false);
 		}
 
 		if ( options.has("help") )

--- a/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/MaxwellBootstrapUtilityConfig.java
@@ -60,8 +60,7 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 		OptionParser parser = new OptionParser();
 		parser.accepts( "config", "location of config.properties file" )
 				.withRequiredArg();
-		parser.accepts( "env_config", "json object encoded config in an environment variable, alternative to config option" )
-				.availableUnless("config")
+		parser.accepts( "env_config", "json object encoded config in an environment variable" )
 				.withRequiredArg();
 		parser.accepts( "__separator_1", "" );
 		parser.accepts( "database", "database that contains the table to bootstrap").withRequiredArg();
@@ -114,12 +113,19 @@ public class MaxwellBootstrapUtilityConfig extends AbstractConfig {
 
 		if (options.has("config")) {
 			properties = parseFile((String) options.valueOf("config"), true);
-		} else if (options.has("env_config")) {
-			properties = readPropertiesEnv((String) options.valueOf("env_config"));
 		} else {
 			properties = parseFile(DEFAULT_CONFIG_FILE, false);
 		}
 
+		if (options.has("env_config")) {
+			Properties envConfigProperties = readPropertiesEnv((String) options.valueOf("env_config"));
+			for (Map.Entry<Object, Object> entry : envConfigProperties.entrySet()) {
+				Object key = entry.getKey();
+				if (properties.put(key, entry.getValue()) != null) {
+					LOGGER.debug("Replaced config key {} with value from env_config", key);
+				}
+			}
+		}
 		if ( options.has("help") )
 			usage("Help for Maxwell Bootstrap Utility:\n\nPlease provide one of:\n--database AND --table, --abort ID, or --monitor ID");
 

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -119,25 +119,8 @@ public abstract class AbstractConfig {
 		} else {
 			System.err.println("No JSON-encoded environment variable named: " + envConfig);
 			System.exit(1);
-			return null; // unreachable
+			throw new IllegalArgumentException("No JSON-encoded environment variable named: " + envConfig);
 		}
-	}
-
-	protected Properties getPrefixedFilteredProperties(Properties properties, String prefix) {
-		if ((prefix == null || prefix.length() == 0) || properties == null) {
-			return properties;
-		}
-		String lowerPrefix = prefix.toLowerCase();
-		Properties filteredProperties = new Properties();
-		properties.entrySet().stream()
-				.filter(entry -> entry.getKey().toString().toLowerCase().startsWith(lowerPrefix))
-				.forEach(entry -> {
-					String rawKey = entry.getKey().toString();
-					String newKey = rawKey.substring(lowerPrefix.length());
-					LOGGER.debug("Reading key {} as {}", rawKey, newKey);
-					filteredProperties.put(newKey, entry.getValue());
-				});
-		return filteredProperties;
 	}
 
 	protected Object fetchOption(String name, OptionSet options, Properties properties, Object defaultVal) {

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -93,6 +93,9 @@ public abstract class AbstractConfig {
 			FileReader reader = new FileReader(file);
 			p = new Properties();
 			p.load(reader);
+			for (Object key : p.keySet()) {
+				LOGGER.debug("Got config key: {}", key);
+			}
 		} catch ( IOException e ) {
 			System.err.println("Couldn't read config file: " + e);
 			System.exit(1);
@@ -103,15 +106,15 @@ public abstract class AbstractConfig {
 	protected Properties readPropertiesEnv(String envConfig) {
 		LOGGER.debug("Attempting to read env_config param: {}", envConfig);
 		String envConfigJsonRaw = System.getenv(envConfig);
-		if (envConfigJsonRaw != null && envConfigJsonRaw.startsWith("{")) {
-			LOGGER.debug("Parsing envConfig");
+		if (envConfigJsonRaw != null && envConfigJsonRaw.trim().startsWith("{")) {
 			ObjectMapper mapper = new ObjectMapper();
 			try {
 				Map<String, Object> stringMap = mapper.readValue(envConfigJsonRaw, Map.class);
 				Properties properties = new Properties();
-				stringMap.entrySet().stream()
-						.map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().toString()))
-						.forEach(entry -> properties.put(entry.getKey(), entry.getValue()));
+				for (Map.Entry<String, Object> entry : stringMap.entrySet()) {
+					LOGGER.debug("Got env_config key: {}", entry.getKey());
+					properties.put(entry.getKey(), entry.getValue().toString());
+				}
 				return properties;
 			} catch (JsonProcessingException e) {
 				throw new IllegalArgumentException("Unparseable JSON in env variable " + envConfig, e);

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -6,12 +6,17 @@ import java.io.IOException;
 
 import java.util.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.shyiko.mysql.binlog.network.SSLMode;
 import joptsimple.*;
 
 import com.zendesk.maxwell.MaxwellMysqlConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractConfig {
+	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractConfig.class);
 	static final protected String DEFAULT_CONFIG_FILE = "config.properties";
 	protected abstract OptionParser buildOptionParser();
 
@@ -93,6 +98,46 @@ public abstract class AbstractConfig {
 			System.exit(1);
 		}
 		return p;
+	}
+
+	protected Properties readPropertiesEnv(String envConfig) {
+		LOGGER.debug("Attempting to read env_config param: {}", envConfig);
+		String envConfigJsonRaw = System.getenv(envConfig);
+		if (envConfigJsonRaw != null && envConfigJsonRaw.startsWith("{")) {
+			LOGGER.debug("Parsing envConfig");
+			ObjectMapper mapper = new ObjectMapper();
+			try {
+				Map<String, Object> stringMap = mapper.readValue(envConfigJsonRaw, Map.class);
+				Properties properties = new Properties();
+				stringMap.entrySet().stream()
+						.map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().toString()))
+						.forEach(entry -> properties.put(entry.getKey(), entry.getValue()));
+				return properties;
+			} catch (JsonProcessingException e) {
+				throw new IllegalArgumentException("Unparseable JSON in env variable " + envConfig, e);
+			}
+		} else {
+			System.err.println("No JSON-encoded environment variable named: " + envConfig);
+			System.exit(1);
+			return null; // unreachable
+		}
+	}
+
+	protected Properties getPrefixedFilteredProperties(Properties properties, String prefix) {
+		if ((prefix == null || prefix.length() == 0) || properties == null) {
+			return properties;
+		}
+		String lowerPrefix = prefix.toLowerCase();
+		Properties filteredProperties = new Properties();
+		properties.entrySet().stream()
+				.filter(entry -> entry.getKey().toString().toLowerCase().startsWith(lowerPrefix))
+				.forEach(entry -> {
+					String rawKey = entry.getKey().toString();
+					String newKey = rawKey.substring(lowerPrefix.length());
+					LOGGER.debug("Reading key {} as {}", rawKey, newKey);
+					filteredProperties.put(newKey, entry.getValue());
+				});
+		return filteredProperties;
 	}
 
 	protected Object fetchOption(String name, OptionSet options, Properties properties, Object defaultVal) {

--- a/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
@@ -96,7 +96,7 @@ public class MaxwellConfigTest
 				.build();
 		ObjectMapper mapper = new ObjectMapper();
 		String jsonConfig = mapper.writeValueAsString(configMap);
-		environmentVariables.set("MAXWELL_JSON", jsonConfig);
+		environmentVariables.set("MAXWELL_JSON", "    " + jsonConfig);
 
 		config = new MaxwellConfig(new String[] { "--env_config=MAXWELL_JSON" });
 		assertEquals("foo", config.maxwellMysql.user);

--- a/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
@@ -112,23 +112,21 @@ public class MaxwellConfigTest
 		config = new MaxwellConfig(new String[] { "--env_config=MAXWELL_JSON", "--host=localhost" });
 	}
 
-	@Test(expected = OptionException.class)
-	public void testFailToUseConfigAndEnvConfig() throws JsonProcessingException {
+	@Test
+	public void testUseConfigAndEnvConfig() throws JsonProcessingException {
 		Map<String, String> configMap = ImmutableMap.<String, String>builder()
-				.put("FOO_user", "foo")
-				.put("foo_password", "bar")
-				.put("foo_host", "remotehost")
-				.put("FOO_kafka.retries", "100")
-				.put("user", "mysql")
+				.put("custom_producer.foo", "foo")
 				.build();
 		ObjectMapper mapper = new ObjectMapper();
 		String jsonConfig = mapper.writeValueAsString(configMap);
 		environmentVariables.set("MAXWELL_JSON", jsonConfig);
 
-		String configPath = getTestConfigDir() + "env-var-config.properties";
+		String configPath = getTestConfigDir() + "producer-factory-config.properties";
 		assertNotNull("Config file not found at: " + configPath, Paths.get(configPath));
 
-		config = new MaxwellConfig(new String[] { "--env_config=MAXWELL_JSON", "--config=" + configPath, "--host=localhost" });
+		config = new MaxwellConfig(new String[] { "--env_config=MAXWELL_JSON", "--config=" + configPath });
+		// foo in env_config overwrites bar in producer-factory-config.properties"
+		assertEquals("foo", config.customProducerProperties.getProperty("foo"));
 	}
 
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
@@ -89,17 +89,16 @@ public class MaxwellConfigTest
 	@Test
 	public void testEnvJsonConfig() throws JsonProcessingException {
 		Map<String, String> configMap = ImmutableMap.<String, String>builder()
-				.put("FOO_user", "foo")
-				.put("foo_password", "bar")
-				.put("foo_host", "remotehost")
-				.put("FOO_kafka.retries", "100")
-				.put("user", "mysql")
+				.put("user", "foo")
+				.put("password", "bar")
+				.put("host", "remotehost")
+				.put("kafka.retries", "100")
 				.build();
 		ObjectMapper mapper = new ObjectMapper();
 		String jsonConfig = mapper.writeValueAsString(configMap);
 		environmentVariables.set("MAXWELL_JSON", jsonConfig);
 
-		config = new MaxwellConfig(new String[] { "--env_config=MAXWELL_JSON", "--config_prefix=FOO_" });
+		config = new MaxwellConfig(new String[] { "--env_config=MAXWELL_JSON" });
 		assertEquals("foo", config.maxwellMysql.user);
 		assertEquals("bar", config.maxwellMysql.password);
 		assertEquals("remotehost", config.maxwellMysql.host);


### PR DESCRIPTION
Setting many kafka parameters is not possible using environment variables in Linux because Java is unable to read environment variables with '.' in them. Environment variables are supposed to be alphanumeric with underscores allowed only. Settings like kafka.bootstrap.servers can only be set in the config.properties. Some organizations prefer configuration via environment variables to prevent seeing sensitive data in `ps` or the docker image itself. [Related link](https://github.com/docker-library/openjdk/issues/135), there are also several stackoverflow questions/answers and I spent a lot of time debugging before realizing this was happening.

This change adds in a JSON-encoded environment variable that can be used as an alternative to config.properties. The input is expected to be a JSON object of string keys and string values. With this change, we are able to set all necessary configs in environment variables.