### PR TITLE
correct the github action operation from create to push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,9 @@
 name: CI to Zendesk Dockerhub
 
 on:
-  create:
+  push:
     tags:
       - v*.*.*
-
 
 jobs:
   build:


### PR DESCRIPTION
From this pr: https://github.com/zendesk/maxwell/pull/1755
Create action shouldn't use as a trigger for a new tag, Push action should be applied here instead. Ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags

https://github.com/zendesk/maxwell/pull/1755#issuecomment-935456061
@osheroff sorry for copying the outdated action file from my test repo, Push action should work.

Please update the action and check again. Cheers!