### PR TITLE
[fix] NPE when schemaId == null

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/BootstrapController.java
@@ -89,7 +89,7 @@ public class BootstrapController extends RunLoopProcess  {
 		return this.currentSchemaID;
 	}
 
-	public synchronized void setCurrentSchemaID(long schemaID) {
+	public synchronized void setCurrentSchemaID(Long schemaID) {
 		this.currentSchemaID = schemaID;
 	}
 

--- a/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellTestSupport.java
@@ -126,6 +126,28 @@ public class MaxwellTestSupport {
 		return new MaxwellContext(config);
 	}
 
+	public static MaxwellContext buildContext(Consumer<MaxwellConfig> maxwellConfigConsumer)
+			throws SQLException, URISyntaxException {
+		MaxwellConfig config = new MaxwellConfig();
+
+		config.replicationMysql.host = "127.0.0.1";
+		config.replicationMysql.user = "maxwell";
+		config.replicationMysql.password = "maxwell";
+		config.replicationMysql.sslMode = SSLMode.DISABLED;
+
+		config.maxwellMysql.host = "127.0.0.1";
+
+		config.maxwellMysql.user = "maxwell";
+		config.maxwellMysql.password = "maxwell";
+		config.maxwellMysql.sslMode = SSLMode.DISABLED;
+
+		config.databaseName = "maxwell";
+
+		maxwellConfigConsumer.accept(config);
+
+		return new MaxwellContext(config);
+	}
+
 	public static boolean inGtidMode() {
 		return System.getenv(MaxwellConfig.GTID_MODE_ENV) != null;
 	}

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorReplicatorTest.java
@@ -11,11 +11,10 @@ import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.MaxwellTestSupport;
 import com.zendesk.maxwell.MysqlIsolatedServer;
 import com.zendesk.maxwell.TestWithNameLogging;
-import com.zendesk.maxwell.bootstrap.SynchronousBootstrapper;
 import com.zendesk.maxwell.monitoring.NoOpMetrics;
 import com.zendesk.maxwell.producer.BufferedProducer;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
-import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.producer.StdoutProducer;
 import com.zendesk.maxwell.schema.MysqlSchemaStore;
 import org.junit.Test;
 
@@ -131,5 +130,51 @@ public class BinlogConnectorReplicatorTest extends TestWithNameLogging {
 		assertEquals(222L, replicator.getRow().getData().get("i"));
 		assertEquals(333L, replicator.getRow().getData().get("i"));
 		assertEquals(null, replicator.getRow());
+	}
+
+	@Test
+	public void testSetNullSchemaIdInProcessQueryEvent() throws Exception {
+		assumeTrue(MysqlIsolatedServer.getVersion().atLeast(MysqlIsolatedServer.VERSION_5_6));
+
+		MysqlIsolatedServer server = MaxwellTestSupport.setupServer("--gtid_mode=ON --enforce-gtid-consistency=true");
+		MaxwellTestSupport.setupSchema(server, false);
+
+		server.execute("create table test.t ( i int )");
+		server.execute("create table test.u ( i int )");
+
+		Position position = Position.capture(server.getConnection(), true);
+
+		MaxwellContext context = MaxwellTestSupport.buildContext(config -> {
+			config.replicationMysql.port = server.getPort();
+			config.maxwellMysql.port = server.getPort();
+			config.filter = null;
+			config.initPosition = position;
+			config.replayMode = true;
+			config.producerType = "stdout";
+
+		});
+
+		BinlogConnectorReplicator replicator = new BinlogConnectorReplicator(
+				new MysqlSchemaStore(context, position),
+				new StdoutProducer(context),
+				context.getBootstrapController(null),
+				context.getConfig().maxwellMysql,
+				333098L,
+				"maxwell",
+				new NoOpMetrics(),
+				position,
+				false,
+				"maxwell-client",
+				new HeartbeatNotifier(),
+				null,
+				context.getFilter(),
+				new MaxwellOutputConfig(),
+				context.getConfig().bufferMemoryUsage
+		);
+
+		replicator.startReplicator();
+		server.execute("DROP TABLE IF EXISTS `xxx_tmp`");
+		replicator.getRow();
+
 	}
 }


### PR DESCRIPTION
fixed #1624 
In case where maxwell is running in --reply mode and there is no saved schema in schemas table(schemaId == null) and eventType is QUERY, NPE is thrown because of unboxing Long object to primitive long in processQueryEvent method :

List<ResolvedSchemaChange> changes = schemaStore.processSQL(sql, dbName, position);
  Long schemaId = getSchemaId(); //schemaId == null

  if ( bootstrapper != null)
   bootstrapper.setCurrentSchemaID(schemaId); //NPE