### PR TITLE
Change maxwell's schema to use BIGINT for ids instead of INT UNSIGNED

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -428,7 +428,7 @@ public class MysqlSavedSchema {
 			), schemaRS.getLong("last_heartbeat_read")
 		));
 
-		LOGGER.info("Restoring schema id " + schemaRS.getInt("id") + " (last modified at " + this.position + ")");
+		LOGGER.info("Restoring schema id " + schemaRS.getLong("id") + " (last modified at " + this.position + ")");
 
 		this.schemaID = schemaRS.getLong("id");
 		this.baseSchemaID = schemaRS.getLong("base_schema_id");

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -187,6 +187,48 @@ public class SchemaStoreSchema {
 		if ( !getTableColumns("bootstrap", c).get("where_clause").equals("text") ) {
 			performAlter(c, "alter table `bootstrap` modify where_clause text default null");
 		}
+
+		// bigint conversions
+		HashMap<String, String> columnsColumns = getTableColumns("columns", c);
+		if ( !columnsColumns.get("id").startsWith("bigint")
+				|| !columnsColumns.get("schema_id").startsWith("bigint")
+				|| !columnsColumns.get("table_id").startsWith("bigint")) {
+			performAlter(c, "alter table `columns` " +
+					"modify id bigint NOT NULL AUTO_INCREMENT, " +
+					"modify schema_id bigint, " +
+					"modify table_id bigint");
+		}
+
+		HashMap<String, String> tablesColumns = getTableColumns("tables", c);
+		if ( !tablesColumns.get("id").startsWith("bigint")
+				|| !tablesColumns.get("schema_id").startsWith("bigint")
+				|| !tablesColumns.get("database_id").startsWith("bigint")) {
+			performAlter(c, "alter table `tables` " +
+					"modify id bigint NOT NULL AUTO_INCREMENT, " +
+					"modify schema_id bigint, " +
+					"modify database_id bigint");
+		}
+
+		HashMap<String, String> databasesColumns = getTableColumns("databases", c);
+		if ( !databasesColumns.get("id").startsWith("bigint")
+				|| !databasesColumns.get("schema_id").startsWith("bigint")) {
+			performAlter(c, "alter table `databases` " +
+					"modify id bigint NOT NULL AUTO_INCREMENT, " +
+					"modify schema_id bigint");
+		}
+
+		HashMap<String, String> schemaColumns2 = getTableColumns("schemas", c);
+		if ( !schemaColumns2.get("id").startsWith("bigint")
+				|| !schemaColumns2.get("base_schema_id").startsWith("bigint")) {
+			performAlter(c, "alter table `schemas` " +
+					"modify id bigint NOT NULL AUTO_INCREMENT, " +
+					"modify base_schema_id bigint");
+		}
+
+		if ( !getTableColumns("bootstrap", c).get("id").startsWith("bigint")) {
+			performAlter(c, "alter table `bootstrap` modify id bigint NOT NULL AUTO_INCREMENT");
+		}
+		// end bigint conversions
 	}
 
 	private static void backfillPositionSHAs(Connection c) throws SQLException {

--- a/src/main/resources/sql/maxwell_schema.sql
+++ b/src/main/resources/sql/maxwell_schema.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS `schemas` (
-  id int unsigned auto_increment NOT NULL primary key,
+  id bigint auto_increment NOT NULL primary key,
   binlog_file varchar(255),
   binlog_position int unsigned,
   last_heartbeat_read bigint null default 0,
   gtid_set varchar(4096),
-  base_schema_id int unsigned NULL default NULL,
+  base_schema_id bigint NULL default NULL,
   deltas mediumtext charset 'utf8' NULL default NULL,
   server_id int unsigned,
   position_sha char(40) CHARACTER SET latin1 DEFAULT NULL,
@@ -15,17 +15,17 @@ CREATE TABLE IF NOT EXISTS `schemas` (
 );
 
 CREATE TABLE IF NOT EXISTS `databases` (
-  id        int unsigned auto_increment NOT NULL primary key,
-  schema_id int unsigned,
+  id        bigint auto_increment NOT NULL primary key,
+  schema_id bigint,
   name      varchar(255) charset 'utf8',
   charset   varchar(255),
   index (schema_id)
 );
 
 CREATE TABLE IF NOT EXISTS `tables` (
-  id          int unsigned auto_increment NOT NULL primary key,
-  schema_id   int unsigned,
-  database_id int unsigned,
+  id          bigint auto_increment NOT NULL primary key,
+  schema_id   bigint,
+  database_id bigint,
   name      varchar(255) charset 'utf8',
   charset   varchar(255),
   pk        varchar(1024) charset 'utf8',
@@ -34,9 +34,9 @@ CREATE TABLE IF NOT EXISTS `tables` (
 );
 
 CREATE TABLE IF NOT EXISTS `columns` (
-  id          int unsigned auto_increment NOT NULL primary key,
-  schema_id   int unsigned,
-  table_id    int unsigned,
+  id          bigint auto_increment NOT NULL primary key,
+  schema_id   bigint,
+  table_id    bigint,
   name        varchar(255) charset 'utf8',
   charset     varchar(255),
   coltype     varchar(255),

--- a/src/main/resources/sql/maxwell_schema_bootstrap.sql
+++ b/src/main/resources/sql/maxwell_schema_bootstrap.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS `bootstrap` (
-  id              int unsigned auto_increment NOT NULL primary key,
+  id              bigint auto_increment NOT NULL primary key,
   database_name   varchar(255) charset 'utf8' NOT NULL,
   table_name      varchar(255) charset 'utf8' NOT NULL,
   where_clause    text default NULL,

--- a/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
+++ b/src/test/java/com/zendesk/maxwell/MysqlSavedSchemaTest.java
@@ -145,6 +145,19 @@ public class MysqlSavedSchemaTest extends MaxwellTestWithIsolatedServer {
 		c.createStatement().executeUpdate("alter table maxwell.positions drop column client_id");
 		c.createStatement().executeUpdate("alter table maxwell.positions drop column gtid_set");
 		c.createStatement().executeUpdate("alter table maxwell.schemas drop column gtid_set");
+		c.createStatement().executeUpdate("alter table `columns` " +
+				"modify id int unsigned NOT NULL AUTO_INCREMENT, " +
+				"modify schema_id int unsigned, " +
+				"modify table_id int unsigned");
+		c.createStatement().executeUpdate("alter table `tables` " +
+				"modify id int unsigned NOT NULL AUTO_INCREMENT, " +
+				"modify schema_id int unsigned, " +
+				"modify database_id int unsigned");
+		c.createStatement().executeUpdate("alter table `databases` " +
+				"modify id int unsigned NOT NULL AUTO_INCREMENT, " +
+				"modify schema_id int unsigned");
+		c.createStatement().executeUpdate("alter table `schemas` modify id int unsigned NOT NULL AUTO_INCREMENT");
+		c.createStatement().executeUpdate("alter table `bootstrap` modify id int unsigned NOT NULL AUTO_INCREMENT");
 		SchemaStoreSchema.upgradeSchemaStoreSchema(c); // just verify no-crash.
 	}
 


### PR DESCRIPTION
Changed the `id` and related references to `id`s in each table to BIGINT. BIGINT (signed) maps directly to Java's long implementation and provides more than enough room to grow. Prior to this change, we are using `int unsigned` for the `id` fields. Java's int is signed and so all of the references to `id`s should have already been using `ResultSet#getLong`.

Work done:
 - Change default DDL for id fields to use `bigint` instead of `int unsigned`
 - Add automatic migration to SchemaStoreSchema
 - Search for all `getInt` and `setInt` calls in the repo, change to getLong/setLong where necessary. There was only one change needed here.
 - Added to existing unit test to verify no SQL issues
 - Verified upgrade code in testing environment (see below)

**More details**
When dealing with per-tenant DBs, DDL changes are frequent. Users who do this need to keep the number of schema deltas down to a reasonable size in order to avoid slow startup and high memory usage on start.

Some environment details that justify this change: Setting `max_schemas` to 30K leads to ~3 compactions per day due to regular change on a testing environment. The overall number of counts are steady at ~5M columns despite this frequent change (a bunch of creates/drops). At the rate of 15M ids per day (5M columns x 3 compactions per day), we'll run into the unsigned int max(4,294,967,295) of the `columns` table in 286 days. We can compact less, but it increases start time as well as memory usage at start time and at compaction time. While we may want to tune this more, the problem of running out of ids with the current table layout remains without this change.

**Manual test details from testing environment**

Time taken for ALTER:
```
columns: 47 secs, 5M rows
tables: 8 secs, 1M rows
databases: < 1 sec, 70K rows
schemas: < 1 sec, 20K rows
bootstrap: < 1 sec, 0 rows
```

Ran `SHOW CREATE TABLE maxwell.<tablename>` for each of columns, tables, schemas, databases, and bootstrap before and after deploying this change.
AUTO_INCREMENT value is unchanged on existing tables.
```
$ diff  ~/before ~/after
2,4c2,4
<   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
<   `schema_id` int(10) unsigned DEFAULT NULL,
<   `table_id` int(10) unsigned DEFAULT NULL,
---
>   `id` bigint(20) NOT NULL AUTO_INCREMENT,
>   `schema_id` bigint(20) DEFAULT NULL,
>   `table_id` bigint(20) DEFAULT NULL,
16,18c16,18
<   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
<   `schema_id` int(10) unsigned DEFAULT NULL,
<   `database_id` int(10) unsigned DEFAULT NULL,
---
>   `id` bigint(20) NOT NULL AUTO_INCREMENT,
>   `schema_id` bigint(20) DEFAULT NULL,
>   `database_id` bigint(20) DEFAULT NULL,
27c27
<   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
---
>   `id` bigint(20) NOT NULL AUTO_INCREMENT,
32c32
<   `base_schema_id` int(10) unsigned DEFAULT NULL,
---
>   `base_schema_id` bigint(20) DEFAULT NULL,
43,44c43,44
<   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
<   `schema_id` int(10) unsigned DEFAULT NULL,
---
>   `id` bigint(20) NOT NULL AUTO_INCREMENT,
>   `schema_id` bigint(20) DEFAULT NULL,
51c51
<   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
---
>   `id` bigint(20) NOT NULL AUTO_INCREMENT,
```