### PR TITLE
Improve Schema database traversal speed / startup time

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/Schema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Schema.java
@@ -6,44 +6,50 @@ import com.zendesk.maxwell.schema.ddl.InvalidSchemaError;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 
 public class Schema {
-	private final ArrayList<Database> databases;
+	private final LinkedHashMap<String, Database> dbMap;
 	private final String charset;
 	private final CaseSensitivity sensitivity;
 
 	public Schema(List<Database> databases, String charset, CaseSensitivity sensitivity) {
 		this.sensitivity = sensitivity;
 		this.charset = charset;
-		this.databases = new ArrayList<>();
+		this.dbMap = new LinkedHashMap<>();
 
 		for ( Database d : databases )
 			addDatabase(d);
 	}
 
-	public List<Database> getDatabases() { return this.databases; }
+	public Collection<Database> getDatabases() { return Collections.unmodifiableCollection(this.dbMap.values()); }
 
 	public List<String> getDatabaseNames () {
-		ArrayList<String> names = new ArrayList<String>();
+		ArrayList<String> names = new ArrayList<>(this.dbMap.size());
 
-		for ( Database d : this.databases ) {
+		for ( Database d : this.dbMap.values() ) {
 			names.add(d.getName());
 		}
 		return names;
 	}
 
 	public Database findDatabase(String string) {
-		for ( Database d: this.databases ) {
-			if ( sensitivity == CaseSensitivity.CASE_SENSITIVE ) {
-				if ( d.getName().equals(string) ) return d;
-			} else {
-				if ( d.getName().toLowerCase().equals(string.toLowerCase()) ) return d;
-			}
-		}
+		return this.dbMap.get(getNormalizedDbName(string));
+	}
 
-		return null;
+	private String getNormalizedDbName(String dbName) {
+		if (dbName == null) {
+			return null;
+		}
+		if (sensitivity == CaseSensitivity.CASE_SENSITIVE) {
+			return dbName;
+		} else {
+			return dbName.toLowerCase();
+		}
 	}
 
 	public Database findDatabaseOrThrow(String name) throws InvalidSchemaError {
@@ -59,11 +65,15 @@ public class Schema {
 
 	public void addDatabase(Database d) {
 		d.setSensitivity(sensitivity);
-		this.databases.add(d);
+		this.dbMap.put(getNormalizedDbName(d.getName()), d);
+	}
+
+	public void removeDatabase(Database d) {
+		this.dbMap.remove(getNormalizedDbName(d.getName()));
 	}
 
 	private void diffDBList(List<String> diff, Schema a, Schema b, String nameA, String nameB, boolean recurse) {
-		for ( Database d : a.databases ) {
+		for ( Database d : a.dbMap.values() ) {
 			Database matchingDB = b.findDatabase(d.getName());
 
 			if ( matchingDB == null )

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseDrop.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/ResolvedDatabaseDrop.java
@@ -14,7 +14,7 @@ public class ResolvedDatabaseDrop extends ResolvedSchemaChange {
 	@Override
 	public void apply(Schema schema) throws InvalidSchemaError {
 		Database d = schema.findDatabaseOrThrow(database);
-		schema.getDatabases().remove(d);
+		schema.removeDatabase(d);
 	}
 
 	@Override

--- a/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/SchemaCaptureTest.java
@@ -74,7 +74,7 @@ public class SchemaCaptureTest extends MaxwellTestWithIsolatedServer {
 		SchemaCapturer sc =
 			new SchemaCapturer(server.getConnection(), CaseSensitivity.CASE_SENSITIVE, "shard_1", "ints");
 		Schema schema = sc.capture();
-		assertEquals(1, schema.getDatabases().get(0).getTableList().size());
+		assertEquals(1, schema.getDatabases().iterator().next().getTableList().size());
 	}
 
 	@Test


### PR DESCRIPTION
For diffs, n^2 -> n.
Change Schema's database list to a LinkedHashMap from an ArrayList to greatly improve startup for instances with many databases/tables. Since case sensitivity doesn't change, we can just pre-compute the name and do comparisons against the normalized name. Moved mutations to the database list (add/remove) to `Schema` methods so it's easier to maintain this normalization logic.

Baseline test: 70K DB, 1M Table, 6M columns
Measured Performance: 12min startup to 3 min startup with this change

Startup was seeing very high sustained CPU usage and thread dumping showed the Schema#findDatabase call was taking the majority time to scan the ArrayList.