### PR TITLE
WIP implementation of Vitess VStream replicator support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
       <version>15.3</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.vitess</groupId>
+      <artifactId>vitess-grpc-client</artifactId>
+      <version>14.0.1</version>
+    </dependency>
+
     <!-- utils and support libs -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -261,8 +267,9 @@
       <artifactId>simpleclient_servlet</artifactId>
       <version>0.9.0</version>
     </dependency>
+
     <!-- OpenCensus used for pushing metrics to stackdriver -->
-    <dependency>
+    <!-- <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-contrib-dropwizard</artifactId>
         <version>${opencensus.version}</version>
@@ -282,7 +289,7 @@
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
         <version>${opencensus.version}</version>
-    </dependency>
+    </dependency> -->
 
     <!-- producer libs -->
     <dependency>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -82,6 +82,16 @@ public class MaxwellConfig extends AbstractConfig {
 	public Boolean gtidMode;
 
 	/**
+	 * If Maxwell is running against a vitess cluster.
+	 */
+	public Boolean vitessEnabled;
+
+	/**
+	 * Vitess (vtgate) connection config
+	 */
+  public MaxwellVitessConfig vitessConfig;
+
+	/**
 	 * Name of database in which to store maxwell data (default `maxwell`)
 	 */
 	public String databaseName;
@@ -641,6 +651,10 @@ public class MaxwellConfig extends AbstractConfig {
 		this.schemaMysql = new MaxwellMysqlConfig();
 		this.masterRecovery = false;
 		this.gtidMode = false;
+
+    this.vitessEnabled = false;
+    this.vitessConfig = new MaxwellVitessConfig();
+
 		this.bufferedProducerSize = 200;
 		this.outputConfig = new MaxwellOutputConfig();
 		setup(null, null); // setup defaults
@@ -1043,9 +1057,11 @@ public class MaxwellConfig extends AbstractConfig {
 		this.replicationMysql   = parseMysqlConfig("replication_", options, properties);
 		this.schemaMysql        = parseMysqlConfig("schema_", options, properties);
 		this.gtidMode           = fetchBooleanOption("gtid_mode", options, properties, System.getenv(GTID_MODE_ENV) != null);
-
 		this.databaseName       = fetchStringOption("schema_database", options, properties, "maxwell");
 		this.maxwellMysql.database = this.databaseName;
+
+    this.vitessEnabled      = fetchBooleanOption("vitess", options, properties, false);
+    this.vitessConfig       = parseVitessConfig(options, properties);
 
 		this.producerFactory    = fetchProducerFactory(options, properties);
 		this.producerType       = fetchStringOption("producer", options, properties, "stdout");

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -14,6 +14,7 @@ import com.zendesk.maxwell.schema.MysqlPositionStore;
 import com.zendesk.maxwell.schema.MysqlSchemaCompactor;
 import com.zendesk.maxwell.schema.PositionStoreThread;
 import com.zendesk.maxwell.schema.ReadOnlyMysqlPositionStore;
+import com.zendesk.maxwell.schema.VitessPositionStore;
 import com.zendesk.maxwell.util.C3P0ConnectionPool;
 import com.zendesk.maxwell.util.RunLoopProcess;
 import com.zendesk.maxwell.util.StoppableTask;
@@ -129,7 +130,9 @@ public class MaxwellContext {
 
 		if ( this.config.replayMode ) {
 			this.positionStore = new ReadOnlyMysqlPositionStore(this.getMaxwellConnectionPool(), this.getServerID(), this.config.clientID, config.gtidMode);
-		} else {
+		} else if (this.config.vitessEnabled) {
+      this.positionStore = new VitessPositionStore(this.getMaxwellConnectionPool(), this.getServerID(), this.config.clientID, config.gtidMode);
+    } else {
 			this.positionStore = new MysqlPositionStore(this.getMaxwellConnectionPool(), this.getServerID(), this.config.clientID, config.gtidMode);
 		}
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellVitessConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellVitessConfig.java
@@ -1,0 +1,23 @@
+package com.zendesk.maxwell;
+
+public class MaxwellVitessConfig {
+  public String vtgateHost;
+  public int vtgatePort;
+
+  public String user;
+  public String password;
+
+  public String keyspace;
+  public String shard;
+
+  public MaxwellVitessConfig() {
+    this.vtgateHost = "localhost";
+    this.vtgatePort = 15991;
+
+    this.user = null;
+    this.password = null;
+
+    this.keyspace = null;
+    this.shard = "";
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellMetrics.java
@@ -12,7 +12,7 @@ import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
-import io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter;
+// import io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -126,17 +126,18 @@ public class MaxwellMetrics implements Metrics {
 		}
 
 		if (config.metricsReportingType.contains(reportingTypeStackdriver)) {
-			io.opencensus.metrics.Metrics.getExportComponent().getMetricProducerManager().add(
-				new io.opencensus.contrib.dropwizard.DropWizardMetrics(
-				  Collections.singletonList(this.registry)));
+      throw new RuntimeException("Stackdriver metrics reporting is not supported for now");
+			// io.opencensus.metrics.Metrics.getExportComponent().getMetricProducerManager().add(
+			// 	new io.opencensus.contrib.dropwizard.DropWizardMetrics(
+			// 	  Collections.singletonList(this.registry)));
 
-			try {
-				StackdriverStatsExporter.createAndRegister();
-			} catch (java.io.IOException e) {
-				LOGGER.error("Maxwell encountered an error in creating the stackdriver exporter.", e);
-			}
+			// try {
+			// 	StackdriverStatsExporter.createAndRegister();
+			// } catch (java.io.IOException e) {
+			// 	LOGGER.error("Maxwell encountered an error in creating the stackdriver exporter.", e);
+			// }
 
-			LOGGER.info("Stackdriver metrics reporter enabled");
+			// LOGGER.info("Stackdriver metrics reporter enabled");
 		}
 
 		if (config.metricsReportingType.contains(reportingTypeHttp)) {

--- a/src/main/java/com/zendesk/maxwell/replication/VStreamObserver.java
+++ b/src/main/java/com/zendesk/maxwell/replication/VStreamObserver.java
@@ -1,0 +1,69 @@
+package com.zendesk.maxwell.replication;
+
+import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import binlogdata.Binlogdata.VEvent;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import io.vitess.proto.Vtgate;
+
+///
+// Observes the VStream response stream, extracts events from VStream responses,
+// then passes them to the VStreamReplicator via a queue for processing.
+//
+public class VStreamObserver implements StreamObserver<Vtgate.VStreamResponse> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(VStreamObserver.class);
+  private final AtomicBoolean mustStop = new AtomicBoolean(false);
+  private final LinkedBlockingDeque<VEvent> queue;
+
+  public VStreamObserver(LinkedBlockingDeque<VEvent> queue) {
+    this.queue = queue;
+  }
+
+  // Shuts down the observer
+  public void stop() {
+    mustStop.set(true);
+  }
+
+  @Override
+  public void onNext(Vtgate.VStreamResponse response) {
+    LOGGER.debug("Received {} VEvents in the VStreamResponse:", response.getEventsCount());
+
+    List<VEvent> messageEvents = response.getEventsList();
+    for (VEvent event : messageEvents) {
+      LOGGER.debug("VEvent: {}", event);
+      enqueueEvent(event);
+    }
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    LOGGER.error("VStream streaming onError. Status: " + Status.fromThrowable(t), t);
+    stop();
+  }
+
+  @Override
+  public void onCompleted() {
+    LOGGER.info("VStream streaming completed.");
+    stop();
+  }
+
+  // Pushes an event to the queue for VStreamReplicator to process.
+  private void enqueueEvent(VEvent event) {
+    while (mustStop.get() != true) {
+      try {
+        if (queue.offer(event, 100, TimeUnit.MILLISECONDS)) {
+          break;
+        }
+      } catch (InterruptedException e) {
+        return;
+      }
+    }
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/VStreamReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/VStreamReplicator.java
@@ -1,0 +1,386 @@
+package com.zendesk.maxwell.replication;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.zendesk.maxwell.MaxwellVitessConfig;
+import com.zendesk.maxwell.filtering.Filter;
+import com.zendesk.maxwell.monitoring.Metrics;
+import com.zendesk.maxwell.producer.AbstractProducer;
+import com.zendesk.maxwell.replication.vitess.ReplicationMessageColumn;
+import com.zendesk.maxwell.replication.vitess.Vgtid;
+import com.zendesk.maxwell.replication.vitess.VitessSchema;
+import com.zendesk.maxwell.replication.vitess.VitessTable;
+import com.zendesk.maxwell.row.RowMap;
+import com.zendesk.maxwell.row.RowMapBuffer;
+import com.zendesk.maxwell.schema.Schema;
+import com.zendesk.maxwell.schema.SchemaStoreException;
+import com.zendesk.maxwell.util.RunLoopProcess;
+
+import binlogdata.Binlogdata.FieldEvent;
+import binlogdata.Binlogdata.RowChange;
+import binlogdata.Binlogdata.RowEvent;
+import binlogdata.Binlogdata.VEvent;
+import binlogdata.Binlogdata.VEventType;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+import io.vitess.proto.Vtgate.VStreamFlags;
+import io.vitess.proto.Vtgate.VStreamRequest;
+import io.vitess.proto.grpc.VitessGrpc;
+import io.vitess.proto.Topodata;
+
+
+public class VStreamReplicator extends RunLoopProcess implements Replicator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(VStreamReplicator.class);
+
+  private static final int GRPC_MAX_INBOUND_MESSAGE_SIZE = 4 * 1024 * 1024;
+  public static final int KEEPALIVE_INTERVAL_SECONDS = 60;
+  public static final int HEARTBEAT_INTERVAL_SECONDS = 30;
+
+  private static final long MAX_TX_ELEMENTS = 10000;
+
+  private static final String INSERT_TYPE = "INSERT";
+  private static final String UPDATE_TYPE = "UPDATE";
+  private static final String DELETE_TYPE = "DELETE";
+
+  private final MaxwellVitessConfig vitessConfig;
+  private final AbstractProducer producer;
+  private final Vgtid initialVgtid;
+  private RowMapBuffer rowBuffer;
+  private final float bufferMemoryUsage;
+
+  private ManagedChannel channel;
+  private VStreamObserver responseObserver;
+  private boolean replicatorStarted = false;
+  private Long lastHeartbeatTime = null;
+
+  private final LinkedBlockingDeque<VEvent> queue;
+  private final VitessSchema vitessSchema = new VitessSchema();
+  private final Filter filter;
+
+  private final Counter rowCounter;
+  private final Meter rowMeter;
+  private final Histogram transactionRowCount;
+  private final Histogram transactionExecutionTime;
+
+  public VStreamReplicator(
+    MaxwellVitessConfig vitessConfig,
+    AbstractProducer producer,
+    Metrics metrics,
+    Filter filter,
+    Float bufferMemoryUsage,
+    int binlogEventQueueSize
+  ) {
+    this.vitessConfig = vitessConfig;
+    this.producer = producer;
+    this.queue = new LinkedBlockingDeque<>(binlogEventQueueSize);
+    this.filter = filter;
+    this.bufferMemoryUsage = bufferMemoryUsage;
+
+    /* setup metrics */
+    MetricRegistry mr = metrics.getRegistry();
+    rowCounter = mr.counter(metrics.metricName("row", "count"));
+    rowMeter = mr.meter(metrics.metricName("row", "meter"));
+    transactionRowCount = mr.histogram(metrics.metricName("transaction", "row_count"));
+    transactionExecutionTime = mr.histogram(metrics.metricName("transaction", "execution_time"));
+
+    // Providing a vgtid MySQL56/19eb2657-abc2-11ea-8ffc-0242ac11000a:1-61 here will make VStream to
+    // start receiving row-changes from MySQL56/19eb2657-abc2-11ea-8ffc-0242ac11000a:1-62
+    // TODO: Need to load the latest vgtid from a persistent store.
+    initialVgtid = Vgtid.of(
+      List.of(
+        new Vgtid.ShardGtid(vitessConfig.keyspace, vitessConfig.shard, "current")
+      )
+    );
+  }
+
+  public void startReplicator() throws Exception {
+    LOGGER.info(
+      "Starting VStreamReplicator, connecting to Vtgate at {}:{}",
+      vitessConfig.vtgateHost, vitessConfig.vtgatePort
+    );
+
+    this.channel = newChannel(
+      vitessConfig.vtgateHost,
+      vitessConfig.vtgatePort,
+      GRPC_MAX_INBOUND_MESSAGE_SIZE
+    );
+    VitessGrpc.VitessStub stub = VitessGrpc.newStub(channel);
+
+    VStreamFlags vStreamFlags = VStreamFlags.newBuilder()
+      .setStopOnReshard(true)
+      .setHeartbeatInterval(HEARTBEAT_INTERVAL_SECONDS)
+      .build();
+
+    VStreamRequest vstreamRequest = VStreamRequest.newBuilder()
+      .setVgtid(initialVgtid.getRawVgtid())
+      .setTabletType(Topodata.TabletType.MASTER)
+      .setFlags(vStreamFlags)
+      .build();
+
+    this.responseObserver = new VStreamObserver(queue);
+
+    stub.vStream(vstreamRequest, responseObserver);
+
+    LOGGER.info("Started VStream");
+
+    this.replicatorStarted = true;
+  }
+
+  @Override
+  protected void beforeStop() throws Exception {
+    responseObserver.stop();
+
+    channel.shutdown();
+    channel.awaitTermination(500, TimeUnit.MILLISECONDS);
+    channel.shutdownNow();
+  }
+
+  /**
+   * get a single row from the replicator and pass it to the producer or bootstrapper.
+   *
+   * This is the top-level function in the run-loop.
+   */
+  @Override
+  public void work() throws Exception {
+    RowMap row = null;
+    try {
+      row = getRow();
+    } catch (InterruptedException e) {
+      LOGGER.debug("Interrupted while waiting for row");
+    }
+
+    if (row == null) {
+      return;
+    }
+
+    rowCounter.inc();
+    rowMeter.mark();
+
+    // if ( scripting != null && !isMaxwellRow(row))
+    // 	scripting.invoke(row);
+
+    processRow(row);
+  }
+
+  public RowMap getRow() throws Exception {
+    if (!replicatorStarted) {
+      LOGGER.warn("replicator was not started, calling startReplicator()...");
+      startReplicator();
+    }
+
+    while (true) {
+      if (rowBuffer != null && !rowBuffer.isEmpty()) {
+        return rowBuffer.removeFirst();
+      }
+
+      final VEvent event = pollEvent();
+      if (event == null) {
+        return null;
+      }
+
+      if (event.getType() == VEventType.BEGIN) {
+        rowBuffer = getTransactionRows(event);
+      } else {
+        processServiceEvent(event);
+      }
+    }
+  }
+
+  private void processRow(RowMap row) throws Exception {
+    producer.push(row);
+  }
+
+  private VEvent pollEvent() throws InterruptedException {
+    return queue.poll(100, TimeUnit.MILLISECONDS);
+  }
+
+  private void processFieldEvent(VEvent event) {
+    FieldEvent fieldEvent = event.getFieldEvent();
+    LOGGER.info("Received field event: " + fieldEvent);
+    vitessSchema.processFieldEvent(fieldEvent);
+  }
+
+
+  private void processVGtidEvent(VEvent event) {
+    LOGGER.info("Received GTID event: " + event);
+  }
+
+  /**
+   * Get a batch of rows for the current transaction.
+   *
+   * We assume the replicator has just processed a "BEGIN" event, and now
+   * we're inside a transaction.  We'll process all rows inside that transaction
+   * and turn them into RowMap objects.
+   *
+   * We do this because we want to attach all rows within
+   * the transaction the same transaction id value (xid, which we generate ourselves since VStream
+   * does not expose underlying transaction ids to the consumer).
+
+   * @return A RowMapBuffer of rows; either in-memory or on disk.
+   */
+  private RowMapBuffer getTransactionRows(VEvent beginEvent) throws Exception {
+    RowMapBuffer buffer = new RowMapBuffer(MAX_TX_ELEMENTS, this.bufferMemoryUsage);
+
+    // Since transactions in VStream do not have an XID value, we generate one
+    long xid = System.currentTimeMillis() * 1000 + Math.abs(beginEvent.hashCode()) % 1000;
+    LOGGER.debug("Generated transaction id: {}", xid);
+    buffer.setXid(xid);
+
+    while (true) {
+      final VEvent event = pollEvent();
+      if (event == null) {
+        continue;
+      }
+
+      final VEventType eventType = event.getType();
+
+      if (eventType == VEventType.COMMIT) {
+        LOGGER.debug("Received COMMIT event");
+        if (!buffer.isEmpty()) {
+          buffer.getLast().setTXCommit();
+          long timeSpent = buffer.getLast().getTimestampMillis() - beginEvent.getTimestamp();
+          transactionExecutionTime.update(timeSpent);
+          transactionRowCount.update(buffer.size());
+        }
+        return buffer;
+      }
+
+      if (eventType == VEventType.ROW) {
+        List<RowMap> eventRows = rowEventToMaps(event, xid);
+        for (RowMap r : eventRows) {
+          // if (shouldOutputRowMap(table.getDatabase(), table.getName(), r, filter)) {
+          buffer.add(r);
+        }
+        continue;
+      }
+
+      // All other events are service events delivering the schema, GTID values, etc.
+      processServiceEvent(event);
+    }
+  }
+
+  private void processServiceEvent(VEvent event) {
+    final VEventType eventType = event.getType();
+    switch(eventType) {
+      case FIELD:
+        processFieldEvent(event);
+        break;
+
+      case HEARTBEAT:
+        LOGGER.debug("Received heartbeat from vtgate: {}", event);
+        break;
+
+      case VGTID:
+        processVGtidEvent(event);
+        break;
+
+      case ROW:
+      case BEGIN:
+      case COMMIT:
+        LOGGER.error("Unexpected event outside of a transaction, skipping: {}", event);
+        break;
+
+      default:
+        LOGGER.warn("Unexpected service event: {}", event);
+        break;
+    }
+
+  }
+
+  private List<RowMap> rowEventToMaps(VEvent event, long xid) {
+    Long timestampMillis = event.getCurrentTime();
+    RowEvent rowEvent = event.getRowEvent();
+    String qualifiedTableName = rowEvent.getTableName();
+
+    List<RowMap> rowMaps = new ArrayList<>(rowEvent.getRowChangesCount());
+    for (RowChange rowChange: rowEvent.getRowChangesList()) {
+      String changeType = rowChangeToMaxwellType(rowChange);
+      final VitessTable table = resolveTable(qualifiedTableName);
+      if (!filter.includes(table.getSchemaName(), table.getTableName())) {
+        LOGGER.debug("Filtering out event for table {}.{}", table.getSchemaName(), table.getTableName());
+        continue;
+      }
+      List<ReplicationMessageColumn> columns = table.resolveColumns(rowChange);
+
+      RowMap rowMap = new RowMap(
+        changeType,
+        table.getSchemaName(),
+        table.getTableName(),
+        timestampMillis,
+        table.getPkColumns(),
+        null, null, null
+      );
+
+      rowMap.setXid(xid);
+
+      for (ReplicationMessageColumn column : columns) {
+        rowMap.putData(column.getName(), column.getValue());
+      }
+
+      rowMaps.add(rowMap);
+    }
+
+    return rowMaps;
+  }
+
+  private String rowChangeToMaxwellType(RowChange change) {
+    if (change.hasAfter() && !change.hasBefore()) { return INSERT_TYPE; }
+    if (change.hasAfter() && change.hasBefore())  { return UPDATE_TYPE; }
+    if (!change.hasAfter() && change.hasBefore()) { return DELETE_TYPE; }
+
+    throw new RuntimeException("Invalid row change: " + change);
+  }
+
+  private VitessTable resolveTable(String qualifiedTableName) {
+    VitessTable table = vitessSchema.getTable(qualifiedTableName);
+    if (table == null) {
+      throw new RuntimeException("Table not found in the schema: " + qualifiedTableName);
+    }
+    return table;
+  }
+
+  @Override
+  public Long getLastHeartbeatRead() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Schema getSchema() throws SchemaStoreException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Long getSchemaId() throws SchemaStoreException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void stopAtHeartbeat(long heartbeat) {
+    // TODO Auto-generated method stub
+  }
+
+  private static ManagedChannel newChannel(String vtgateHost, int vtgatePort, int maxInboundMessageSize) {
+    return ManagedChannelBuilder
+      .forAddress(vtgateHost, vtgatePort)
+      .usePlaintext()
+      .maxInboundMessageSize(maxInboundMessageSize)
+      .keepAliveTime(KEEPALIVE_INTERVAL_SECONDS, TimeUnit.SECONDS)
+      .build();
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/ColumnMetaData.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/ColumnMetaData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.zendesk.maxwell.replication.vitess;
+
+/**
+ * It maps the VStream FIELD to a relational column. A list of ColumnMetaData
+ * can be used to create
+ * a {@link VitessTable}.
+ */
+public class ColumnMetaData {
+  private final String columnName;
+  private final VitessType vitessType;
+  private final boolean optional;
+  private final KeyMetaData keyMetaData;
+
+  public ColumnMetaData(String columnName, VitessType vitessType, boolean optional, KeyMetaData keyMetaData) {
+    this.columnName = columnName;
+    this.vitessType = vitessType;
+    this.keyMetaData = keyMetaData;
+    this.optional = optional;
+  }
+
+  public String getColumnName() {
+    return columnName;
+  }
+
+  public VitessType getVitessType() {
+    return vitessType;
+  }
+
+  public boolean isOptional() {
+    return optional;
+  }
+
+  public KeyMetaData getKeyMetaData() {
+    return keyMetaData;
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/KeyMetaData.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/KeyMetaData.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.zendesk.maxwell.replication.vitess;
+
+/**
+ * If a column is part of the primary key (including multi-column primary key),
+ * or a column is a single-column unique key
+ */
+public enum KeyMetaData {
+  /**
+   * The column is part of the primary key (including multi-column primary key)
+   */
+  IS_KEY,
+  /**
+   * The column is single-column unique key
+   */
+  IS_UNIQUE_KEY,
+  /**
+   * The column is not part of any key, or the column is part of multi-column
+   * unique key
+   */
+  NONE
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/ReplicationMessageColumn.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/ReplicationMessageColumn.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.zendesk.maxwell.replication.vitess;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Types;
+
+/** Logical representation of both column type and value. */
+public class ReplicationMessageColumn {
+  private final String columnName;
+  private final VitessType type;
+  private final byte[] rawValue;
+
+  public ReplicationMessageColumn(String columnName, VitessType type, byte[] rawValue) {
+    this.columnName = columnName;
+    this.type = type;
+    this.rawValue = rawValue;
+  }
+
+  public String getName() {
+    return columnName;
+  }
+
+  public VitessType getType() {
+    return type;
+  }
+
+  public Object getValue() {
+    final VitessColumnValue value = new VitessColumnValue(rawValue);
+
+    if (value.isNull()) {
+      return null;
+    }
+
+    switch (type.getJdbcId()) {
+      case Types.SMALLINT:
+        return value.asShort();
+      case Types.INTEGER:
+        return value.asInteger();
+      case Types.BIGINT:
+        return value.asLong();
+      case Types.BLOB:
+      case Types.BINARY:
+        return value.asBytes();
+      case Types.VARCHAR:
+        return value.asString();
+      case Types.FLOAT:
+        return value.asFloat();
+      case Types.DOUBLE:
+        return value.asDouble();
+      default:
+        break;
+    }
+
+    return value.asDefault(type);
+  }
+
+  public byte[] getRawValue() {
+    return rawValue;
+  }
+
+  @Override
+  public String toString() {
+    return columnName + "=" + new String(rawValue, StandardCharsets.UTF_8);
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/Vgtid.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/Vgtid.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.zendesk.maxwell.replication.vitess;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import binlogdata.Binlogdata;
+
+/** Vitess source position coordinates. */
+public class Vgtid {
+  public static final String CURRENT_GTID = "current";
+  public static final String KEYSPACE_KEY = "keyspace";
+  public static final String SHARD_KEY = "shard";
+  public static final String GTID_KEY = "gtid";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Binlogdata.VGtid rawVgtid;
+  private final List<ShardGtid> shardGtids = new ArrayList<>();
+
+  private Vgtid(Binlogdata.VGtid rawVgtid) {
+    this.rawVgtid = rawVgtid;
+    for (Binlogdata.ShardGtid shardGtid : rawVgtid.getShardGtidsList()) {
+      shardGtids.add(new ShardGtid(shardGtid.getKeyspace(), shardGtid.getShard(), shardGtid.getGtid()));
+    }
+  }
+
+  private Vgtid(List<ShardGtid> shardGtids) {
+    this.shardGtids.addAll(shardGtids);
+
+    Binlogdata.VGtid.Builder builder = Binlogdata.VGtid.newBuilder();
+    for (ShardGtid shardGtid : shardGtids) {
+      builder.addShardGtids(
+          Binlogdata.ShardGtid.newBuilder()
+              .setKeyspace(shardGtid.getKeyspace())
+              .setShard(shardGtid.getShard())
+              .setGtid(shardGtid.getGtid())
+              .build());
+    }
+    this.rawVgtid = builder.build();
+  }
+
+  public static Vgtid of(String shardGtidsInJson) {
+    try {
+      List<ShardGtid> shardGtids = MAPPER.readValue(shardGtidsInJson, new TypeReference<List<ShardGtid>>() {
+      });
+      return of(shardGtids);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static Vgtid of(Binlogdata.VGtid rawVgtid) {
+    return new Vgtid(rawVgtid);
+  }
+
+  public static Vgtid of(List<ShardGtid> shardGtids) {
+    return new Vgtid(shardGtids);
+  }
+
+  public Binlogdata.VGtid getRawVgtid() {
+    return rawVgtid;
+  }
+
+  public List<ShardGtid> getShardGtids() {
+    return shardGtids;
+  }
+
+  public boolean isSingleShard() {
+    return rawVgtid.getShardGtidsCount() == 1;
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return MAPPER.writeValueAsString(shardGtids);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Vgtid vgtid = (Vgtid) o;
+    return Objects.equals(rawVgtid, vgtid.rawVgtid) &&
+        Objects.equals(shardGtids, vgtid.shardGtids);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rawVgtid, shardGtids);
+  }
+
+  @JsonPropertyOrder({ KEYSPACE_KEY, SHARD_KEY, GTID_KEY })
+  public static class ShardGtid {
+    private final String keyspace;
+    private final String shard;
+    private final String gtid;
+
+    @JsonCreator
+    public ShardGtid(@JsonProperty(KEYSPACE_KEY) String keyspace, @JsonProperty(SHARD_KEY) String shard,
+        @JsonProperty(GTID_KEY) String gtid) {
+      this.keyspace = keyspace;
+      this.shard = shard;
+      this.gtid = gtid;
+    }
+
+    public String getKeyspace() {
+      return keyspace;
+    }
+
+    public String getShard() {
+      return shard;
+    }
+
+    public String getGtid() {
+      return gtid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ShardGtid shardGtid = (ShardGtid) o;
+      return Objects.equals(keyspace, shardGtid.keyspace) &&
+          Objects.equals(shard, shardGtid.shard) &&
+          Objects.equals(gtid, shardGtid.gtid);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(keyspace, shard, gtid);
+    }
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/VitessColumn.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/VitessColumn.java
@@ -1,0 +1,23 @@
+package com.zendesk.maxwell.replication.vitess;
+
+public class VitessColumn {
+  private final String name;
+  private final VitessType type;
+
+  public VitessColumn(String name, VitessType type) {
+    this.name = name;
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public VitessType getType() {
+    return type;
+  }
+
+  public String toString() {
+    return "Column [name=" + name + ", type=" + type + "]";
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/VitessColumnValue.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/VitessColumnValue.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.zendesk.maxwell.replication.vitess;
+
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A convenient wrapper that wraps the raw bytes value and converts it to Java
+ * value.
+ */
+public class VitessColumnValue {
+  private static final Logger LOGGER = LoggerFactory.getLogger(VitessColumnValue.class);
+
+  private final byte[] value;
+
+  public VitessColumnValue(byte[] value) {
+    this.value = value;
+  }
+
+  public byte[] getRawValue() {
+    return value;
+  }
+
+  public boolean isNull() {
+    return value == null;
+  }
+
+  public byte[] asBytes() {
+    return value;
+  }
+
+  /**
+   * Convert raw bytes value to string using UTF-8 encoding.
+   *
+   * This is *enforced* for VARCHAR and CHAR types, and is *required* for other
+   * non-bytes types (numeric,
+   * timestamp, etc.). For bytes (BLOB, BINARY, etc.) types, the asBytes() should
+   * be used.
+   *
+   * @return the UTF-8 string
+   */
+  public String asString() {
+    return new String(value, StandardCharsets.UTF_8);
+  }
+
+  public Integer asInteger() {
+    return Integer.valueOf(asString());
+  }
+
+  public Short asShort() {
+    return Short.valueOf(asString());
+  }
+
+  public Long asLong() {
+    return Long.valueOf(asString());
+  }
+
+  public Float asFloat() {
+    return Float.valueOf(asString());
+  }
+
+  public Double asDouble() {
+    return Double.valueOf(asString());
+  }
+
+  public Object asDefault(VitessType vitessType) {
+    LOGGER.warn("processing unknown column type {} as string", vitessType);
+    return asString();
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/VitessSchema.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/VitessSchema.java
@@ -1,0 +1,125 @@
+package com.zendesk.maxwell.replication.vitess;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import binlogdata.Binlogdata.FieldEvent;
+import io.vitess.proto.Query.Field;
+
+// An in-memory representation of a Vitess schema.
+public class VitessSchema {
+  private static final Logger LOGGER = LoggerFactory.getLogger(VitessSchema.class);
+
+  // See all flags:
+  // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/group__group__cs__column__definition__flags.html
+  private static final int NOT_NULL_FLAG = 1;
+  private static final int PRI_KEY_FLAG = 1 << 1;
+  private static final int UNIQUE_KEY_FLAG = 1 << 2;
+
+  private final Map<String, VitessTable> tables = new HashMap<>();
+
+  public void addTable(VitessTable table) {
+    String tableName = table.getQualifiedTableName();
+    if (tables.containsKey(tableName)) {
+      LOGGER.info("Schema change detected for: {}", table);
+    } else {
+      LOGGER.info("Table schema received for: {}", table);
+    }
+    tables.put(tableName, table);
+  }
+
+  public VitessTable getTable(String name) {
+    return tables.get(name);
+  }
+
+  public void processFieldEvent(FieldEvent event) {
+    if (event == null) {
+      throw new RuntimeException(String.format("fieldEvent is expected from {}", event));
+    }
+
+    String qualifiedTableName = event.getTableName();
+    String[] schemaTableTuple = qualifiedTableName.split("\\.");
+    if (schemaTableTuple.length != 2) {
+      throw new RuntimeException(
+          String.format(
+              "Handling FIELD VEvent. schemaTableTuple should have schema name and table name but has size {}. {} is skipped",
+              schemaTableTuple.length,
+              event));
+    }
+
+    LOGGER.debug("Handling FIELD VEvent: {}", event);
+    String schemaName = schemaTableTuple[0];
+    String tableName = schemaTableTuple[1];
+    int columnCount = event.getFieldsCount();
+
+    List<ColumnMetaData> columns = new ArrayList<>(columnCount);
+    for (short i = 0; i < columnCount; ++i) {
+      Field field = event.getFields(i);
+      String columnName = validateColumnName(field.getName(), schemaName, tableName);
+
+      VitessType vitessType = VitessType.resolve(field);
+      if (vitessType.getJdbcId() == Types.OTHER) {
+        LOGGER.error("Cannot resolve JDBC type from VStream field {}", field);
+      }
+
+      KeyMetaData keyMetaData = KeyMetaData.NONE;
+      if ((field.getFlags() & PRI_KEY_FLAG) != 0) {
+        keyMetaData = KeyMetaData.IS_KEY;
+      } else if ((field.getFlags() & UNIQUE_KEY_FLAG) != 0) {
+        keyMetaData = KeyMetaData.IS_UNIQUE_KEY;
+      }
+      boolean optional = (field.getFlags() & NOT_NULL_FLAG) == 0;
+
+      columns.add(new ColumnMetaData(columnName, vitessType, optional, keyMetaData));
+    }
+
+    VitessTable table = createTable(schemaName, tableName, columns);
+    addTable(table);
+  }
+
+  private static String validateColumnName(String columnName, String schemaName, String tableName) {
+    int length = columnName.length();
+    if (length == 0) {
+      throw new IllegalArgumentException(
+          String.format("Empty column name from schema: %s, table: %s", schemaName, tableName));
+    }
+
+    // Vitess VStreamer schema reloading transient bug could cause column names to
+    // be anonymized to @1, @2, etc
+    // We want to fail in this case instead of sending the corrupted row events with
+    // @1, @2 as column names.
+    char first = columnName.charAt(0);
+    if (first == '@') {
+      throw new IllegalArgumentException(
+          String.format(
+              "Illegal prefix '@' for column: %s, from schema: %s, table: %s",
+              columnName,
+              schemaName,
+              tableName));
+    }
+
+    return columnName;
+  }
+
+  private VitessTable createTable(String schemaName, String tableName, List<ColumnMetaData> columnsMetaData) {
+    List<VitessColumn> columns = new ArrayList<>(columnsMetaData.size());
+    List<String> pkColumns = new ArrayList<>();
+
+    for (ColumnMetaData columnMetaData : columnsMetaData) {
+      VitessColumn column = new VitessColumn(columnMetaData.getColumnName(), columnMetaData.getVitessType());
+      columns.add(column);
+
+      if (columnMetaData.getKeyMetaData() == KeyMetaData.IS_KEY) {
+        pkColumns.add(columnMetaData.getColumnName());
+      }
+    }
+
+    return new VitessTable(schemaName, tableName, columns, pkColumns);
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/VitessTable.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/VitessTable.java
@@ -1,0 +1,89 @@
+package com.zendesk.maxwell.replication.vitess;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.protobuf.ByteString;
+
+import binlogdata.Binlogdata.RowChange;
+import io.vitess.proto.Query.Row;
+
+public class VitessTable {
+  private final String schemaName;
+  private final String tableName;
+  private final List<VitessColumn> columns;
+  private final List<String> pkColumns;
+
+  public VitessTable(String schemaName, String tableName, List<VitessColumn> columns, List<String> pkColumns) {
+    this.schemaName = schemaName;
+    this.tableName = tableName;
+    this.columns = columns;
+    this.pkColumns = pkColumns;
+  }
+
+  public String getSchemaName() {
+    return schemaName;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public String getQualifiedTableName() {
+    return schemaName + "." + tableName;
+  }
+
+  public List<VitessColumn> getColumns() {
+    return columns;
+  }
+
+  public List<String> getPkColumns() {
+    return pkColumns;
+  }
+
+  public String toString() {
+    return "Table [schemaName=" + schemaName
+        + ", tableName=" + tableName
+        + ", columns=" + columns
+        + ", pkColumns=" + pkColumns
+        + "]";
+  }
+
+  /**
+   * Resolve the vEvent data to a list of replication message columns (with
+   * values).
+   */
+  public List<ReplicationMessageColumn> resolveColumns(RowChange rowChange) {
+    Row row = rowChange.hasAfter() ? rowChange.getAfter() : rowChange.getBefore();
+    int changedColumnsCnt = row.getLengthsCount();
+    if (columns.size() != changedColumnsCnt) {
+      throw new IllegalStateException(
+          String.format(
+              "The number of columns in the ROW event {} is different from the in-memory table schema {}.",
+              row,
+              this));
+    }
+
+    ByteString rawValues = row.getValues();
+    int rawValueIndex = 0;
+    List<ReplicationMessageColumn> eventColumns = new ArrayList<>(changedColumnsCnt);
+    for (short i = 0; i < changedColumnsCnt; i++) {
+      final VitessColumn columnDefinition = columns.get(i);
+      final String columnName = columnDefinition.getName();
+      final VitessType vitessType = columnDefinition.getType();
+
+      final int rawValueLength = (int) row.getLengths(i);
+      final byte[] rawValue = rawValueLength == -1
+          ? null
+          : rawValues.substring(rawValueIndex, rawValueIndex + rawValueLength).toByteArray();
+      if (rawValueLength != -1) {
+        // no update to rawValueIndex when no value in the rawValue
+        rawValueIndex += rawValueLength;
+      }
+
+      final ReplicationMessageColumn column = new ReplicationMessageColumn(columnName, vitessType, rawValue);
+      eventColumns.add(column);
+    }
+    return eventColumns;
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/replication/vitess/VitessType.java
+++ b/src/main/java/com/zendesk/maxwell/replication/vitess/VitessType.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.zendesk.maxwell.replication.vitess;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import io.vitess.proto.Query.Field;
+
+/** The Vitess table column type */
+public class VitessType {
+
+  // name of the column type
+  private final String name;
+  // enum of column jdbc type
+  private final int jdbcId;
+  // permitted enum values
+  private final List<String> enumValues;
+
+  public VitessType(String name, int jdbcId) {
+    this(name, jdbcId, Collections.emptyList());
+  }
+
+  public VitessType(String name, int jdbcId, List<String> enumValues) {
+    this.name = name;
+    this.jdbcId = jdbcId;
+    this.enumValues = Collections.unmodifiableList(enumValues);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getJdbcId() {
+    return jdbcId;
+  }
+
+  public List<String> getEnumValues() {
+    return enumValues;
+  }
+
+  public boolean isEnum() {
+    return !enumValues.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    return "VitessType{" +
+        "name='" + name + '\'' +
+        ", jdbcId=" + jdbcId +
+        ", enumValues=" + enumValues +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    VitessType that = (VitessType) o;
+    return jdbcId == that.jdbcId && name.equals(that.name) && Objects.equals(enumValues, that.enumValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, jdbcId, enumValues);
+  }
+
+  // Resolve JDBC type from vstream FIELD event
+  public static VitessType resolve(Field field) {
+    final String type = field.getType().name();
+    switch (type) {
+      case "INT8":
+      case "UINT8":
+      case "INT16":
+        return new VitessType(type, Types.SMALLINT);
+      case "UINT16":
+      case "INT24":
+      case "UINT24":
+      case "INT32":
+        return new VitessType(type, Types.INTEGER);
+      case "ENUM":
+        return new VitessType(type, Types.INTEGER, resolveEnumAndSetValues(field.getColumnType()));
+      case "SET":
+        return new VitessType(type, Types.BIGINT, resolveEnumAndSetValues(field.getColumnType()));
+      case "UINT32":
+      case "INT64":
+        return new VitessType(type, Types.BIGINT);
+      case "BLOB":
+        return new VitessType(type, Types.BLOB);
+      case "VARBINARY":
+      case "BINARY":
+        return new VitessType(type, Types.BINARY);
+      case "UINT64":
+      case "VARCHAR":
+      case "CHAR":
+      case "TEXT":
+      case "JSON":
+      case "DECIMAL":
+      case "TIME":
+      case "DATE":
+      case "DATETIME":
+      case "TIMESTAMP":
+      case "YEAR":
+        return new VitessType(type, Types.VARCHAR);
+      case "FLOAT32":
+        return new VitessType(type, Types.FLOAT);
+      case "FLOAT64":
+        return new VitessType(type, Types.DOUBLE);
+      default:
+        return new VitessType(type, Types.OTHER);
+    }
+  }
+
+  /**
+   * Resolve the list of permitted Enum or Set values from the Enum or Set
+   * Definition
+   *
+   * @param definition the Enum or Set column definition from the MySQL table.
+   *                   E.g. "enum('m','l','xl')" or "set('a','b','c')"
+   * @return The list of permitted Enum values or Set values
+   */
+  private static List<String> resolveEnumAndSetValues(String definition) {
+    List<String> values = new ArrayList<>();
+    if (definition == null || definition.length() == 0) {
+      return values;
+    }
+
+    StringBuilder sb = new StringBuilder();
+    boolean startCollecting = false;
+    char[] chars = definition.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      if (chars[i] == '\'') {
+        if (chars[i + 1] != '\'') {
+          if (startCollecting) {
+            // end of the Enum/Set value, add the Enum/Set value to the result list
+            values.add(sb.toString());
+            sb.setLength(0);
+          }
+          startCollecting = !startCollecting;
+        } else {
+          sb.append("'");
+          // In MySQL, the single quote in the Enum/Set definition "a'b" is escaped and
+          // becomes "a''b".
+          // Skip the second single-quote
+          i++;
+        }
+      } else if (startCollecting) {
+        sb.append(chars[i]);
+      }
+    }
+    return values;
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/schema/VitessPositionStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/VitessPositionStore.java
@@ -1,0 +1,20 @@
+package com.zendesk.maxwell.schema;
+
+import com.zendesk.maxwell.replication.Position;
+import com.zendesk.maxwell.util.ConnectionPool;
+
+public class VitessPositionStore extends MysqlPositionStore {
+  public VitessPositionStore(ConnectionPool pool, Long serverID, String clientID, boolean gtidMode) {
+    super(pool, serverID, clientID, gtidMode);
+  }
+
+  @Override
+  public void set(Position p) {
+    // TODO: implement this for storing vtgid values
+  }
+
+  @Override
+  public long heartbeat() throws Exception {
+    return System.currentTimeMillis();
+  }
+}

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -12,6 +12,8 @@ import com.github.shyiko.mysql.binlog.network.SSLMode;
 import joptsimple.*;
 
 import com.zendesk.maxwell.MaxwellMysqlConfig;
+import com.zendesk.maxwell.MaxwellVitessConfig;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -223,6 +225,17 @@ public abstract class AbstractConfig {
 		config.enableHeartbeat = fetchBooleanOption("binlog_heartbeat", options, properties, config.enableHeartbeat);
 		return config;
 	}
+
+  protected MaxwellVitessConfig parseVitessConfig(OptionSet options, Properties properties) {
+    MaxwellVitessConfig config = new MaxwellVitessConfig();
+    config.vtgateHost = fetchStringOption("vitess_host", options, properties, "localhost");
+    config.vtgatePort = fetchIntegerOption("vitess_port", options, properties, 15991);
+    config.user = fetchStringOption("vitess_user", options, properties, null);
+    config.password = fetchStringOption("vitess_password", options, properties, null);
+    config.keyspace = fetchStringOption("vitess_keyspace", options, properties, null);
+    config.shard = fetchStringOption("vitess_shard", options, properties, "");
+    return config;
+  }
 
 	private SSLMode getSslModeFromString(String sslMode) {
 		if (sslMode != null) {


### PR DESCRIPTION
Attempts to implement/fix #1757.

Things that work:
* The code successfully connects to `vtgate` via the VStream API
* Maxwell follows a given keyspace in a Vitess cluster (a specific shard or all shards) and receives all relevant events
* Maxwell uses FIELD events from VStream to maintain an in-memory representation of the database schema (meaning we don't need to load it from MySQL).
* Using the in-memory schema, Maxwell converts VStream ROW events into `RowMap` objects and pushes those to a given producer.

Still need to implement/fix/figure out:
* Position store is stubbed out for now and position recovery is not implemented, so it always starts at the current stream position.
* I'm not sure I'm handling GRPC stream shutdown properly.
* Had to disable OpenCensus dependency for now because they depend on an ancient grpc version that conflicts with the grpc dependency used by vitess.