### PR TITLE
Fix "Cannot parse argument '1.1' of option pubsub_rpc_timeout_multiplier"

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -248,7 +248,7 @@ public class MaxwellConfig extends AbstractConfig {
 	/**
 	 * {@link com.zendesk.maxwell.producer.MaxwellPubsubProducer} retry delay multiplier
 	 */
-	public Double pubsubRetryDelayMultiplier;
+	public Float pubsubRetryDelayMultiplier;
 
 	/**
 	 * {@link com.zendesk.maxwell.producer.MaxwellPubsubProducer} max retry delay
@@ -263,7 +263,7 @@ public class MaxwellConfig extends AbstractConfig {
 	/**
 	 * {@link com.zendesk.maxwell.producer.MaxwellPubsubProducer} RPC timeout multiplier
 	 */
-	public Double pubsubRpcTimeoutMultiplier;
+	public Float pubsubRpcTimeoutMultiplier;
 
 	/**
 	 * {@link com.zendesk.maxwell.producer.MaxwellPubsubProducer} max RPC timeout
@@ -867,13 +867,13 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "pubsub_retry_delay", "delay in millis before sending the first retry message. default: 100 ms" )
 				.withRequiredArg().ofType(Long.class);
 		parser.accepts( "pubsub_retry_delay_multiplier", "multiply by this ratio to increase delay time each retry. default: 1.3" )
-				.withRequiredArg();
+				.withRequiredArg().ofType(Float.class);
 		parser.accepts( "pubsub_max_retry_delay", "maximum retry delay time in seconds. default: 60 seconds" )
 				.withRequiredArg().ofType(Long.class);
 		parser.accepts( "pubsub_initial_rpc_timeout", "timeout for initial rpc call. default: 5 seconds" )
 				.withRequiredArg();
 		parser.accepts( "pubsub_rpc_timeout_multiplier", "backoff delay ratio for rpc timeout. default: 1.0" )
-				.withRequiredArg().ofType(Long.class);
+				.withRequiredArg().ofType(Float.class);
 		parser.accepts( "pubsub_max_rpc_timeout", "max delay in seconds for rpc timeout. default: 600 seconds" )
 				.withRequiredArg().ofType(Long.class);
 		parser.accepts( "pubsub_total_timeout", "maximum timeout in seconds (clamps exponential backoff)" )
@@ -1074,10 +1074,10 @@ public class MaxwellConfig extends AbstractConfig {
 		this.pubsubMessageOrderingKey			= fetchStringOption("pubsub_message_ordering_key", options, properties, null);
 		this.pubsubPublishDelayThreshold		= Duration.ofMillis(fetchLongOption("pubsub_publish_delay_threshold", options, properties, 1L));
 		this.pubsubRetryDelay 					= Duration.ofMillis(fetchLongOption("pubsub_retry_delay", options, properties, 100L));
-		this.pubsubRetryDelayMultiplier 		= Double.parseDouble(fetchStringOption("pubsub_retry_delay_multiplier", options, properties, "1.3"));
+		this.pubsubRetryDelayMultiplier 		= fetchFloatOption("pubsub_retry_delay_multiplier", options, properties, 1.0f);
 		this.pubsubMaxRetryDelay 		 		= Duration.ofSeconds(fetchLongOption("pubsub_max_retry_delay", options, properties, 60L));
 		this.pubsubInitialRpcTimeout 		 	= Duration.ofSeconds(fetchLongOption("pubsub_initial_rpc_timeout", options, properties, 5L));
-		this.pubsubRpcTimeoutMultiplier 		= Double.parseDouble(fetchStringOption("pubsub_rpc_timeout_multiplier", options, properties, "1.0"));
+		this.pubsubRpcTimeoutMultiplier 		= fetchFloatOption("pubsub_rpc_timeout_multiplier", options, properties, 1.0f);
 		this.pubsubMaxRpcTimeout 		 		= Duration.ofSeconds(fetchLongOption("pubsub_max_rpc_timeout", options, properties, 600L));
 		this.pubsubTotalTimeout 		 		= Duration.ofSeconds(fetchLongOption("pubsub_total_timeout", options, properties, 600L));
 		this.pubsubEmulator						= fetchStringOption("pubsub_emulator", options, properties, null);

--- a/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
@@ -129,6 +129,18 @@ public class MaxwellConfigTest
 		assertEquals("foo", config.customProducerProperties.getProperty("foo"));
 	}
 
+	@Test
+	public void testPubsubConfigNonDefault() {
+		config = new MaxwellConfig(new String[] { "--pubsub_rpc_timeout_multiplier=1.5" });
+		assertEquals(config.pubsubRpcTimeoutMultiplier, 1.5f, 0.0f);
+	}
+
+	@Test
+	public void testPubsubConfigDefault() {
+		config = new MaxwellConfig();
+		assertEquals(config.pubsubRpcTimeoutMultiplier, 1.0f, 0.0f);
+	}
+
 
 	private String getTestConfigDir() {
 		return System.getProperty("user.dir") + "/src/test/resources/config/";


### PR DESCRIPTION
This PR fix failure when parsing option args for '--pubsub_rpc_timeout_multiplier' and  `pubsub_retry_delay_multiplier` to run maxwell

This happen when you run maxwell with `--pubsub_rpc_timeout_multiplier=1.1` (in my case`

```
joptsimple.OptionArgumentConversionException: Cannot parse argument '1.1' of option pubsub_rpc_timeout_multiplier
	at joptsimple.AbstractOptionSpec.convertWith(AbstractOptionSpec.java:92)
	at joptsimple.ArgumentAcceptingOptionSpec.convert(ArgumentAcceptingOptionSpec.java:277)
	at joptsimple.OptionSet.valuesOf(OptionSet.java:223)
	at joptsimple.OptionSet.valueOf(OptionSet.java:172)
	at joptsimple.OptionSet.valueOf(OptionSet.java:153)
	at com.zendesk.maxwell.util.AbstractConfig.fetchOption(AbstractConfig.java:132)
	at com.zendesk.maxwell.util.AbstractConfig.fetchStringOption(AbstractConfig.java:140)
	at com.zendesk.maxwell.MaxwellConfig.setup(MaxwellConfig.java:1080)
	at com.zendesk.maxwell.MaxwellConfig.parse(MaxwellConfig.java:1031)
	at com.zendesk.maxwell.MaxwellConfig.<init>(MaxwellConfig.java:655)
	at com.zendesk.maxwell.Maxwell.main(Maxwell.java:316)
Caused by: joptsimple.internal.ReflectionException: java.lang.NumberFormatException: For input string: "1.1"
	at joptsimple.internal.Reflection.reflectionException(Reflection.java:136)
	at joptsimple.internal.Reflection.invoke(Reflection.java:118)
	at joptsimple.internal.MethodInvokingValueConverter.convert(MethodInvokingValueConverter.java:48)
	at joptsimple.internal.Reflection.convertWith(Reflection.java:124)
	at joptsimple.AbstractOptionSpec.convertWith(AbstractOptionSpec.java:90)
	... 10 more
Caused by: java.lang.NumberFormatException: For input string: "1.1"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Long.parseLong(Long.java:692)
	at java.base/java.lang.Long.valueOf(Long.java:1144)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at joptsimple.internal.Reflection.invoke(Reflection.java:116)
	... 13 more
```