### PR TITLE
Prevent NPE during initialization

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -49,7 +49,7 @@ public class SchemaStoreSchema {
 
 		if ( schemaDatabaseName != null ) {
 			connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS `" + schemaDatabaseName + "`");
-			if (!connection.getCatalog().equals(schemaDatabaseName))
+			if (!schemaDatabaseName.equals(connection.getCatalog()))
 				connection.setCatalog(schemaDatabaseName);
 		}
 


### PR DESCRIPTION
`Connection#getCatalog` may return `null` per the API documentation, but it is not checked for. Reverse the equality check so an NPE cannot occur.

The Oracle MySQL JDBC library does not have this issue, but this seems to be an implementation quirk rather than something guaranteed by the API. When swapping it for a MariaDB JDBC library, I run into this issue during initialization:
```
java.lang.NullPointerException
	at com.zendesk.maxwell.schema.SchemaStoreSchema.executeSQLInputStream(SchemaStoreSchema.java:52)
	at com.zendesk.maxwell.schema.SchemaStoreSchema.createStoreDatabase(SchemaStoreSchema.java:69)
	at com.zendesk.maxwell.schema.SchemaStoreSchema.ensureMaxwellSchema(SchemaStoreSchema.java:31)
	at com.zendesk.maxwell.Maxwell.startInner(Maxwell.java:206)
	at com.zendesk.maxwell.Maxwell.start(Maxwell.java:183)
	at com.zendesk.maxwell.Maxwell.main(Maxwell.java:287)
```

The fix in this commit resolves the problem.