### PR TITLE
docs: updating docs to reflect the changes to sqs configs 

### DIFF
--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -218,7 +218,12 @@ See the [AWS docs](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/cr
 In case you need to set up a different region also along with credentials then default one, see the [AWS docs](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html#setup-credentials-setting-region).
 
 ## Options
-Set the output queue in the `config.properties` by setting the `sqs_queue_uri` property to full SQS queue uri from AWS console.
+Set the output queue in the `config.properties` by setting the following properites
+
+- **sqs_signing_region**: the region to use for SigV4 signing of requests. e.g. `us-east-1`
+- **sqs_service_endpoint**: the service endpoint either with or without the protocol (e.g. `https://sns.us-west-1.amazonaws.com` or `sns.us-west-1.amazonaws.com`)
+- **sqs_queue_uri**: the full SQS queue uri from AWS console. e.g. `https://sqs.us-east-1.amazonaws.com/xxxxxxxxxxxx/maxwell`
+
 
 The producer uses the [AWS SQS SDK](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/AmazonSQSClient.html).
 


### PR DESCRIPTION
Commit [43b457d63daa538a100d89aab754bb935f39252c ](https://github.com/zendesk/maxwell/commit/43b457d63daa538a100d89aab754bb935f39252c)switched the AWS SQS client which necessitates adding two additional parameters: serviceEndpoint, signingRegion.

This PR updates the docs to list these two as requirements and provides example values for them.