### PR TITLE
Fix DDL multi-line comments

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
@@ -58,7 +58,7 @@ public abstract class SchemaChange {
 		// now strip out comments
 		sql = CSTYLE_COMMENTS.matcher(sql).replaceAll("");
 		sql = sql.replaceAll("\\-\\-.*", "");
-		sql = sql.replaceAll("^\\s*#.*", "");
+		sql = Pattern.compile("^\\s*#.*", Pattern.MULTILINE).matcher(sql).replaceAll("");
 
 		for (Pattern p : SQL_BLACKLIST) {
 			if (p.matcher(sql).find()) {

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -602,4 +602,16 @@ public class DDLParserTest {
 		}
 		System.out.println(nFixed + " fixed, " + nErr + " remain.");
 	}
+
+	@Test
+	public void testPolardbXCreateIndexSQL(){
+
+		List<SchemaChange> changes = parse(
+				"# POLARX_ORIGIN_SQL=CREATE INDEX device_id_idx ON event_tracking_info_extra (event, create_time)\n" +
+				"# POLARX_TSO=698905756181096044815201227773638819850000000000000000\n" +
+				"CREATE INDEX device_id_idx ON event_tracking_info_extra (event, create_time)");
+
+		assertThat(changes,is(nullValue()));
+
+	}
 }


### PR DESCRIPTION
As shown in the #1927 issue, the binlog comment in polardb-x（aliyun） was in line with the mysql annotation specification, when maxwell threw exceptions when executing specific sql, and tests found that the comment could be multiple lines in a piece of sql.
eg:
```
String sql = "# POLARX_ORIGIN_SQL=CREATE INDEX device_id_idx ON event_tracking_info_extra (event, create_time)\n" +
                    "# POLARX_TSO=699055265586505324815216178714011320320000000000000000\n" +
                    "# POLARX_TSO=69905526558650532481521617871401x320320000000000000000\n" +
                    "CREATE INDEX device_id_idx ON event_tracking_info_extra (event, create_time)";
```
execute : 
``` 
String s = sql.replaceAll("^\\s*#.*", "");
System.out.println("s = " + s); 
```
results : 
``` 
s = 
# POLARX_TSO=699055265586505324815216178714011320320000000000000000
# POLARX_TSO=69905526558650532481521617871401x320320000000000000000
CREATE INDEX device_id_idx ON event_tracking_info_extra (event, create_time)
```
eventually an exception occurs #1927 

the solution is to replace the comment section with a multi-line match, resulting in the actual executed sql

