### PR TITLE
Fix pubsub and update dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,11 +23,13 @@ jobs:
         uses: zendesk/setup-buildx-action@v1.6.0
         with:
           install: true
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Docker Build and push
         run: |-
-          set -eu -o pipefail
-          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login --username=${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-          set -x
           current_tag=zendesk/maxwell:"${GITHUB_REF##refs/tags/}"
           latest_tag=zendesk/maxwell:latest
           docker buildx build --platform=linux/arm64,linux/amd64 --file=Dockerfile --push --tag="$current_tag" --tag="$latest_tag" .

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockito.version>3.7.7</mockito.version>
-    <opencensus.version>0.28.3</opencensus.version>
+    <opencensus.version>0.31.1</opencensus.version>
     <aws-java.version>1.12.327</aws-java.version>
   </properties>
 
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.1</version>
+      <version>2.13.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.jgroups</groupId>
@@ -175,9 +175,19 @@
 
     <!-- utils and support libs -->
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.1</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -202,7 +212,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.14</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>
@@ -288,12 +298,12 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquerystorage</artifactId>
-      <version>2.14.2</version>
+      <version>2.24.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>2.13.3</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -333,7 +343,12 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.115.1</version>
+      <version>1.120.24</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>io.nats</groupId>
@@ -343,12 +358,65 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.7</version>
+      <version>3.21.8</version>
     </dependency>
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>3.5.1</version>
+    </dependency>
+
+    <!-- grpc stuff -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>1.50.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>1.50.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>1.50.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-auth</artifactId>
+      <version>1.50.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <version>1.50.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>1.50.1</version>
+    </dependency> 
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-context</artifactId>
+      <version>1.50.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+      <version>2.5.2</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+      <version>3.27.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.16</version>
     </dependency>
 
     <!-- test -->

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -1074,7 +1074,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.pubsubMessageOrderingKey			= fetchStringOption("pubsub_message_ordering_key", options, properties, null);
 		this.pubsubPublishDelayThreshold		= Duration.ofMillis(fetchLongOption("pubsub_publish_delay_threshold", options, properties, 1L));
 		this.pubsubRetryDelay 					= Duration.ofMillis(fetchLongOption("pubsub_retry_delay", options, properties, 100L));
-		this.pubsubRetryDelayMultiplier 		= fetchFloatOption("pubsub_retry_delay_multiplier", options, properties, 1.0f);
+		this.pubsubRetryDelayMultiplier 		= fetchFloatOption("pubsub_retry_delay_multiplier", options, properties, 1.3f);
 		this.pubsubMaxRetryDelay 		 		= Duration.ofSeconds(fetchLongOption("pubsub_max_retry_delay", options, properties, 60L));
 		this.pubsubInitialRpcTimeout 		 	= Duration.ofSeconds(fetchLongOption("pubsub_initial_rpc_timeout", options, properties, 5L));
 		this.pubsubRpcTimeoutMultiplier 		= fetchFloatOption("pubsub_rpc_timeout_multiplier", options, properties, 1.0f);
@@ -1345,13 +1345,13 @@ public class MaxwellConfig extends AbstractConfig {
 				usage("--pubsub_publish_delay_threshold must be > 0");
 			if (this.pubsubRetryDelay.isNegative() || this.pubsubRetryDelay.isZero())
 				usage("--pubsub_retry_delay must be > 0");
-			if (this.pubsubRetryDelayMultiplier <= 1.0)
-				usage("--pubsub_retry_delay_multiplier must be > 1.0");
+			if (this.pubsubRetryDelayMultiplier < 1.0f)
+				usage("--pubsub_retry_delay_multiplier must be >= 1.0");
 			if (this.pubsubMaxRetryDelay.isNegative() || this.pubsubMaxRetryDelay.isZero())
 				usage("--pubsub_max_retry_delay must be > 0");
 			if (this.pubsubInitialRpcTimeout.isNegative() || this.pubsubInitialRpcTimeout.isZero())
 				usage("--pubsub_initial_rpc_timeout must be > 0");
-			if (this.pubsubRpcTimeoutMultiplier < 1.0)
+			if (this.pubsubRpcTimeoutMultiplier < 1.0f)
 				usage("--pubsub_rpc_timeout_multiplier must be >= 1.0");
 			if (this.pubsubMaxRpcTimeout.isNegative() || this.pubsubMaxRpcTimeout.isZero())
 				usage("--pubsub_max_rpc_timeout must be > 0");

--- a/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
@@ -133,12 +133,19 @@ public class MaxwellConfigTest
 	public void testPubsubConfigNonDefault() {
 		config = new MaxwellConfig(new String[] { "--pubsub_rpc_timeout_multiplier=1.5" });
 		assertEquals(config.pubsubRpcTimeoutMultiplier, 1.5f, 0.0f);
+
+		config = new MaxwellConfig(new String[] { "--pubsub_retry_delay_multiplier=1.5" });
+		assertEquals(config.pubsubRetryDelayMultiplier, 1.5f, 0.0f);
 	}
 
 	@Test
 	public void testPubsubConfigDefault() {
 		config = new MaxwellConfig();
 		assertEquals(config.pubsubRpcTimeoutMultiplier, 1.0f, 0.0f);
+		assertTrue(config.pubsubRpcTimeoutMultiplier >= 1.0f);
+
+		assertEquals(config.pubsubRetryDelayMultiplier, 1.3f, 0.0f);
+		assertTrue(config.pubsubRetryDelayMultiplier >= 1.0f);
 	}
 
 


### PR DESCRIPTION
This fix #1939 and update to #1940. 

I change `pubsubRetryDelayMultiplier` default value to 1.3f to follow default on PubSub lib

This also fix failed to auth to google when deployed to kubernetes. 

`$GOOGLE_APPLICATION_CREDENTIALS file is in "volumeMount" `
