### PR TITLE
SchemaCapturer - minor query optimization and better connection cleanup

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -101,9 +101,9 @@ public class Maxwell implements Runnable {
 	}
 
 	private void logColumnCastError(ColumnDefCastException e) throws SQLException, SchemaStoreException {
-		try ( Connection conn = context.getSchemaConnectionPool().getConnection() ) {
-			LOGGER.error("checking for schema inconsistencies in " + e.database + "." + e.table);
-			SchemaCapturer capturer = new SchemaCapturer(conn, context.getCaseSensitivity(), e.database, e.table);
+		LOGGER.error("checking for schema inconsistencies in " + e.database + "." + e.table);
+		try ( Connection conn = context.getSchemaConnectionPool().getConnection();
+			  SchemaCapturer capturer = new SchemaCapturer(conn, context.getCaseSensitivity(), e.database, e.table)) {
 			Schema recaptured = capturer.capture();
 			Table t = this.replicator.getSchema().findDatabase(e.database).findTable(e.table);
 			List<String> diffs = new ArrayList<>();

--- a/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
@@ -38,9 +38,9 @@ public abstract class AbstractSchemaStore {
 	}
 
 	protected Schema captureSchema() throws SQLException {
-		try(Connection connection = schemaConnectionPool.getConnection()) {
-			LOGGER.info("Maxwell is capturing initial schema");
-			SchemaCapturer capturer = new SchemaCapturer(connection, caseSensitivity);
+		LOGGER.info("Maxwell is capturing initial schema");
+		try(Connection connection = schemaConnectionPool.getConnection();
+			SchemaCapturer capturer = new SchemaCapturer(connection, caseSensitivity)) {
 			return capturer.capture();
 		}
 	}

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -679,13 +679,13 @@ public class MysqlSavedSchema {
 		int caseDiffs = 0;
 
 		for ( Pair<ColumnDef, ColumnDef> pair : schema.matchColumns(recaptured) ) {
-			ColumnDef schemaCol = pair.getLeft();
-			ColumnDef recapturedCol = pair.getRight();
+			ColumnDef cA = pair.getLeft();
+			ColumnDef cB = pair.getRight();
 
-			if ( !schemaCol.getName().equals(recapturedCol.getName()) ) {
-				LOGGER.info("correcting column case of `" + schemaCol.getName() + "` to `" + recapturedCol.getName() + "`.  Will save a full schema snapshot after the new DDL update is processed.");
+			if ( !cA.getName().equals(cB.getName()) ) {
+				LOGGER.info("correcting column case of `" + cA.getName() + "` to `" + cB.getName() + "`.  Will save a full schema snapshot after the new DDL update is processed.");
 				caseDiffs++;
-				schemaCol.setName(recapturedCol.getName());
+				cA.setName(cB.getName());
 			}
 		}
 

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaCapturer.java
@@ -3,44 +3,61 @@ package com.zendesk.maxwell.schema;
 import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 import com.zendesk.maxwell.util.Sql;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class SchemaCapturer {
+public class SchemaCapturer implements AutoCloseable {
 	private final Connection connection;
-	static final Logger LOGGER = LoggerFactory.getLogger(MysqlSavedSchema.class);
+	static final Logger LOGGER = LoggerFactory.getLogger(SchemaCapturer.class);
 
-	public static final HashSet<String> IGNORED_DATABASES = new HashSet<String>(
+	public static final HashSet<String> IGNORED_DATABASES = new HashSet<>(
 			Arrays.asList(new String[]{"performance_schema", "information_schema"})
 	);
 
-	private final HashSet<String> includeDatabases;
-	private final HashSet<String> includeTables;
+	private final Set<String> includeDatabases;
+	private final Set<String> includeTables;
 
 	private final CaseSensitivity sensitivity;
+	private final boolean isMySQLAtLeast56;
+	private final PreparedStatement tablePreparedStatement;
+	private final PreparedStatement columnPreparedStatement;
+	private final PreparedStatement pkPreparedStatement;
 
-	private PreparedStatement columnPreparedStatement;
-
-	private PreparedStatement pkPreparedStatement;
 
 	public SchemaCapturer(Connection c, CaseSensitivity sensitivity) throws SQLException {
-		this.includeDatabases = new HashSet<>();
-		this.includeTables = new HashSet<>();
+		this(c, sensitivity, Collections.emptySet(), Collections.emptySet());
+	}
+
+	SchemaCapturer(Connection c, CaseSensitivity sensitivity, Set<String> includeDatabases, Set<String> includeTables) throws SQLException {
+		this.includeDatabases = includeDatabases;
+		this.includeTables = includeTables;
 		this.connection = c;
 		this.sensitivity = sensitivity;
 
+		this.isMySQLAtLeast56 = isMySQLAtLeast56();
 		String dateTimePrecision = "";
-		if(isMySQLAtLeast56())
+		if (isMySQLAtLeast56) {
 			dateTimePrecision = "DATETIME_PRECISION, ";
+		}
+
+		String tblSql = "SELECT TABLES.TABLE_NAME, CCSA.CHARACTER_SET_NAME "
+				+ "FROM INFORMATION_SCHEMA.TABLES "
+				+ "JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS CCSA"
+				+ " ON TABLES.TABLE_COLLATION = CCSA.COLLATION_NAME WHERE TABLES.TABLE_SCHEMA = ? ";
+
+		if (!includeTables.isEmpty()) {
+			tblSql += " AND TABLES.TABLE_NAME IN " + Sql.inListSQL(includeTables.size());
+		}
+		tablePreparedStatement = connection.prepareStatement(tblSql);
 
 		String columnSql = "SELECT " +
 				"TABLE_NAME," +
@@ -55,21 +72,23 @@ public class SchemaCapturer {
 
 		columnPreparedStatement = connection.prepareStatement(columnSql);
 
-		String pkSql = "SELECT TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION FROM information_schema.KEY_COLUMN_USAGE "
-				+ "WHERE CONSTRAINT_NAME = 'PRIMARY' AND TABLE_SCHEMA = ? ORDER BY TABLE_NAME, ORDINAL_POSITION";
+		String pkSQl = "SELECT " +
+				"TABLE_NAME, " +
+				"COLUMN_NAME, " +
+				"ORDINAL_POSITION " +
+				"FROM information_schema.KEY_COLUMN_USAGE " +
+				"WHERE CONSTRAINT_NAME = 'PRIMARY' AND TABLE_SCHEMA = ? " +
+				"ORDER BY TABLE_NAME, ORDINAL_POSITION";
 
-		pkPreparedStatement = connection.prepareStatement(pkSql);
-
+		pkPreparedStatement = connection.prepareStatement(pkSQl);
 	}
 
 	public SchemaCapturer(Connection c, CaseSensitivity sensitivity, String dbName) throws SQLException {
-		this(c, sensitivity);
-		this.includeDatabases.add(dbName);
+		this(c, sensitivity, Collections.singleton(dbName), Collections.emptySet());
 	}
 
 	public SchemaCapturer(Connection c, CaseSensitivity sensitivity, String dbName, String tblName) throws SQLException {
-		this(c, sensitivity, dbName);
-		this.includeTables.add(tblName);
+		this(c, sensitivity, Collections.singleton(dbName), Collections.singleton(tblName));
 	}
 
 	public Schema capture() throws SQLException {
@@ -85,21 +104,22 @@ public class SchemaCapturer {
 		}
 		dbCaptureQuery += " ORDER BY SCHEMA_NAME";
 
-		PreparedStatement statement = connection.prepareStatement(dbCaptureQuery);
-		Sql.prepareInList(statement, 1, includeDatabases);
+		try (PreparedStatement statement = connection.prepareStatement(dbCaptureQuery)) {
+			Sql.prepareInList(statement, 1, includeDatabases);
 
-		ResultSet rs = statement.executeQuery();
-		while (rs.next()) {
-			String dbName = rs.getString("SCHEMA_NAME");
-			String charset = rs.getString("DEFAULT_CHARACTER_SET_NAME");
+			try (ResultSet rs = statement.executeQuery()) {
+				while (rs.next()) {
+					String dbName = rs.getString("SCHEMA_NAME");
+					String charset = rs.getString("DEFAULT_CHARACTER_SET_NAME");
 
-			if (IGNORED_DATABASES.contains(dbName))
-				continue;
+					if (IGNORED_DATABASES.contains(dbName))
+						continue;
 
-			Database db = new Database(dbName, charset);
-			databases.add(db);
+					Database db = new Database(dbName, charset);
+					databases.add(db);
+				}
+			}
 		}
-		rs.close();
 
 		int size = databases.size();
 		LOGGER.debug("Starting schema capture of {} databases...", size);
@@ -116,37 +136,27 @@ public class SchemaCapturer {
 
 	private String captureDefaultCharset() throws SQLException {
 		LOGGER.debug("Capturing Default Charset");
-		ResultSet rs = connection.createStatement().executeQuery("select @@character_set_server");
-		rs.next();
-		return rs.getString("@@character_set_server");
+		try (Statement stmt = connection.createStatement();
+			 ResultSet rs = stmt.executeQuery("select @@character_set_server")) {
+			rs.next();
+			return rs.getString("@@character_set_server");
+		}
 	}
 
 
 	private void captureDatabase(Database db) throws SQLException {
-		String tblSql = "SELECT TABLES.TABLE_NAME, CCSA.CHARACTER_SET_NAME "
-			+ "FROM INFORMATION_SCHEMA.TABLES "
-			+ "JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS CCSA"
-			+ " ON TABLES.TABLE_COLLATION = CCSA.COLLATION_NAME WHERE TABLES.TABLE_SCHEMA = ?";
-
-		if ( this.includeTables.size() > 0 ) {
-			tblSql += " AND TABLES.TABLE_NAME IN " + Sql.inListSQL(includeTables.size());
-		}
-
-		PreparedStatement tblQuery = connection.prepareStatement(tblSql);
-		tblQuery.setString(1, db.getName());
-		Sql.prepareInList(tblQuery, 2, includeTables);
-
-		ResultSet rs = tblQuery.executeQuery();
+		tablePreparedStatement.setString(1, db.getName());
+		Sql.prepareInList(tablePreparedStatement, 2, includeTables);
 
 		HashMap<String, Table> tables = new HashMap<>();
-		while (rs.next()) {
-			String tableName = rs.getString("TABLE_NAME");
-			String characterSetName = rs.getString("CHARACTER_SET_NAME");
-			Table t = db.buildTable(tableName, characterSetName);
-			tables.put(tableName, t);
+		try (ResultSet rs = tablePreparedStatement.executeQuery()) {
+			while (rs.next()) {
+				String tableName = rs.getString("TABLE_NAME");
+				String characterSetName = rs.getString("CHARACTER_SET_NAME");
+				Table t = db.buildTable(tableName, characterSetName);
+				tables.put(tableName, t);
+			}
 		}
-		rs.close();
-
 		captureTables(db, tables);
 	}
 
@@ -160,72 +170,70 @@ public class SchemaCapturer {
 
 
 	private void captureTables(Database db, HashMap<String, Table> tables) throws SQLException {
-
 		columnPreparedStatement.setString(1, db.getName());
-		ResultSet r = columnPreparedStatement.executeQuery();
 
-		boolean hasDatetimePrecision = isMySQLAtLeast56();
+		try (ResultSet r = columnPreparedStatement.executeQuery()) {
 
-		HashMap<String, Integer> pkIndexCounters = new HashMap<>();
-		for (String tableName : tables.keySet()) {
-			pkIndexCounters.put(tableName, 0);
-		}
+			HashMap<String, Integer> pkIndexCounters = new HashMap<>();
+			for (String tableName : tables.keySet()) {
+				pkIndexCounters.put(tableName, 0);
+			}
 
-		while (r.next()) {
-			String[] enumValues = null;
-			String tableName = r.getString("TABLE_NAME");
+			while (r.next()) {
+				String[] enumValues = null;
+				String tableName = r.getString("TABLE_NAME");
 
-			if (tables.containsKey(tableName)) {
-				Table t = tables.get(tableName);
-				String colName = r.getString("COLUMN_NAME");
-				String colType = r.getString("DATA_TYPE");
-				String colEnc = r.getString("CHARACTER_SET_NAME");
-				short colPos = (short) (r.getInt("ORDINAL_POSITION") - 1);
-				boolean colSigned = !r.getString("COLUMN_TYPE").matches(".* unsigned$");
-				Long columnLength = null;
+				if (tables.containsKey(tableName)) {
+					Table t = tables.get(tableName);
+					String colName = r.getString("COLUMN_NAME");
+					String colType = r.getString("DATA_TYPE");
+					String colEnc = r.getString("CHARACTER_SET_NAME");
+					short colPos = (short) (r.getInt("ORDINAL_POSITION") - 1);
+					boolean colSigned = !r.getString("COLUMN_TYPE").matches(".* unsigned$");
+					Long columnLength = null;
 
-				if (hasDatetimePrecision)
-					columnLength = r.getLong("DATETIME_PRECISION");
+					if (isMySQLAtLeast56)
+						columnLength = r.getLong("DATETIME_PRECISION");
 
-				if (r.getString("COLUMN_KEY").equals("PRI"))
-					t.pkIndex = pkIndexCounters.get(tableName);
+					if (r.getString("COLUMN_KEY").equals("PRI"))
+						t.pkIndex = pkIndexCounters.get(tableName);
 
-				if (colType.equals("enum") || colType.equals("set")) {
-					String expandedType = r.getString("COLUMN_TYPE");
+					if (colType.equals("enum") || colType.equals("set")) {
+						String expandedType = r.getString("COLUMN_TYPE");
 
-					enumValues = extractEnumValues(expandedType);
+						enumValues = extractEnumValues(expandedType);
+					}
+
+					t.addColumn(ColumnDef.build(colName, colEnc, colType, colPos, colSigned, enumValues, columnLength));
+
+					pkIndexCounters.put(tableName, pkIndexCounters.get(tableName) + 1);
 				}
-
-				t.addColumn(ColumnDef.build(colName, colEnc, colType, colPos, colSigned, enumValues, columnLength));
-
-				pkIndexCounters.put(tableName, pkIndexCounters.get(tableName) + 1);
 			}
 		}
-		r.close();
 
 		captureTablesPK(db, tables);
 	}
 
 	private void captureTablesPK(Database db, HashMap<String, Table> tables) throws SQLException {
 		pkPreparedStatement.setString(1, db.getName());
-		ResultSet rs = pkPreparedStatement.executeQuery();
 
 		HashMap<String, ArrayList<String>> tablePKMap = new HashMap<>();
 
-		for (String tableName : tables.keySet()) {
-			tablePKMap.put(tableName, new ArrayList<String>());
-		}
+		try (ResultSet rs = pkPreparedStatement.executeQuery()) {
+			for (String tableName : tables.keySet()) {
+				tablePKMap.put(tableName, new ArrayList<>());
+			}
 
-		while (rs.next()) {
-			int ordinalPosition = rs.getInt("ORDINAL_POSITION");
-			String tableName = rs.getString("TABLE_NAME");
-			String columnName = rs.getString("COLUMN_NAME");
+			while (rs.next()) {
+				int ordinalPosition = rs.getInt("ORDINAL_POSITION");
+				String tableName = rs.getString("TABLE_NAME");
+				String columnName = rs.getString("COLUMN_NAME");
 
-			ArrayList<String> pkList = tablePKMap.get(tableName);
-			if ( pkList != null )
-				pkList.add(ordinalPosition - 1, columnName);
+				ArrayList<String> pkList = tablePKMap.get(tableName);
+				if ( pkList != null )
+					pkList.add(ordinalPosition - 1, columnName);
+			}
 		}
-		rs.close();
 
 		for (Map.Entry<String, Table> entry : tables.entrySet()) {
 			String key = entry.getKey();
@@ -259,6 +267,15 @@ public class SchemaCapturer {
 			result.add(value);
 		}
 		return result.toArray(new String[0]);
+	}
+
+	@Override
+	public void close() throws SQLException {
+		try (PreparedStatement p1 = tablePreparedStatement;
+			 PreparedStatement p2 = columnPreparedStatement;
+			 PreparedStatement p3 = pkPreparedStatement) {
+			// auto-close shared prepared statements
+		}
 	}
 
 }


### PR DESCRIPTION
Query Optimization:
 - Call `isMySQLAtLeast56` only once during initialization instead of at each call to `captureTables` (one call per DB)
 - Save a call to Connection#prepareStatement in `captureDatabase` by retaining the PreparedStatement as a member variable, similar to the other statements. (one call per DB)

Connection cleanup
 - Made SchemaCapturer AutoClosable
 - Used try-with-resources everywhere in the class, and made calls to SchemaCapturer do the same.

For SchemaCapturer, I recommend reviewing the diff in an IDE like IntelliJ, it makes it super-clear what lines are indent-only.