### PR TITLE
Make BinlogConnectorReplicator throw exception on server ids changing on binlog re-connect

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -491,7 +491,13 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 				// standard binlog positioning is a lot easier; we can really reconnect anywhere
 				// we like, so we don't have to bail out of the middle of an event.
 				LOGGER.warn("replicator stopped at position: {} -- restarting", client.getBinlogFilename() + ":" + client.getBinlogPosition());
+
+				Long oldMasterId = client.getMasterServerId();
 				tryReconnect();
+				if (client.getMasterServerId() != oldMasterId) {
+					throw new Exception("Master id changed from " + oldMasterId + " to " + client.getMasterServerId()
+								+ " while using binlog coordinate positioning. Cannot continue with the info that we have");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When maxwell is re-connects to db host it does no checks to see if the id of the server that
it connected to is the same server as it was previously connected to. Normally this results
in a crash since binlog coordinates between servers are generally not compatible. However,
in certain situations it is possible that this re-connection suceeds (ie: the coordinates
between the two servers are similar) and maxwell starts writing positions for the second
server as if they were for the first server. This will eventually make it impossible for
maxwell to re-connect to the first server and cause to crash on startup.

In order to correct this, make maxwell check if the server id has changed on re-connection
and throw an exception. This fixes https://github.com/zendesk/maxwell/issues/1863 which
also describes the problem in more detail