### PR TITLE
Build non-root image and smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-11
+FROM maven:3.6-jdk-11 as builder
 ENV MAXWELL_VERSION=1.34.1 KAFKA_VERSION=1.0.0
 
 RUN apt-get update \
@@ -18,6 +18,15 @@ RUN cd /workspace \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* /workspace/ /root/.m2/ \
     && echo "$MAXWELL_VERSION" > /REVISION
 
+# Build clean image with non-root priveledge
+FROM openjdk:11-jdk-slim
+
+COPY --from=builder /app /app
+
 WORKDIR /app
+
+RUN chown 1000:1000 /app && echo "$MAXWELL_VERSION" > /REVISION
+
+USER 1000
 
 CMD [ "/bin/bash", "-c", "bin/maxwell-docker" ]


### PR DESCRIPTION
Hi i would like use non-root image, because it's more secure.
I need need it, because our K8s cluster doesn't allow image with root priviledges.

So I prepare build image with non-root priviledges and also with less layer, which is more efficienty.
I used multi-stage build.

Miloš from Livesport