### PR TITLE
Make all debug statements parameterized

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -231,8 +231,9 @@ public class MaxwellContext {
 					// ignore
 				}
 
-				LOGGER.debug("Shutdown complete: " + shutdownComplete.get());
-				if (!shutdownComplete.get()) {
+				final boolean isShutdownComplete = shutdownComplete.get();
+				LOGGER.debug("Shutdown complete: {}", isShutdownComplete);
+				if (!isShutdownComplete) {
 					LOGGER.error("Shutdown stalled - forcefully killing maxwell process");
 					if (self.error != null) {
 						LOGGER.error("Termination reason:", self.error);

--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -66,7 +66,9 @@ public class BootstrapController extends RunLoopProcess  {
 		List<BootstrapTask> tasks = getIncompleteTasks();
 		synchronized(bootstrapMutex) {
 			for ( BootstrapTask task : tasks ) {
-				LOGGER.debug("starting bootstrap task: {}", task.logString());
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("starting bootstrap task: {}", task.logString());
+				}
 				synchronized(completionMutex) {
 					activeTask = task;
 				}

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -85,7 +85,9 @@ public class SynchronousBootstrapper {
 	}
 
 	public void performBootstrap(BootstrapTask task, AbstractProducer producer, Long currentSchemaID) throws Exception {
-		LOGGER.debug("bootstrapping requested for " + task.logString());
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("bootstrapping requested for {}", task.logString());
+		}
 
 		Table table = getTableForTask(task);
 
@@ -107,7 +109,7 @@ public class SynchronousBootstrapper {
 					scripting.invoke(row);
 
 				if ( LOGGER.isDebugEnabled() )
-					LOGGER.debug("bootstrapping row : " + row.toJSON());
+					LOGGER.debug("bootstrapping row : {}", row.toJSON());
 
 				producer.push(row);
 				++insertedRows;

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKafkaProducer.java
@@ -83,10 +83,10 @@ class KafkaCallback implements Callback {
 			this.succeededMessageMeter.mark();
 
 			if (LOGGER.isDebugEnabled()) {
-				LOGGER.debug("->  key:" + key + ", partition:" + md.partition() + ", offset:" + md.offset());
-				LOGGER.debug("   " + this.json);
-				LOGGER.debug("   " + position);
-				LOGGER.debug("");
+				LOGGER.debug("->  key:{}, partition:{}, offset:{}\n" +
+								"   {}\n" +
+								"   {}\n",
+						key, md.partition(), md.offset(), this.json, position);
 			}
 			cc.markCompleted();
 		}
@@ -279,7 +279,7 @@ class MaxwellKafkaProducerWorker extends AbstractAsyncProducer implements Runnab
 			if (topic == null) {
 				topic = this.topicInterpolator.generateFromRowMap(r);
 			}
-			LOGGER.debug("context.getConfig().producerPartitionKey = " + context.getConfig().producerPartitionKey);
+			LOGGER.debug("context.getConfig().producerPartitionKey = {}",  context.getConfig().producerPartitionKey);
 
 			record = new ProducerRecord<>(topic, this.partitioner.kafkaPartition(r, getNumPartitions(topic)), key, value);
 		}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -80,10 +80,10 @@ class KinesisCallback implements FutureCallback<UserRecordResult> {
 		this.succeededMessageCount.inc();
 		this.succeededMessageMeter.mark();
 		if(logger.isDebugEnabled()) {
-			logger.debug("->  key:" + key + ", shard id:" + result.getShardId() + ", sequence number:" + result.getSequenceNumber());
-			logger.debug("   " + json);
-			logger.debug("   " + position);
-			logger.debug("");
+			logger.debug("->  key:{}, shard id:{}, sequence number:{}\n" +
+							"   {}\n" +
+							"   {}\n",
+					key, result.getShardId(), result.getSequenceNumber(), json, position);
 		}
 
 		cc.markCompleted();

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellPubsubProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellPubsubProducer.java
@@ -61,9 +61,9 @@ class PubsubCallback implements ApiFutureCallback<String> {
     this.succeededMessageMeter.mark();
 
     if ( LOGGER.isDebugEnabled() ) {
-      LOGGER.debug("->  " + this.json);
-      LOGGER.debug("    " + this.position);
-      LOGGER.debug("");
+      LOGGER.debug("->  {}\n" +
+			  "    {}\n",
+			  this.json, this.position);
     }
 
     cc.markCompleted();

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellRedisProducer.java
@@ -125,17 +125,17 @@ public class MaxwellRedisProducer extends AbstractProducer implements StoppableT
 		if (logger.isDebugEnabled()) {
 			switch (redisType) {
 				case "lpush":
-					logger.debug("->  queue (left):" + channel + ", msg:" + msg);
+					logger.debug("->  queue (left):{}, msg:{}", channel, msg);
 					break;
 				case "rpush":
-					logger.debug("->  queue (right):" + channel + ", msg:" + msg);
+					logger.debug("->  queue (right):{}, msg:{}", channel, msg);
 					break;
 				case "xadd":
-					logger.debug("->  stream:" + channel + ", msg:" + msg);
+					logger.debug("->  stream:{}, msg:{}", channel, msg);
 					break;
 				case "pubsub":
 				default:
-					logger.debug("->  channel:" + channel + ", msg:" + msg);
+					logger.debug("->  channel:{}, msg:{}", channel, msg);
 					break;
 			}
 		}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -103,7 +103,7 @@ class SNSCallback implements AsyncHandler<PublishRequest, PublishResult> {
 	@Override
 	public void onSuccess(PublishRequest request, PublishResult result) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("-> MessageId: " + result.getMessageId());
+			logger.debug("-> MessageId: {}", result.getMessageId());
 		}
 		cc.markCompleted();
 	}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
@@ -69,7 +69,8 @@ class SQSCallback implements AsyncHandler<SendMessageRequest, SendMessageResult>
 	@Override
 	public void onSuccess(SendMessageRequest request, SendMessageResult result) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("-> Message id:" + result.getMessageId() + ", sequence number:" + result.getSequenceNumber()+"  "+json+"  "+position);
+			logger.debug("-> Message id:{}, sequence number:{}  {}  {}",
+					result.getMessageId(), result.getSequenceNumber(), json, position);
 		}
 		cc.markCompleted();
 	}

--- a/src/main/java/com/zendesk/maxwell/producer/NatsProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/NatsProducer.java
@@ -59,7 +59,7 @@ public class NatsProducer extends AbstractProducer {
 			context.setPosition(r.getNextPosition());
 		}
 		if (LOGGER.isDebugEnabled()) {
-			LOGGER.debug("->  nats subject:" + natsSubject + ", message:" + value);
+			LOGGER.debug("->  nats subject:{}, message:{}", natsSubject, value);
 		}
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/RabbitmqProducer.java
@@ -84,7 +84,7 @@ public class RabbitmqProducer extends AbstractProducer {
 			context.setPosition(r.getNextPosition());
 		}
 		if ( LOGGER.isDebugEnabled()) {
-			LOGGER.debug("->  routing key:" + routingKey + ", partition:" + value);
+			LOGGER.debug("->  routing key:{}, partition:{}", routingKey, value);
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -58,7 +58,7 @@ public class Recovery {
 			Position position = Position.valueOf(binlogPosition, recoveryInfo.getHeartbeat());
 			Metrics metrics = new NoOpMetrics();
 
-			LOGGER.debug("scanning binlog: " + binlogPosition);
+			LOGGER.debug("scanning binlog: {}", binlogPosition);
 			Replicator replicator = new BinlogConnectorReplicator(
 					this.schemaStore,
 					null,

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -311,7 +311,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 			return row; // plain row -- do not process.
 
 		long lastHeartbeatRead = (Long) row.getData("heartbeat");
-		LOGGER.debug("replicator picked up heartbeat: " + lastHeartbeatRead);
+		LOGGER.debug("replicator picked up heartbeat: {}", lastHeartbeatRead);
 		this.lastHeartbeatPosition = row.getPosition().withHeartbeat(lastHeartbeatRead);
 		heartbeatNotifier.heartbeat(lastHeartbeatRead);
 		return HeartbeatRowMap.valueOf(row.getDatabase(), this.lastHeartbeatPosition, row.getNextPosition().withHeartbeat(lastHeartbeatRead));
@@ -530,7 +530,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 					String upperCaseSql = sql.toUpperCase();
 
 					if ( upperCaseSql.startsWith(BinlogConnectorEvent.SAVEPOINT)) {
-						LOGGER.debug("Ignoring SAVEPOINT in transaction: " + qe);
+						LOGGER.debug("Ignoring SAVEPOINT in transaction: {}", qe);
 					} else if ( createTablePattern.matcher(sql).find() ) {
 						// CREATE TABLE `foo` SELECT * FROM `bar` will put a CREATE TABLE
 						// inside a transaction.  Note that this could, in rare cases, lead

--- a/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMapBuffer.java
@@ -55,7 +55,7 @@ public class RowMapBuffer extends ListWithDiskBuffer<RowMap> {
 		this.outputStreamCacheSize += r.getApproximateSize();
 		if ( this.outputStreamCacheSize > FlushOutputStreamBytes ) {
 			resetOutputStreamCaches();
-			LOGGER.debug("outputStreamCacheSize: " + this.outputStreamCacheSize + ", memorySize: " + this.memorySize);
+			LOGGER.debug("outputStreamCacheSize: {}, memorySize: {}", this.outputStreamCacheSize, this.memorySize);
 			this.outputStreamCacheSize = 0;
 		}
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -58,7 +58,8 @@ public class MysqlPositionStore {
 		connectionPool.withSQLRetry(1, (c) -> {
 			PreparedStatement s = c.prepareStatement(sql);
 
-			LOGGER.debug("Writing binlog position to " + c.getCatalog() + ".positions: " + newPosition + ", last heartbeat read: " + heartbeat);
+			LOGGER.debug("Writing binlog position to {}.positions: {}, last heartbeat read: {}",
+					c.getCatalog(), newPosition, heartbeat);
 			s.setLong(1, serverID);
 			s.setString(2, binlogPosition.getGtidSetStr());
 			s.setString(3, binlogPosition.getFile());
@@ -134,7 +135,7 @@ public class MysqlPositionStore {
 		s.setString(3, clientID);
 		s.setLong(4, lastHeartbeat);
 
-		LOGGER.debug("writing heartbeat: " + thisHeartbeat + " (last heartbeat written: " + lastHeartbeat + ")");
+		LOGGER.debug("writing heartbeat: {} (last heartbeat written: {})", thisHeartbeat, lastHeartbeat);
 		int nRows = s.executeUpdate();
 		if ( nRows != 1 ) {
 			String msg = String.format(

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -135,7 +135,7 @@ public class MysqlSavedSchema {
 
 		if ( rs.next() ) {
 			Long id = rs.getLong("id");
-			LOGGER.debug("findSchemaForPositionSHA: found schema_id: " + id + " for sha: " + sha);
+			LOGGER.debug("findSchemaForPositionSHA: found schema_id: {} for sha: {}", id, sha);
 			return id;
 		} else {
 			return null;
@@ -495,7 +495,7 @@ public class MysqlSavedSchema {
 				this.schema.addDatabase(currentDatabase);
 				// make sure two tables named the same in different dbs are picked up.
 				currentTable = null;
-				LOGGER.debug("Restoring database " + dbName + "...");
+				LOGGER.debug("Restoring database {}...", dbName);
 			}
 
 			if (tName == null) {
@@ -554,7 +554,7 @@ public class MysqlSavedSchema {
 
 	private static Long findSchema(Connection connection, Position targetPosition, Long serverID)
 			throws SQLException {
-		LOGGER.debug("looking to restore schema at target position " + targetPosition);
+		LOGGER.debug("looking to restore schema at target position {}", targetPosition);
 		BinlogPosition targetBinlogPosition = targetPosition.getBinlogPosition();
 		if (targetBinlogPosition.getGtidSetStr() != null) {
 			PreparedStatement s = connection.prepareStatement(
@@ -566,11 +566,11 @@ public class MysqlSavedSchema {
 			while (rs.next()) {
 				Long id = rs.getLong("id");
 				String gtid = rs.getString("gtid_set");
-				LOGGER.debug("Retrieving schema at id: " + id + " gtid: " + gtid);
+				LOGGER.debug("Retrieving schema at id: {} gtid: {}", id, gtid);
 				if (gtid != null) {
 					GtidSet gtidSet = new GtidSet(gtid);
 					if (gtidSet.isContainedWithin(targetBinlogPosition.getGtidSet())) {
-						LOGGER.debug("Found contained schema: " + id);
+						LOGGER.debug("Found contained schema: {}", id);
 						return id;
 					}
 				}

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -102,14 +102,14 @@ public class SchemaCapturer {
 		rs.close();
 
 		int size = databases.size();
-		LOGGER.debug("Starting schema capture of " + size + " databases...");
+		LOGGER.debug("Starting schema capture of {} databases...", size);
 		int counter = 1;
 		for (Database db : databases) {
-			LOGGER.debug(counter + "/" + size + " Capturing " + db.getName() + "...");
+			LOGGER.debug("{}/{} Capturing {}...", counter, size, db.getName());
 			captureDatabase(db);
 			counter++;
 		}
-		LOGGER.debug(size + " database schemas captured!");
+		LOGGER.debug("{} database schemas captured!", size);
 
 		return new Schema(databases, captureDefaultCharset(), this.sensitivity);
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
@@ -61,7 +61,7 @@ public abstract class SchemaChange {
 
 		for (Pattern p : SQL_BLACKLIST) {
 			if (p.matcher(sql).find()) {
-				LOGGER.debug("ignoring sql: " + sql);
+				LOGGER.debug("ignoring sql: {}", sql);
 				return true;
 			}
 		}
@@ -83,7 +83,7 @@ public abstract class SchemaChange {
 
 		TokenStream tokens = new CommonTokenStream(lexer);
 
-		LOGGER.debug("SQL_PARSE <- \"" + sql + "\"");
+		LOGGER.debug("SQL_PARSE <- \"{}\"", sql);
 		mysqlParser parser = new mysqlParser(tokens);
 		parser.removeErrorListeners();
 
@@ -92,7 +92,9 @@ public abstract class SchemaChange {
 		ParseTree tree = parser.parse();
 
 		ParseTreeWalker.DEFAULT.walk(listener, tree);
-		LOGGER.debug("SQL_PARSE ->   " + tree.toStringTree(parser));
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("SQL_PARSE ->   {}", tree.toStringTree(parser));
+		}
 		return listener.getSchemaChanges();
 	}
 
@@ -106,13 +108,17 @@ public abstract class SchemaChange {
 				return parseSQL(currentDB, sql);
 			} catch ( ReparseSQLException e ) {
 				sql = e.getSQL();
-				LOGGER.debug("rewrote SQL to " + sql);
+				LOGGER.debug("rewrote SQL to {}", sql);
 				// re-enter loop
 			} catch ( ParseCancellationException e ) {
-				LOGGER.debug("Parse cancelled: " + e);
+				if (LOGGER.isDebugEnabled()) {
+					// we are debug logging the toString message, slf4j will log the stacktrace of a throwable
+					String msg = e.toString();
+					LOGGER.debug("Parse cancelled: {}", msg);
+				}
 				return null;
 			} catch ( MaxwellSQLSyntaxError e) {
-				LOGGER.error("Error parsing SQL: '" + sql + "'");
+				LOGGER.error("Error parsing SQL: '{}'", sql);
 				throw (e);
 			}
 		}

--- a/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
+++ b/src/main/java/com/zendesk/maxwell/util/ListWithDiskBuffer.java
@@ -36,7 +36,7 @@ public class ListWithDiskBuffer<T> {
 	}
 
 	protected void resetOutputStreamCaches() throws IOException {
-		LOGGER.debug("Resetting OutputStream caches. elementsInFile: " + elementsInFile);
+		LOGGER.debug("Resetting OutputStream caches. elementsInFile: {}", elementsInFile);
 		os.reset();
 	}
 

--- a/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
+++ b/src/main/java/com/zendesk/maxwell/util/StoppableTaskState.java
@@ -20,7 +20,7 @@ public class StoppableTaskState {
 	}
 
 	public synchronized void requestStop() {
-		LOGGER.debug(description + " requestStop() called (in state: " + state + ")");
+		LOGGER.debug("{} requestStop() called (in state: {})", description, state);
 		if (isRunning()) {
 			this.state = RunState.REQUEST_STOP;
 		}

--- a/src/main/java/com/zendesk/maxwell/util/TaskManager.java
+++ b/src/main/java/com/zendesk/maxwell/util/TaskManager.java
@@ -51,7 +51,7 @@ public class TaskManager {
 		// then wait for everything to stop
 		Long timeout = 1000L;
 		for (StoppableTask task: this.tasks) {
-			LOGGER.debug("Awaiting stop of: " + task);
+			LOGGER.debug("Awaiting stop of: {}", task);
 			task.awaitStop(timeout);
 		}
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -223,7 +223,7 @@ public class MaxwellTestSupport {
 
 		long finalHeartbeat = maxwell.context.getPositionStore().heartbeat();
 
-		LOGGER.debug("running replicator up to heartbeat: " + finalHeartbeat);
+		LOGGER.debug("running replicator up to heartbeat: {}", finalHeartbeat);
 
 		Long pollTime = 5000L;
 		Position lastPositionRead = null;
@@ -234,8 +234,9 @@ public class MaxwellTestSupport {
 			pollTime = 500L; // after the first row is received, we go into a tight loop.
 
 			if ( row != null ) {
-				if ( row.toJSON(config.outputConfig) != null ) {
-					LOGGER.debug("getRowsWithReplicator: saw: " + row.toJSON(config.outputConfig));
+				String outputConfigJson = row.toJSON(config.outputConfig);
+				if ( outputConfigJson != null ) {
+					LOGGER.debug("getRowsWithReplicator: saw: {}", outputConfigJson);
 					list.add(row);
 				}
 				lastPositionRead = row.getPosition();
@@ -246,7 +247,7 @@ public class MaxwellTestSupport {
 			boolean timedOut = !replicationComplete && row == null;
 
 			if (timedOut) {
-				LOGGER.debug("timed out waiting for final row. Last position we saw: " + lastPositionRead);
+				LOGGER.debug("timed out waiting for final row. Last position we saw: {}", lastPositionRead);
 				break;
 			}
 


### PR DESCRIPTION
Most of the logging in Maxwell is currently done by concatenating strings, however one of the main benefits of using SLF4j is that you can skip the cost of concatenating log message strings and calling the toString method on parameters when you don't log something. This is particularly relevant for debug logging because it is usually turned off. The same should be done for all other logging calls for consistency, but those changes are not part of this PR and provide less benefit as logging for INFO and above is usually on.

There are some places where there is both a isDebugEnabled() check and parameterization, I added isDebugEnabled where it was relevant (like calls to an alternative toString method for debugging purposes) and left it alone when it was already there. While parameterization is  redundant in these cases I think consistency of using parameterization is more important.

Reference: http://www.slf4j.org/faq.html#logging_performance