### PR TITLE
Add support for log4j2 JSON Template Layout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>2.12.1</version>
     </dependency>


### PR DESCRIPTION
Customizing json logging with log4j2 JSON Template Layout is useful for getting nicely presented logs in DataDog for example.