### PR TITLE
Change non-test SQL code to try-with-resources

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -334,8 +335,9 @@ public class MaxwellContext {
 		if ( this.serverID != null)
 			return this.serverID;
 
-		try ( Connection c = getReplicationConnection() ) {
-			ResultSet rs = c.createStatement().executeQuery("SELECT @@server_id as server_id");
+		try ( Connection c = getReplicationConnection();
+		      Statement s = c.createStatement();
+		      ResultSet rs = s.executeQuery("SELECT @@server_id as server_id") ) {
 			if ( !rs.next() ) {
 				throw new RuntimeException("Could not retrieve server_id!");
 			}

--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -95,14 +95,14 @@ public class BootstrapController extends RunLoopProcess  {
 
 	private List<BootstrapTask> getIncompleteTasks() throws SQLException {
 		ArrayList<BootstrapTask> list = new ArrayList<>();
-		try ( Connection cx = maxwellConnectionPool.getConnection() ) {
-			PreparedStatement s = cx.prepareStatement("select * from bootstrap where is_complete = 0 and client_id = ? and (started_at is null or started_at <= now()) order by isnull(started_at), started_at asc, id asc");
+		try ( Connection cx = maxwellConnectionPool.getConnection();
+			  PreparedStatement s = cx.prepareStatement("select * from bootstrap where is_complete = 0 and client_id = ? and (started_at is null or started_at <= now()) order by isnull(started_at), started_at asc, id asc") ) {
 			s.setString(1, this.clientID);
 
-			ResultSet rs = s.executeQuery();
-
-			while (rs.next()) {
-				list.add(BootstrapTask.valueOf(rs));
+			try ( ResultSet rs = s.executeQuery() ) {
+				while (rs.next()) {
+					list.add(BootstrapTask.valueOf(rs));
+				}
 			}
 		}
 		return list;

--- a/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
+++ b/src/main/java/com/zendesk/maxwell/recovery/Recovery.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -113,8 +114,9 @@ public class Recovery {
 
 	private List<BinlogPosition> getBinlogInfo() throws SQLException {
 		ArrayList<BinlogPosition> list = new ArrayList<>();
-		try ( Connection c = replicationConnectionPool.getConnection() ) {
-			ResultSet rs = c.createStatement().executeQuery("SHOW BINARY LOGS");
+		try ( Connection c = replicationConnectionPool.getConnection() ;
+		      Statement s = c.createStatement();
+		      ResultSet rs = s.executeQuery("SHOW BINARY LOGS") ) {
 			while ( rs.next() ) {
 				list.add(BinlogPosition.at(4, rs.getString("Log_name")));
 			}

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlPositionStore.java
@@ -56,22 +56,22 @@ public class MysqlPositionStore {
 
 		BinlogPosition binlogPosition = newPosition.getBinlogPosition();
 		connectionPool.withSQLRetry(1, (c) -> {
-			PreparedStatement s = c.prepareStatement(sql);
+			try ( PreparedStatement s = c.prepareStatement(sql) ) {
+				LOGGER.debug("Writing binlog position to {}.positions: {}, last heartbeat read: {}",
+						c.getCatalog(), newPosition, heartbeat);
+				s.setLong(1, serverID);
+				s.setString(2, binlogPosition.getGtidSetStr());
+				s.setString(3, binlogPosition.getFile());
+				s.setLong(4, binlogPosition.getOffset());
+				s.setLong(5, heartbeat);
+				s.setString(6, clientID);
+				s.setLong(7, heartbeat);
+				s.setString(8, binlogPosition.getGtidSetStr());
+				s.setString(9, binlogPosition.getFile());
+				s.setLong(10, binlogPosition.getOffset());
 
-			LOGGER.debug("Writing binlog position to {}.positions: {}, last heartbeat read: {}",
-					c.getCatalog(), newPosition, heartbeat);
-			s.setLong(1, serverID);
-			s.setString(2, binlogPosition.getGtidSetStr());
-			s.setString(3, binlogPosition.getFile());
-			s.setLong(4, binlogPosition.getOffset());
-			s.setLong(5, heartbeat);
-			s.setString(6, clientID);
-			s.setLong(7, heartbeat);
-			s.setString(8, binlogPosition.getGtidSetStr());
-			s.setString(9, binlogPosition.getFile());
-			s.setLong(10, binlogPosition.getOffset());
-
-			s.execute();
+				s.execute();
+			}
 		});
 	}
 
@@ -98,12 +98,12 @@ public class MysqlPositionStore {
 	private Long insertHeartbeat(Connection c, Long thisHeartbeat) throws SQLException, DuplicateProcessException {
 		String heartbeatInsert = "insert into `heartbeats` set `heartbeat` = ?, `server_id` = ?, `client_id` = ?";
 
-		PreparedStatement s = c.prepareStatement(heartbeatInsert);
-		s.setLong(1, thisHeartbeat);
-		s.setLong(2, serverID);
-		s.setString(3, clientID);
 
-		try {
+		try ( PreparedStatement s = c.prepareStatement(heartbeatInsert) ) {
+			s.setLong(1, thisHeartbeat);
+			s.setLong(2, serverID);
+			s.setString(3, clientID);
+
 			s.execute();
 			return thisHeartbeat;
 		} catch ( SQLIntegrityConstraintViolationException e ) {
@@ -113,30 +113,34 @@ public class MysqlPositionStore {
 
 	private void heartbeat(Connection c, long thisHeartbeat) throws SQLException, DuplicateProcessException {
 		if ( lastHeartbeat == null ) {
-			PreparedStatement s = c.prepareStatement("SELECT `heartbeat` from `heartbeats` where server_id = ? and client_id = ?");
-			s.setLong(1, serverID);
-			s.setString(2, clientID);
+			try ( PreparedStatement s = c.prepareStatement("SELECT `heartbeat` from `heartbeats` where server_id = ? and client_id = ?") ) {
+				s.setLong(1, serverID);
+				s.setString(2, clientID);
 
-			ResultSet rs = s.executeQuery();
-			if ( !rs.next() ) {
-				insertHeartbeat(c, thisHeartbeat);
-				lastHeartbeat = thisHeartbeat;
-				return;
-			} else {
-				lastHeartbeat = rs.getLong("heartbeat");
+				try ( ResultSet rs = s.executeQuery() ) {
+					if ( !rs.next() ) {
+						insertHeartbeat(c, thisHeartbeat);
+						lastHeartbeat = thisHeartbeat;
+						return;
+					} else {
+						lastHeartbeat = rs.getLong("heartbeat");
+					}
+				}
 			}
 		}
 
 		String heartbeatUpdate = "update `heartbeats` set `heartbeat` = ? where `server_id` = ? and `client_id` = ? and `heartbeat` = ?";
 
-		PreparedStatement s = c.prepareStatement(heartbeatUpdate);
-		s.setLong(1, thisHeartbeat);
-		s.setLong(2, serverID);
-		s.setString(3, clientID);
-		s.setLong(4, lastHeartbeat);
+		final int nRows;
+		try ( PreparedStatement s = c.prepareStatement(heartbeatUpdate) ) {
+			s.setLong(1, thisHeartbeat);
+			s.setLong(2, serverID);
+			s.setString(3, clientID);
+			s.setLong(4, lastHeartbeat);
 
-		LOGGER.debug("writing heartbeat: {} (last heartbeat written: {})", thisHeartbeat, lastHeartbeat);
-		int nRows = s.executeUpdate();
+			LOGGER.debug("writing heartbeat: {} (last heartbeat written: {})", thisHeartbeat, lastHeartbeat);
+			nRows = s.executeUpdate();
+		}
 		if ( nRows != 1 ) {
 			String msg = String.format(
 				"Expected a heartbeat value of %d but didn't find it.  Is another Maxwell process running with the same client_id?",
@@ -173,21 +177,25 @@ public class MysqlPositionStore {
 	}
 
 	public Position getLatestFromAnyClient() throws SQLException {
-		try ( Connection c = connectionPool.getConnection() ) {
-			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? ORDER BY last_heartbeat_read desc limit 1");
+		try ( Connection c = connectionPool.getConnection();
+			  PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? ORDER BY last_heartbeat_read desc limit 1") ) {
 			s.setLong(1, serverID);
 
-			return positionFromResultSet(s.executeQuery());
+			try ( ResultSet rs = s.executeQuery() ) {
+				return positionFromResultSet(rs);
+			}
 		}
 	}
 
 	public Position get() throws SQLException {
-		try ( Connection c = connectionPool.getConnection() ) {
-			PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? and client_id = ?");
+		try ( Connection c = connectionPool.getConnection();
+			  PreparedStatement s = c.prepareStatement("SELECT * from `positions` where server_id = ? and client_id = ?") ) {
 			s.setLong(1, serverID);
 			s.setString(2, clientID);
 
-			return positionFromResultSet(s.executeQuery());
+			try ( ResultSet rs = s.executeQuery() ) {
+				return positionFromResultSet(rs);
+			}
 		}
 	}
 
@@ -220,28 +228,29 @@ public class MysqlPositionStore {
 	}
 
 	protected List<RecoveryInfo> getAllRecoveryInfos(Connection c) throws SQLException {
-		PreparedStatement s = c.prepareStatement("SELECT * from `positions` where client_id = ? order by last_heartbeat_read DESC");
-		s.setString(1, clientID);
-		ResultSet rs = s.executeQuery();
+		try ( PreparedStatement s = c.prepareStatement("SELECT * from `positions` where client_id = ? order by last_heartbeat_read DESC") ) {
+			s.setString(1, clientID);
+			try ( ResultSet rs = s.executeQuery() ) {
+				ArrayList<RecoveryInfo> recoveries = new ArrayList<>();
 
-		ArrayList<RecoveryInfo> recoveries = new ArrayList<>();
+				while ( rs.next() ) {
+					Long server_id = rs.getLong("server_id");
+					String gtid = gtidMode ? rs.getString("gtid_set") : null;
+					Position position = new Position(
+							BinlogPosition.at(gtid,
+									rs.getLong("binlog_position"),
+									rs.getString("binlog_file")
+							), rs.getLong("last_heartbeat_read"));
 
-		while ( rs.next() ) {
-			Long server_id = rs.getLong("server_id");
-			String gtid = gtidMode ? rs.getString("gtid_set") : null;
-			Position position = new Position(
-				BinlogPosition.at(gtid,
-					rs.getLong("binlog_position"),
-					rs.getString("binlog_file")
-				), rs.getLong("last_heartbeat_read"));
-
-			if ( rs.wasNull() ) {
-				LOGGER.warn("master recovery is ignoring position with NULL heartbeat");
-			} else {
-				recoveries.add(new RecoveryInfo(position, server_id, clientID));
+					if ( rs.wasNull() ) {
+						LOGGER.warn("master recovery is ignoring position with NULL heartbeat");
+					} else {
+						recoveries.add(new RecoveryInfo(position, server_id, clientID));
+					}
+				}
+				return recoveries;
 			}
 		}
-		return recoveries;
 	}
 
 	protected List<String> formatRecoveryFailure(MaxwellConfig config, List<RecoveryInfo> recoveries) {
@@ -270,10 +279,9 @@ public class MysqlPositionStore {
 		if (allRecoveryInfos.size() > 1) {
 			LOGGER.warn("Multiple recovery infos found: " + allRecoveryInfos);
 			LOGGER.info("Removing entries where server_id != " + serverID);
-			try (Connection c = connectionPool.getConnection()) {
-				PreparedStatement s = c.prepareStatement(
-					"DELETE FROM `positions` WHERE server_id <> ? AND client_id = ?"
-				);
+			try ( Connection c = connectionPool.getConnection();
+				  PreparedStatement s = c.prepareStatement(
+				    "DELETE FROM `positions` WHERE server_id <> ? AND client_id = ?") ) {
 				s.setLong(1, serverID);
 				s.setString(2, clientID);
 				s.execute();

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -93,12 +93,12 @@ public class MysqlSavedSchema {
 		}
 		preparedStatement.executeUpdate();
 
-		ResultSet rs = preparedStatement.getGeneratedKeys();
-
-		if (rs.next()) {
-			return rs.getLong(1);
-		} else
-			return null;
+		try ( ResultSet rs = preparedStatement.getGeneratedKeys() ) {
+			if (rs.next()) {
+				return rs.getLong(1);
+			} else
+				return null;
+		}
 	}
 
 	public Long save(Connection connection) throws SQLException {
@@ -129,48 +129,52 @@ public class MysqlSavedSchema {
 	/* Look for SHAs already created at a position we're about to save to.
 	 * don't conflict with other maxwell replicators running on the same server. */
 	private Long findSchemaForPositionSHA(Connection c, String sha) throws SQLException {
-		PreparedStatement p = c.prepareStatement("SELECT * from `schemas` where position_sha = ?");
-		p.setString(1, sha);
-		ResultSet rs = p.executeQuery();
+		try ( PreparedStatement p = c.prepareStatement("SELECT * from `schemas` where position_sha = ?") ) {
+			p.setString(1, sha);
+			try ( ResultSet rs = p.executeQuery() ) {
 
-		if ( rs.next() ) {
-			Long id = rs.getLong("id");
-			LOGGER.debug("findSchemaForPositionSHA: found schema_id: {} for sha: {}", id, sha);
-			return id;
-		} else {
-			return null;
+				if ( rs.next() ) {
+					Long id = rs.getLong("id");
+					LOGGER.debug("findSchemaForPositionSHA: found schema_id: {} for sha: {}", id, sha);
+					return id;
+				} else {
+					return null;
+				}
+			}
 		}
 	}
 
 	private Long saveDerivedSchema(Connection conn) throws SQLException {
-		PreparedStatement insert = conn.prepareStatement(
+		try ( PreparedStatement insert = conn.prepareStatement(
 				"INSERT into `schemas` SET base_schema_id = ?, deltas = ?, binlog_file = ?, " +
 				"binlog_position = ?, server_id = ?, charset = ?, version = ?, " +
 				"position_sha = ?, gtid_set = ?, last_heartbeat_read = ?",
-				Statement.RETURN_GENERATED_KEYS);
+				Statement.RETURN_GENERATED_KEYS);) {
 
-		String deltaString;
 
-		try {
-			deltaString = mapper.writerFor(listOfResolvedSchemaChangeType).writeValueAsString(deltas);
-		} catch ( JsonProcessingException e ) {
-			throw new RuntimeException("Couldn't serialize " + deltas + " to JSON.");
+			String deltaString;
+
+			try {
+				deltaString = mapper.writerFor(listOfResolvedSchemaChangeType).writeValueAsString(deltas);
+			} catch ( JsonProcessingException e ) {
+				throw new RuntimeException("Couldn't serialize " + deltas + " to JSON.");
+			}
+			BinlogPosition binlogPosition = position.getBinlogPosition();
+
+			return executeInsert(
+					insert,
+					this.baseSchemaID,
+					deltaString,
+					binlogPosition.getFile(),
+					binlogPosition.getOffset(),
+					serverID,
+					schema.getCharset(),
+					SchemaStoreVersion,
+					getPositionSHA(),
+					binlogPosition.getGtidSetStr(),
+					position.getLastHeartbeatRead()
+			);
 		}
-		BinlogPosition binlogPosition = position.getBinlogPosition();
-
-		return executeInsert(
-			insert,
-			this.baseSchemaID,
-			deltaString,
-			binlogPosition.getFile(),
-			binlogPosition.getOffset(),
-			serverID,
-			schema.getCharset(),
-			SchemaStoreVersion,
-			getPositionSHA(),
-			binlogPosition.getGtidSetStr(),
-			position.getLastHeartbeatRead()
-		);
 
 	}
 
@@ -178,95 +182,90 @@ public class MysqlSavedSchema {
 		if (this.baseSchemaID != null)
 			return saveDerivedSchema(conn);
 
-		PreparedStatement schemaInsert;
-
-		schemaInsert = conn.prepareStatement(
+		final Long schemaId;
+		try ( PreparedStatement schemaInsert = conn.prepareStatement(
 				"INSERT INTO `schemas` SET binlog_file = ?, binlog_position = ?, server_id = ?, charset = ?, version = ?, position_sha = ?, gtid_set = ?, last_heartbeat_read = ?",
-				Statement.RETURN_GENERATED_KEYS
-		);
+				Statement.RETURN_GENERATED_KEYS) ) {
 
-		BinlogPosition binlogPosition = position.getBinlogPosition();
-		Long schemaId = executeInsert(schemaInsert, binlogPosition.getFile(),
-				binlogPosition.getOffset(), serverID, schema.getCharset(), SchemaStoreVersion,
-				getPositionSHA(), binlogPosition.getGtidSetStr(), position.getLastHeartbeatRead());
+			BinlogPosition binlogPosition = position.getBinlogPosition();
+			schemaId = executeInsert(schemaInsert, binlogPosition.getFile(),
+					binlogPosition.getOffset(), serverID, schema.getCharset(), SchemaStoreVersion,
+					getPositionSHA(), binlogPosition.getGtidSetStr(), position.getLastHeartbeatRead());
+		}
 		saveFullSchema(conn, schemaId);
 		return schemaId;
 	}
 
 	public void saveFullSchema(Connection conn, Long schemaId) throws SQLException {
-		PreparedStatement databaseInsert, tableInsert;
 
-		databaseInsert = conn.prepareStatement(
+		try ( PreparedStatement databaseInsert = conn.prepareStatement(
 				"INSERT INTO `databases` SET schema_id = ?, name = ?, charset=?",
-				Statement.RETURN_GENERATED_KEYS
-		);
+				Statement.RETURN_GENERATED_KEYS);
+			  PreparedStatement tableInsert = conn.prepareStatement(
+			    "INSERT INTO `tables` SET schema_id = ?, database_id = ?, name = ?, charset=?, pk=?",
+			    Statement.RETURN_GENERATED_KEYS) ) {
 
-		tableInsert = conn.prepareStatement(
-				"INSERT INTO `tables` SET schema_id = ?, database_id = ?, name = ?, charset=?, pk=?",
-				Statement.RETURN_GENERATED_KEYS
-		);
+			ArrayList<Object> columnData = new ArrayList<Object>();
 
+			for (Database d : schema.getDatabases()) {
+				Long dbId = executeInsert(databaseInsert, schemaId, d.getName(), d.getCharset());
 
-		ArrayList<Object> columnData = new ArrayList<Object>();
-
-		for (Database d : schema.getDatabases()) {
-			Long dbId = executeInsert(databaseInsert, schemaId, d.getName(), d.getCharset());
-
-			for (Table t : d.getTableList()) {
-				Long tableId = executeInsert(tableInsert, schemaId, dbId, t.getName(), t.getCharset(), t.getPKString());
+				for (Table t : d.getTableList()) {
+					Long tableId = executeInsert(tableInsert, schemaId, dbId, t.getName(), t.getCharset(), t.getPKString());
 
 
-				for (ColumnDef c : t.getColumnList()) {
-					String enumValuesSQL = null;
+					for (ColumnDef c : t.getColumnList()) {
+						String enumValuesSQL = null;
 
-					if ( c instanceof EnumeratedColumnDef ) {
-						EnumeratedColumnDef enumColumn = (EnumeratedColumnDef) c;
-						if (enumColumn.getEnumValues() != null) {
-							try {
-								enumValuesSQL = mapper.writeValueAsString(enumColumn.getEnumValues());
-							} catch (JsonProcessingException e) {
-								throw new SQLException(e);
+						if ( c instanceof EnumeratedColumnDef ) {
+							EnumeratedColumnDef enumColumn = (EnumeratedColumnDef) c;
+							if (enumColumn.getEnumValues() != null) {
+								try {
+									enumValuesSQL = mapper.writeValueAsString(enumColumn.getEnumValues());
+								} catch (JsonProcessingException e) {
+									throw new SQLException(e);
+								}
 							}
+						}
+
+						columnData.add(schemaId);
+						columnData.add(tableId);
+						columnData.add(c.getName());
+
+						if ( c instanceof StringColumnDef ) {
+							columnData.add(((StringColumnDef) c).getCharset());
+						} else {
+							columnData.add(null);
+						}
+
+						columnData.add(c.getType());
+
+						if ( c instanceof IntColumnDef ) {
+							columnData.add(((IntColumnDef) c).isSigned() ? 1 : 0);
+						} else if ( c instanceof BigIntColumnDef ) {
+							columnData.add(((BigIntColumnDef) c).isSigned() ? 1 : 0);
+						} else {
+							columnData.add(0);
+						}
+
+						columnData.add(enumValuesSQL);
+
+						if ( c instanceof ColumnDefWithLength ) {
+							Long columnLength = ((ColumnDefWithLength) c).getColumnLength();
+							columnData.add(columnLength);
+						} else {
+							columnData.add(null);
 						}
 					}
 
-					columnData.add(schemaId);
-					columnData.add(tableId);
-					columnData.add(c.getName());
+					if ( columnData.size() > 1000 )
+						executeColumnInsert(conn, columnData);
 
-					if ( c instanceof StringColumnDef ) {
-						columnData.add(((StringColumnDef) c).getCharset());
-					} else {
-						columnData.add(null);
-					}
-
-					columnData.add(c.getType());
-
-					if ( c instanceof IntColumnDef ) {
-						columnData.add(((IntColumnDef) c).isSigned() ? 1 : 0);
-					} else if ( c instanceof BigIntColumnDef ) {
-						columnData.add(((BigIntColumnDef) c).isSigned() ? 1 : 0);
-					} else {
-						columnData.add(0);
-					}
-
-					columnData.add(enumValuesSQL);
-
-					if ( c instanceof ColumnDefWithLength ) {
-						Long columnLength = ((ColumnDefWithLength) c).getColumnLength();
-						columnData.add(columnLength);
-					} else {
-						columnData.add(null);
-					}
 				}
-
-				if ( columnData.size() > 1000 )
-					executeColumnInsert(conn, columnData);
-
 			}
+			if ( columnData.size() > 0 )
+				executeColumnInsert(conn, columnData);
 		}
-		if ( columnData.size() > 0 )
-			executeColumnInsert(conn, columnData);
 	}
 
 	private void executeColumnInsert(Connection conn, ArrayList<Object> columnData) throws SQLException {
@@ -276,14 +275,14 @@ public class MysqlSavedSchema {
 			insertColumnSQL = insertColumnSQL + ", (?, ?, ?, ?, ?, ?, ?, ?)";
 		}
 
-		PreparedStatement columnInsert = conn.prepareStatement(insertColumnSQL);
-		int i = 1;
+		try ( PreparedStatement columnInsert = conn.prepareStatement(insertColumnSQL) ) {
+			int i = 1;
 
-		for (Object o : columnData)
-			columnInsert.setObject(i++,  o);
+			for (Object o : columnData)
+				columnInsert.setObject(i++,  o);
 
-		columnInsert.execute();
-		columnInsert.close();
+			columnInsert.execute();
+		}
 		columnData.clear();
 	}
 
@@ -334,18 +333,17 @@ public class MysqlSavedSchema {
 	private HashMap<Long, HashMap<String, Object>> buildSchemaMap(Connection conn) throws SQLException {
 		HashMap<Long, HashMap<String, Object>> schemas = new HashMap<>();
 
-		PreparedStatement p = conn.prepareStatement("SELECT * from `schemas`");
-		ResultSet rs = p.executeQuery();
-
-		ResultSetMetaData md = rs.getMetaData();
-		while ( rs.next() ) {
-			HashMap<String, Object> row = new HashMap<>();
-			for ( int i = 1; i <= md.getColumnCount(); i++ )
-				row.put(md.getColumnName(i), rs.getObject(i));
-			schemas.put(rs.getLong("id"), row);
+		try ( PreparedStatement p = conn.prepareStatement("SELECT * from `schemas`");
+			  ResultSet rs = p.executeQuery() ) {
+			ResultSetMetaData md = rs.getMetaData();
+			while ( rs.next() ) {
+				HashMap<String, Object> row = new HashMap<>();
+				for ( int i = 1; i <= md.getColumnCount(); i++ )
+					row.put(md.getColumnName(i), rs.getObject(i));
+				schemas.put(rs.getLong("id"), row);
+			}
+			return schemas;
 		}
-		rs.close();
-		return schemas;
 	}
 
 	/*
@@ -414,36 +412,37 @@ public class MysqlSavedSchema {
 	}
 
 	private void restoreSchemaMetadata(Connection conn, Long schemaID) throws SQLException {
-		PreparedStatement p = conn.prepareStatement("select * from `schemas` where id = " + schemaID);
-		ResultSet schemaRS = p.executeQuery();
+		try ( PreparedStatement p = conn.prepareStatement("select * from `schemas` where id = " + schemaID);
+			  ResultSet schemaRS = p.executeQuery() ) {
 
-		schemaRS.next();
+			schemaRS.next();
 
-		setPosition(new Position(
-			new BinlogPosition(
-				schemaRS.getString("gtid_set"),
-				null,
-				schemaRS.getInt("binlog_position"),
-				schemaRS.getString("binlog_file")
-			), schemaRS.getLong("last_heartbeat_read")
-		));
+			setPosition(new Position(
+					new BinlogPosition(
+							schemaRS.getString("gtid_set"),
+							null,
+							schemaRS.getInt("binlog_position"),
+							schemaRS.getString("binlog_file")
+					), schemaRS.getLong("last_heartbeat_read")
+			));
 
-		LOGGER.info("Restoring schema id " + schemaRS.getInt("id") + " (last modified at " + this.position + ")");
+			LOGGER.info("Restoring schema id " + schemaRS.getInt("id") + " (last modified at " + this.position + ")");
 
-		this.schemaID = schemaRS.getLong("id");
-		this.baseSchemaID = schemaRS.getLong("base_schema_id");
+			this.schemaID = schemaRS.getLong("id");
+			this.baseSchemaID = schemaRS.getLong("base_schema_id");
 
-		if ( schemaRS.wasNull() )
-			this.baseSchemaID = null;
+			if ( schemaRS.wasNull() )
+				this.baseSchemaID = null;
 
-		this.deltas = parseDeltas(schemaRS.getString("deltas"));
-		this.schemaVersion = schemaRS.getInt("version");
-		this.schema = new Schema(new ArrayList<Database>(), schemaRS.getString("charset"), this.sensitivity);
+			this.deltas = parseDeltas(schemaRS.getString("deltas"));
+			this.schemaVersion = schemaRS.getInt("version");
+			this.schema = new Schema(new ArrayList<Database>(), schemaRS.getString("charset"), this.sensitivity);
+		}
 	}
 
 
 	private void restoreFullSchema(Connection conn, Long schemaID) throws SQLException, InvalidSchemaError {
-		PreparedStatement p = conn.prepareStatement(
+		String sql =
 				"SELECT " +
 						"d.id AS dbId," +
 						"d.name AS dbName," +
@@ -462,94 +461,94 @@ public class MysqlSavedSchema {
 						"LEFT JOIN tables t ON d.id = t.database_id " +
 						"LEFT JOIN columns c ON c.table_id=t.id " +
 						"WHERE d.schema_id = ? " +
-						"ORDER BY d.id, t.id, c.id"
-		);
+						"ORDER BY d.id, t.id, c.id";
+		try ( PreparedStatement p = conn.prepareStatement(sql) ) {
+			p.setLong(1, this.schemaID);
+			try ( ResultSet rs = p.executeQuery() ) {
 
-		p.setLong(1, this.schemaID);
-		ResultSet rs = p.executeQuery();
+				Database currentDatabase = null;
+				Table currentTable = null;
+				short columnIndex = 0;
 
-		Database currentDatabase = null;
-		Table currentTable = null;
-		short columnIndex = 0;
+				while (rs.next()) {
+					// Database
+					String dbName = rs.getString("dbName");
+					String dbCharset = rs.getString("dbCharset");
 
-		while (rs.next()) {
-			// Database
-			String dbName = rs.getString("dbName");
-			String dbCharset = rs.getString("dbCharset");
+					// Table
+					String tName = rs.getString("tableName");
+					String tCharset = rs.getString("tableCharset");
+					String tPKs = rs.getString("tablePk");
 
-			// Table
-			String tName = rs.getString("tableName");
-			String tCharset = rs.getString("tableCharset");
-			String tPKs = rs.getString("tablePk");
+					// Column
+					String columnName = rs.getString("columnName");
+					int columnLengthInt = rs.getInt("columnLength");
+					String columnEnumValues = rs.getString("columnEnumValues");
+					String columnCharset = rs.getString("columnCharset");
+					String columnType = rs.getString("columnColtype");
+					int columnIsSigned = rs.getInt("columnIsSigned");
 
-			// Column
-			String columnName = rs.getString("columnName");
-			int columnLengthInt = rs.getInt("columnLength");
-			String columnEnumValues = rs.getString("columnEnumValues");
-			String columnCharset = rs.getString("columnCharset");
-			String columnType = rs.getString("columnColtype");
-			int columnIsSigned = rs.getInt("columnIsSigned");
-
-			if (currentDatabase == null || !currentDatabase.getName().equals(dbName)) {
-				currentDatabase = new Database(dbName, dbCharset);
-				this.schema.addDatabase(currentDatabase);
-				// make sure two tables named the same in different dbs are picked up.
-				currentTable = null;
-				LOGGER.debug("Restoring database {}...", dbName);
-			}
-
-			if (tName == null) {
-				// if tName is null, there are no tables connected to this database
-				continue;
-			} else if (currentTable == null || !currentTable.getName().equals(tName)) {
-				currentTable = currentDatabase.buildTable(tName, tCharset);
-				if (tPKs != null) {
-					List<String> pkList = Arrays.asList(StringUtils.split(tPKs, ','));
-					currentTable.setPKList(pkList);
-				}
-				columnIndex = 0;
-			}
-
-
-			if (columnName == null) {
-				// If columnName is null, there are no columns connected to this table
-				continue;
-			}
-
-			Long columnLength;
-			if (rs.wasNull()) {
-				columnLength = null;
-			} else {
-				columnLength = Long.valueOf(columnLengthInt);
-			}
-
-			String[] enumValues = null;
-			if (columnEnumValues != null) {
-				if (this.schemaVersion >= 4) {
-					try {
-						enumValues = mapper.readValue(columnEnumValues, String[].class);
-					} catch (IOException e) {
-						throw new SQLException(e);
+					if (currentDatabase == null || !currentDatabase.getName().equals(dbName)) {
+						currentDatabase = new Database(dbName, dbCharset);
+						this.schema.addDatabase(currentDatabase);
+						// make sure two tables named the same in different dbs are picked up.
+						currentTable = null;
+						LOGGER.debug("Restoring database {}...", dbName);
 					}
-				} else {
-					enumValues = StringUtils.splitByWholeSeparatorPreserveAllTokens(columnEnumValues, ",");
+
+					if (tName == null) {
+						// if tName is null, there are no tables connected to this database
+						continue;
+					} else if (currentTable == null || !currentTable.getName().equals(tName)) {
+						currentTable = currentDatabase.buildTable(tName, tCharset);
+						if (tPKs != null) {
+							List<String> pkList = Arrays.asList(StringUtils.split(tPKs, ','));
+							currentTable.setPKList(pkList);
+						}
+						columnIndex = 0;
+					}
+
+
+					if (columnName == null) {
+						// If columnName is null, there are no columns connected to this table
+						continue;
+					}
+
+					Long columnLength;
+					if (rs.wasNull()) {
+						columnLength = null;
+					} else {
+						columnLength = Long.valueOf(columnLengthInt);
+					}
+
+					String[] enumValues = null;
+					if (columnEnumValues != null) {
+						if (this.schemaVersion >= 4) {
+							try {
+								enumValues = mapper.readValue(columnEnumValues, String[].class);
+							} catch (IOException e) {
+								throw new SQLException(e);
+							}
+						} else {
+							enumValues = StringUtils.splitByWholeSeparatorPreserveAllTokens(columnEnumValues, ",");
+						}
+					}
+
+					ColumnDef c = ColumnDef.build(
+							columnName,
+							columnCharset,
+							columnType,
+							columnIndex++,
+							columnIsSigned == 1,
+							enumValues,
+							columnLength
+					);
+					currentTable.addColumn(c);
+
 				}
+				LOGGER.debug("Restored all databases");
 			}
-
-			ColumnDef c = ColumnDef.build(
-					columnName,
-					columnCharset,
-					columnType,
-					columnIndex++,
-					columnIsSigned == 1,
-					enumValues,
-					columnLength
-			);
-			currentTable.addColumn(c);
-
 		}
-		rs.close();
-		LOGGER.debug("Restored all databases");
 	}
 
 	private static Long findSchema(Connection connection, Position targetPosition, Long serverID)
@@ -557,51 +556,54 @@ public class MysqlSavedSchema {
 		LOGGER.debug("looking to restore schema at target position {}", targetPosition);
 		BinlogPosition targetBinlogPosition = targetPosition.getBinlogPosition();
 		if (targetBinlogPosition.getGtidSetStr() != null) {
-			PreparedStatement s = connection.prepareStatement(
-				"SELECT id, gtid_set from `schemas` "
-				+ "WHERE deleted = 0 "
-				+ "ORDER BY id desc");
-
-			ResultSet rs = s.executeQuery();
-			while (rs.next()) {
-				Long id = rs.getLong("id");
-				String gtid = rs.getString("gtid_set");
-				LOGGER.debug("Retrieving schema at id: {} gtid: {}", id, gtid);
-				if (gtid != null) {
-					GtidSet gtidSet = new GtidSet(gtid);
-					if (gtidSet.isContainedWithin(targetBinlogPosition.getGtidSet())) {
-						LOGGER.debug("Found contained schema: {}", id);
-						return id;
+			String sql = "SELECT id, gtid_set from `schemas` "
+					+ "WHERE deleted = 0 "
+					+ "ORDER BY id desc";
+			try ( PreparedStatement s = connection.prepareStatement(sql) ) {
+				try ( ResultSet rs = s.executeQuery() ) {
+					while (rs.next()) {
+						Long id = rs.getLong("id");
+						String gtid = rs.getString("gtid_set");
+						LOGGER.debug("Retrieving schema at id: {} gtid: {}", id, gtid);
+						if (gtid != null) {
+							GtidSet gtidSet = new GtidSet(gtid);
+							if (gtidSet.isContainedWithin(targetBinlogPosition.getGtidSet())) {
+								LOGGER.debug("Found contained schema: {}", id);
+								return id;
+							}
+						}
 					}
+					return null;
 				}
 			}
-			return null;
 		} else {
 			// Only consider binlog positions before the target position on the current server.
 			// Within those, sort for the latest binlog file, then the latest binlog position.
-			PreparedStatement s = connection.prepareStatement(
-				"SELECT id from `schemas` "
-				+ "WHERE deleted = 0 "
-				+ "AND last_heartbeat_read <= ? AND ("
-				+ "(binlog_file < ?) OR "
-				+ "(binlog_file = ? and binlog_position < ? and base_schema_id is not null) OR "
-				+ "(binlog_file = ? and binlog_position <= ? and base_schema_id is null) "
-				+ ") AND server_id = ? "
-				+ "ORDER BY last_heartbeat_read DESC, binlog_file DESC, binlog_position DESC limit 1");
+			String sql = "SELECT id from `schemas` "
+					+ "WHERE deleted = 0 "
+					+ "AND last_heartbeat_read <= ? AND ("
+					+ "(binlog_file < ?) OR "
+					+ "(binlog_file = ? and binlog_position < ? and base_schema_id is not null) OR "
+					+ "(binlog_file = ? and binlog_position <= ? and base_schema_id is null) "
+					+ ") AND server_id = ? "
+					+ "ORDER BY last_heartbeat_read DESC, binlog_file DESC, binlog_position DESC limit 1";
+			try ( PreparedStatement s = connection.prepareStatement(sql) ) {
 
-			s.setLong(1, targetPosition.getLastHeartbeatRead());
-			s.setString(2, targetBinlogPosition.getFile());
-			s.setString(3, targetBinlogPosition.getFile());
-			s.setLong(4, targetBinlogPosition.getOffset());
-			s.setString(5, targetBinlogPosition.getFile());
-			s.setLong(6, targetBinlogPosition.getOffset());
-			s.setLong(7, serverID);
+				s.setLong(1, targetPosition.getLastHeartbeatRead());
+				s.setString(2, targetBinlogPosition.getFile());
+				s.setString(3, targetBinlogPosition.getFile());
+				s.setLong(4, targetBinlogPosition.getOffset());
+				s.setString(5, targetBinlogPosition.getFile());
+				s.setLong(6, targetBinlogPosition.getOffset());
+				s.setLong(7, serverID);
 
-			ResultSet rs = s.executeQuery();
-			if (rs.next()) {
-				return rs.getLong("id");
-			} else
-				return null;
+				try ( ResultSet rs = s.executeQuery() ) {
+					if (rs.next()) {
+						return rs.getLong("id");
+					} else
+						return null;
+				}
+			}
 		}
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaCompactor.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaCompactor.java
@@ -53,20 +53,19 @@ public class MysqlSchemaCompactor extends RunLoopProcess {
 	}
 
 	private boolean getLock(Connection cx) throws SQLException {
-		PreparedStatement s = cx.prepareStatement(
-			"SELECT GET_LOCK(?, 0)"
-		);
-		s.setString(1, this.lockName());
-		ResultSet rs = s.executeQuery();
-		return rs.next() && rs.getBoolean(1);
+		try ( PreparedStatement s = cx.prepareStatement("SELECT GET_LOCK(?, 0)") ) {
+			s.setString(1, this.lockName());
+			try ( ResultSet rs = s.executeQuery() ) {
+				return rs.next() && rs.getBoolean(1);
+			}
+		}
 	}
 
 	private void releaseLock(Connection cx) throws SQLException {
-		PreparedStatement s = cx.prepareStatement(
-			"SELECT RELEASE_LOCK(?)"
-		);
-		s.setString(1, this.lockName());
-		s.execute();
+		try ( PreparedStatement s = cx.prepareStatement("SELECT RELEASE_LOCK(?)") ) {
+			s.setString(1, this.lockName());
+			s.execute();
+		}
 	}
 
 	public void doWork() throws Exception {
@@ -84,10 +83,11 @@ public class MysqlSchemaCompactor extends RunLoopProcess {
 	}
 
 	private boolean shouldCompact(Connection cx) throws SQLException {
-		ResultSet rs = cx.prepareStatement(
-			"select count(*) as count from `schemas` where `server_id` = " + this.serverID
-		).executeQuery();
-		return rs.next() && rs.getInt("count") >= this.maxDeltas;
+		String sql = "select count(*) as count from `schemas` where `server_id` = " + this.serverID;
+		try ( PreparedStatement ps = cx.prepareStatement(sql);
+			  ResultSet rs = ps.executeQuery() ) {
+			return rs.next() && rs.getInt("count") >= this.maxDeltas;
+		}
 	}
 
 	Long lastWarnedSchemaID = null;
@@ -97,38 +97,39 @@ public class MysqlSchemaCompactor extends RunLoopProcess {
 			return null;
 		}
 
-		ResultSet rs = cx.prepareStatement(
-			"select id, binlog_file, binlog_position, gtid_set, 0 as last_heartbeat_read "
-			+ " from `schemas` where `server_id` = " + this.serverID
-			+ " order by id desc limit 1"
-		).executeQuery();
+		String schemaSql = "select id, binlog_file, binlog_position, gtid_set, 0 as last_heartbeat_read "
+				+ " from `schemas` where `server_id` = " + this.serverID
+				+ " order by id desc limit 1";
+		final Long schemaID;
+		final Position schemaPosition;
+		try ( PreparedStatement ps = cx.prepareStatement(schemaSql);
+			  ResultSet rs = ps.executeQuery() ) {
+			if ( !rs.next() )
+				return null;
 
-		if ( !rs.next() )
-			return null;
-
-
-		Long schemaID = rs.getLong("id");
-		Position schemaPosition = MysqlPositionStore.positionFromResultSet(rs, serverID == 0);
+			schemaID = rs.getLong("id");
+			schemaPosition = MysqlPositionStore.positionFromResultSet(rs, serverID == 0);
+		}
 
 		LOGGER.debug("trying to compact schema {} @ {}", schemaID, schemaPosition);
 
-		ResultSet positionsRS = cx.prepareStatement(
-			"select * from `positions` where server_id = " + serverID
-		).executeQuery();
+		try ( PreparedStatement ps = cx.prepareStatement("select * from `positions` where server_id = " + serverID);
+			  ResultSet positionsRS = ps.executeQuery() ) {
 
-		while ( positionsRS.next() ) {
-			Position clientPosition = MysqlPositionStore.positionFromResultSet(positionsRS, serverID == 0);
-			if ( clientPosition.newerThan(schemaPosition) ) {
-				LOGGER.debug("found a client @ {}, that's fine...", clientPosition);
-			} else {
-				if ( !schemaID.equals(lastWarnedSchemaID) ) {
-					LOGGER.warn("Not compacting schema {}, client '{}' @ {} has not reached that position yet",
-						schemaID,
-						positionsRS.getString("client_id"),
-						clientPosition);
-					lastWarnedSchemaID = schemaID;
+			while ( positionsRS.next() ) {
+				Position clientPosition = MysqlPositionStore.positionFromResultSet(positionsRS, serverID == 0);
+				if ( clientPosition.newerThan(schemaPosition) ) {
+					LOGGER.debug("found a client @ {}, that's fine...", clientPosition);
+				} else {
+					if ( !schemaID.equals(lastWarnedSchemaID) ) {
+						LOGGER.warn("Not compacting schema {}, client '{}' @ {} has not reached that position yet",
+								schemaID,
+								positionsRS.getString("client_id"),
+								clientPosition);
+						lastWarnedSchemaID = schemaID;
+					}
+					return null;
 				}
-				return null;
 			}
 		}
 
@@ -144,13 +145,17 @@ public class MysqlSchemaCompactor extends RunLoopProcess {
 			return;
 
 		LOGGER.info("compacting schemas before {}", schemaID);
-		cx.prepareStatement("BEGIN").execute();
+		try ( Statement begin = cx.createStatement();
+		      Statement update = cx.createStatement();
+		      Statement commit = cx.createStatement() ) {
+			begin.execute("BEGIN");
 
-		MysqlSavedSchema savedSchema = MysqlSavedSchema.restoreFromSchemaID(schemaID, cx, this.sensitivity);
-		savedSchema.saveFullSchema(cx, schemaID);
-		cx.createStatement().executeUpdate("update `schemas` set `base_schema_id` = null, `deltas` = null where `id` = " + schemaID);
+			MysqlSavedSchema savedSchema = MysqlSavedSchema.restoreFromSchemaID(schemaID, cx, this.sensitivity);
+			savedSchema.saveFullSchema(cx, schemaID);
+			update.executeUpdate("update `schemas` set `base_schema_id` = null, `deltas` = null where `id` = " + schemaID);
 
-		cx.prepareStatement("COMMIT").execute();
+			commit.execute("COMMIT");
+		}
 
 		slowDeleteSchemas(cx, schemaID);
 	}
@@ -158,15 +163,16 @@ public class MysqlSchemaCompactor extends RunLoopProcess {
 	private void slowDeleteSchemas(Connection cx, long newBaseSchemaID) throws SQLException {
 		cx.setAutoCommit(true);
 
-		PreparedStatement ps = cx.prepareStatement(
-			"select * from `schemas` where id < ? and server_id = ?"
-		);
-		ps.setLong(1, newBaseSchemaID);
-		ps.setLong(2, serverID);
+		String sql = "select * from `schemas` where id < ? and server_id = ?";
+		try ( PreparedStatement ps = cx.prepareStatement(sql) ) {
+			ps.setLong(1, newBaseSchemaID);
+			ps.setLong(2, serverID);
 
-		ResultSet rs = ps.executeQuery();
-		while ( rs.next() ) {
-			slowDeleteSchema(cx, rs.getLong("id"));
+			try ( ResultSet rs = ps.executeQuery() ) {
+				while ( rs.next() ) {
+					slowDeleteSchema(cx, rs.getLong("id"));
+				}
+			}
 		}
 	}
 
@@ -175,16 +181,17 @@ public class MysqlSchemaCompactor extends RunLoopProcess {
 		slowDeleteFrom("columns", cx, schemaID);
 		slowDeleteFrom("tables", cx, schemaID);
 		slowDeleteFrom("databases", cx, schemaID);
-		cx.createStatement().executeUpdate("delete from `schemas` where id = " + schemaID);
+		try ( Statement s = cx.createStatement() ) {
+			s.executeUpdate("delete from `schemas` where id = " + schemaID);
+		}
 	}
 
 	private static final int DELETE_SLEEP_MS = 200;
 	private static final int DELETE_LIMIT = 500;
 
 	private void slowDeleteFrom(String table, Connection cx, long schemaID) throws SQLException {
-		try {
+		try ( Statement s = cx.createStatement() ) {
 			while ( true ) {
-				Statement s = cx.createStatement();
 				int deleted = s.executeUpdate("DELETE from `" + table + "` where schema_id = " + schemaID + " LIMIT " + DELETE_LIMIT);
 
 				if ( deleted == 0 )

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -88,9 +88,9 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 				} else {
 					// The capture time might be long and the conn connection might be closed already. Consulting the pool
 					// again for a new connection
-					Connection newConn = maxwellConnectionPool.getConnection();
-					savedSchema.save(newConn);
-					newConn.close();
+					try ( Connection newConn = maxwellConnectionPool.getConnection() ) {
+						savedSchema.save(newConn);
+					}
 				}
 			return savedSchema;
 		}

--- a/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/SchemaStoreSchema.java
@@ -33,14 +33,16 @@ public class SchemaStoreSchema {
 	}
 
 	private static boolean storeDatabaseExists(Connection connection, String schemaDatabaseName) throws SQLException {
-		Statement s = connection.createStatement();
-		ResultSet rs = s.executeQuery("show databases like '" + schemaDatabaseName + "'");
+		try ( Statement s = connection.createStatement() ) {
+			try ( ResultSet rs = s.executeQuery("show databases like '" + schemaDatabaseName + "'") ) {
+				if (!rs.next())
+					return false;
+			}
 
-		if (!rs.next())
-			return false;
-
-		rs = s.executeQuery("show tables from `" + schemaDatabaseName + "` like 'schemas'");
-		return rs.next();
+			try (ResultSet rs = s.executeQuery("show tables from `" + schemaDatabaseName + "` like 'schemas'") ) {
+				return rs.next();
+			}
+		}
 	}
 
 	private static void executeSQLInputStream(Connection connection, InputStream schemaSQL, String schemaDatabaseName) throws SQLException, IOException {
@@ -48,7 +50,9 @@ public class SchemaStoreSchema {
 		String sql = "", line;
 
 		if ( schemaDatabaseName != null ) {
-			connection.createStatement().execute("CREATE DATABASE IF NOT EXISTS `" + schemaDatabaseName + "`");
+			try ( Statement stmt = connection.createStatement() ) {
+				stmt.execute("CREATE DATABASE IF NOT EXISTS `" + schemaDatabaseName + "`");
+			}
 			if (!schemaDatabaseName.equals(connection.getCatalog()))
 				connection.setCatalog(schemaDatabaseName);
 		}
@@ -60,7 +64,9 @@ public class SchemaStoreSchema {
 			if (statement.length() == 0)
 				continue;
 
-			connection.createStatement().execute(statement);
+			try ( Statement stmt = connection.createStatement() ) {
+				stmt.execute(statement);
+			}
 		}
 	}
 
@@ -73,9 +79,11 @@ public class SchemaStoreSchema {
 
 	private static HashMap<String, String> getTableColumns(String table, Connection c) throws SQLException {
 		HashMap<String, String> map = new HashMap<>();
-		ResultSet rs = c.createStatement().executeQuery("show columns from `" + table + "`");
-		while (rs.next()) {
-			map.put(rs.getString("Field"), rs.getString("Type"));
+		try ( Statement stmt = c.createStatement();
+		      ResultSet rs = stmt.executeQuery("show columns from `" + table + "`") ) {
+			while (rs.next()) {
+				map.put(rs.getString("Field"), rs.getString("Type"));
+			}
 		}
 		return map;
 	}
@@ -83,16 +91,20 @@ public class SchemaStoreSchema {
 	private static ArrayList<String> getMaxwellTables(Connection c) throws SQLException {
 		ArrayList<String> l = new ArrayList<>();
 
-		ResultSet rs = c.createStatement().executeQuery("show tables");
-		while (rs.next()) {
-			l.add(rs.getString(1));
+		try ( Statement stmt = c.createStatement();
+			  ResultSet rs = stmt.executeQuery("show tables") ) {
+			while (rs.next()) {
+				l.add(rs.getString(1));
+			}
 		}
 		return l;
 	}
 
 	private static void performAlter(Connection c, String sql) throws SQLException {
 		LOGGER.info("Maxwell is upgrading its own schema: '" + sql + "'");
-		c.createStatement().execute(sql);
+		try ( Statement stmt = c.createStatement() ) {
+			stmt.execute(sql);
+		}
 	}
 
 	public static void upgradeSchemaStoreSchema(Connection c) throws SQLException, IOException {
@@ -190,16 +202,19 @@ public class SchemaStoreSchema {
 	}
 
 	private static void backfillPositionSHAs(Connection c) throws SQLException {
-		ResultSet rs = c.createStatement().executeQuery("select * from `schemas`");
-		while (rs.next()) {
-			Long id = rs.getLong("id");
-			Position position = new Position(
-				new BinlogPosition(rs.getLong("binlog_position"), rs.getString("binlog_file")),
-				rs.getLong("last_heartbeat_read")
-			);
-			String sha = MysqlSavedSchema.getSchemaPositionSHA(rs.getLong("server_id"), position);
-			c.createStatement().executeUpdate("update `schemas` set `position_sha` = '" + sha + "' where id = " + id);
+		try ( Statement stmt = c.createStatement();
+		      ResultSet rs = stmt.executeQuery("select * from `schemas`") ) {
+			while (rs.next()) {
+				Long id = rs.getLong("id");
+				Position position = new Position(
+						new BinlogPosition(rs.getLong("binlog_position"), rs.getString("binlog_file")),
+						rs.getLong("last_heartbeat_read")
+				);
+				String sha = MysqlSavedSchema.getSchemaPositionSHA(rs.getLong("server_id"), position);
+				try ( Statement stmtUpdate = c.createStatement() ) { // statements cannot interleave ResultSets, so we need a new statement
+					stmtUpdate.executeUpdate("update `schemas` set `position_sha` = '" + sha + "' where id = " + id);
+				}
+			}
 		}
-		rs.close();
 	}
 }


### PR DESCRIPTION
This commit is intended to only add try-with-resources to Connection/PreparedStatement/Statement/ResultSets.

Goal when changing this was to keep the same number of resources opened/closed and avoid changing logic/queries  to avoid creating issues.

Reviewer recommendation: review in an IDE that will help you ignore whitespace changes like IntelliJ IDEA