### PR TITLE
Related to issue: https://github.com/zendesk/maxwell/issues/1847

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -1047,6 +1047,8 @@ public class MaxwellConfig extends AbstractConfig {
 				String k = (String) e.nextElement();
 				if (k.startsWith("custom_producer.")) {
 					this.customProducerProperties.setProperty(k.replace("custom_producer.", ""), properties.getProperty(k));
+				} else if (k.startsWith("custom_producer_")) {
+					this.customProducerProperties.setProperty(k.replace("custom_producer_", ""), properties.getProperty(k));
 				} else if (k.startsWith("kafka.")) {
 					if (k.equals("kafka.bootstrap.servers") && kafkaBootstrapServers != null)
 						continue; // don't override command line bootstrap servers with config files'


### PR DESCRIPTION
When providing custom_producer arguments many systems don't support periods
in environment variables, this means callers have to use option args --custom_producer.var=1

However this is not ideal as it may be not ideal to pass these items as envvars.