### PR TITLE
Bump up viafoura/metrics-datadog version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
     <dependency>
       <groupId>com.viafoura</groupId>
       <artifactId>metrics-datadog</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0-RC3</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
We submitted an [upstream PR](https://github.com/viafoura/metrics-datadog/pull/7) to bump up `java-dogstatd-client` version. They have merged it and released a new version to maven repo. Updating pom.xml to use latest dependency version.

The vulnerability being fixed is this:
<img width="1133" alt="Screen Shot 2022-06-21 at 10 35 39 am" src="https://user-images.githubusercontent.com/92696443/174693446-6f28627d-6473-4380-94d4-255de02337a9.png">

