### PR TITLE
fix: localstack sqs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.191</version>
+      <version>1.12.213</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -323,7 +323,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sqs</artifactId>
-      <version>1.12.137</version>
+      <version>1.12.213</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -179,6 +179,16 @@ public class MaxwellConfig extends AbstractConfig {
 	public String sqsQueueUri;
 
 	/**
+	 * {@link com.zendesk.maxwell.producer.MaxwellSQSProducer} Queue Service Endpoint URL
+	 */
+	public String sqsServiceEndpoint;
+
+	/**
+	 * {@link com.zendesk.maxwell.producer.MaxwellSQSProducer} Queue Signing region
+	 */
+	public String sqsSigningRegion;
+
+	/**
 	 * {@link com.zendesk.maxwell.producer.MaxwellSQSProducer} topic
 	 */
 	public String snsTopic;
@@ -771,6 +781,10 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.section("sqs");
 		parser.accepts( "sqs_queue_uri", "SQS Queue uri" )
 				.withRequiredArg();
+		parser.accepts( "sqs_service_endpoint", "SQS Service Endpoint" )
+				.withRequiredArg();
+		parser.accepts( "sqs_signing_region", "SQS Signing region" )
+				.withRequiredArg();
 
 		parser.section("sns");
 		parser.accepts("sns_topic", "SNS Topic ARN")
@@ -1066,6 +1080,8 @@ public class MaxwellConfig extends AbstractConfig {
 		this.kinesisMd5Keys = fetchBooleanOption("kinesis_md5_keys", options, properties, false);
 
 		this.sqsQueueUri = fetchStringOption("sqs_queue_uri", options, properties, null);
+		this.sqsServiceEndpoint = fetchStringOption("sqs_service_endpoint", options, properties, null);
+		this.sqsSigningRegion = fetchStringOption("sqs_signing_region", options, properties, null);
 
 		this.snsTopic = fetchStringOption("sns_topic", options, properties, null);
 		this.snsAttrs = fetchStringOption("sns_attrs", options, properties, null);
@@ -1252,6 +1268,10 @@ public class MaxwellConfig extends AbstractConfig {
 			usageForOptions("please specify a stream name for kinesis", "kinesis_stream");
 		} else if (this.producerType.equals("sqs") && this.sqsQueueUri == null) {
 			usageForOptions("please specify a queue uri for sqs", "sqs_queue_uri");
+		} else if (this.producerType.equals("sqs") && this.sqsServiceEndpoint == null) {
+			usageForOptions("please specify a service endpoint for sqs", "sqs_service_endpoint");
+		} else if (this.producerType.equals("sqs") && this.sqsSigningRegion == null) {
+			usageForOptions("please specify a signing region for sqs", "sqs_signing_region");
 		} else if (this.producerType.equals("sns") && this.snsTopic == null) {
 			usageForOptions("please specify a topic ARN for SNS", "sns_topic");
 		} else if (this.producerType.equals("pubsub")) {

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -524,7 +524,7 @@ public class MaxwellContext {
 				this.producer = new MaxwellKinesisProducer(this, this.config.kinesisStream);
 				break;
 			case "sqs":
-				this.producer = new MaxwellSQSProducer(this, this.config.sqsQueueUri);
+				this.producer = new MaxwellSQSProducer(this, this.config.sqsQueueUri, this.config.sqsServiceEndpoint, this.config.sqsSigningRegion);
 				break;
 			case "sns":
 				this.producer = new MaxwellSNSProducer(this, this.config.snsTopic);

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
@@ -1,11 +1,11 @@
 package com.zendesk.maxwell.producer;
 
+import com.amazonaws.client.builder.AwsClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
@@ -18,10 +18,12 @@ public class MaxwellSQSProducer extends AbstractAsyncProducer {
 	private AmazonSQSAsync client;
 	private String queueUri;
 
-	public MaxwellSQSProducer(MaxwellContext context, String queueUri) {
+	public MaxwellSQSProducer(MaxwellContext context, String queueUri, String serviceEndpoint, String signingRegion) {
 		super(context);
 		this.queueUri = queueUri;
-		this.client = AmazonSQSAsyncClientBuilder.defaultClient();
+		this.client = AmazonSQSAsyncClientBuilder.standard()
+				.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, signingRegion))
+				.build();
 	}
 
 	@Override


### PR DESCRIPTION
An attempt to fix an issue with the localstack sqs connection. Required service endpoint url flag was missing in the cli.

With the update the following should work with localstack:

```
bin/maxwell \
  --host=mysql \
  --port=3306 \
  --user=maxwell \
  --password=password \
  --producer=sqs \
  --sqs_service_endpoint=localstack:4566 \
  --sqs_signing_region=es-west-1 \
  --sqs_queue_uri=http://localstack:4566/000000000000/maxwell
```

I guess handling defaults for backward compatibility would be good to have. 🤔 Unfortunately I am not an expert of Java, a bit of help would be appreciated. ✌️