### PR TITLE
Add completion logging to Schema Compactor

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaCompactor.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaCompactor.java
@@ -155,9 +155,11 @@ public class MysqlSchemaCompactor extends RunLoopProcess {
 			update.executeUpdate("update `schemas` set `base_schema_id` = null, `deltas` = null where `id` = " + schemaID);
 
 			commit.execute("COMMIT");
+			LOGGER.info("Committed schema compaction for {}", schemaID);
 		}
 
 		slowDeleteSchemas(cx, schemaID);
+		LOGGER.info("Finished deleting old schemas prior to {}", schemaID);
 	}
 
 	private void slowDeleteSchemas(Connection cx, long newBaseSchemaID) throws SQLException {


### PR DESCRIPTION
In environments with very many databases and tables, it can take a long time (1hr+) to compact the schema changes. However, it is difficult to figure this out unless you are watching the processlist as there are no logs or metrics to indicate completion nor any indication in the `maxwell` database of how long it took.

This PR adds two additional log lines to MysqlSchemaCompactor to indicate completion of the commit and slow deletion phases.
For most users, they will never see the logs because they rarely or never compact.