### PR TITLE
Make SNS/SQS procuders to respect outputConfig

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -35,7 +35,7 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 
 	@Override
 	public void sendAsync(RowMap r, CallbackCompleter cc) throws Exception {
-		String value = r.toJSON();
+		String value = r.toJSON(outputConfig);
 		// Publish a message to an Amazon SNS topic.
 		final PublishRequest publishRequest = new PublishRequest(topic, value);
 		Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
@@ -26,7 +26,7 @@ public class MaxwellSQSProducer extends AbstractAsyncProducer {
 
 	@Override
 	public void sendAsync(RowMap r, CallbackCompleter cc) throws Exception {
-		String value = r.toJSON();
+		String value = r.toJSON(outputConfig);
 		SendMessageRequest messageRequest = new SendMessageRequest(queueUri, value);
 		if ( queueUri.endsWith(".fifo")) {
 			messageRequest.setMessageGroupId(r.getDatabase());


### PR DESCRIPTION
I found that output options such as `output_binlog_positions` are not available for SNS/SQS producers.