### PR TITLE
add config for binlog_event_queue_size

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -235,6 +235,7 @@ init_position                  | FILE:POSITION[:HEARTBEAT]           | ignore th
 replay                         | BOOLEAN                             | enable maxwell's read-only "replay" mode: don't store a binlog position or schema changes.  Not available in config.properties. |
 buffer_memory_usage            | FLOAT                               | Determines how much memory the Maxwell event buffer will use from the jvm max memory. Size of the buffer is: buffer_memory_usage * -Xmx" | 0.25
 http_config                    | BOOLEAN                             | enable http config endpoint for config updates without restart | false
+binlog_event_queue_size        | INT                                 | Size of queue to buffer events parsed from binlog   | 5000
 
 
 <p id="loglevel" class="jumptarget">

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -287,7 +287,8 @@ public class Maxwell implements Runnable {
 			context.getFilter(),
 			config.outputConfig,
 			config.bufferMemoryUsage,
-			config.replicationReconnectionRetries
+			config.replicationReconnectionRetries,
+			config.binlogEventQueueSize
 		);
 
 		context.setReplicator(replicator);

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -9,6 +9,7 @@ import com.zendesk.maxwell.monitoring.MaxwellDiagnosticContext;
 import com.zendesk.maxwell.producer.EncryptionMode;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import com.zendesk.maxwell.producer.ProducerFactory;
+import com.zendesk.maxwell.replication.BinlogConnectorReplicator;
 import com.zendesk.maxwell.replication.BinlogPosition;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.scripting.Scripting;
@@ -575,6 +576,12 @@ public class MaxwellConfig extends AbstractConfig {
 	public String raftMemberID;
 
 	/**
+	 * The size for the queue used to buffer events parsed off binlog in
+	 * {@link com.zendesk.maxwell.replication.BinlogConnectorReplicator}
+	 */
+	public int binlogEventQueueSize;
+
+	/**
 	 * Build a default configuration object.
 	 */
 	public MaxwellConfig() { // argv is only null in tests
@@ -714,6 +721,8 @@ public class MaxwellConfig extends AbstractConfig {
 				.withOptionalArg().ofType(Boolean.class);
 		parser.accepts( "buffer_memory_usage", "Percentage of JVM memory available for transaction buffer.  Floating point between 0 and 1." )
 				.withRequiredArg().ofType(Float.class);
+		parser.accepts("binlog_event_queue_size", "Size of queue to buffer events parsed from binlog.")
+				.withOptionalArg().ofType(Integer.class);
 
 		parser.section( "custom_producer" );
 		parser.accepts( "custom_producer.factory", "fully qualified custom producer factory class" )
@@ -1121,6 +1130,8 @@ public class MaxwellConfig extends AbstractConfig {
 		this.jgroupsConf = fetchStringOption("jgroups_config", options, properties, "raft.xml");
 		this.raftMemberID = fetchStringOption("raft_member_id", options, properties, null);
 		this.replicationReconnectionRetries = fetchIntegerOption("replication_reconnection_retries", options, properties, 1);
+
+		this.binlogEventQueueSize = fetchIntegerOption("binlog_event_queue_size", options, properties, BinlogConnectorReplicator.BINLOG_QUEUE_SIZE);
 	}
 
 	private void setupEncryptionOptions(OptionSet options, Properties properties) {


### PR DESCRIPTION
This change is to make the size of queue in `BinlogConnectorReplicator` configurable, which is critical for performance, by introducing a new config `binlog_event_queue_size`. It can be set the same way as other configs, with default value 5k which is the queue size before this change. 

cc @osheroff

