### PR TITLE
Fix NPE when reading null values from env_config

### DIFF
--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -343,13 +343,14 @@ public class Maxwell implements Runnable {
 		} catch ( URISyntaxException e ) {
 			// catch URISyntaxException explicitly as well to provide more information to the user
 			LOGGER.error("Syntax issue with URI, check for misconfigured host, port, database, or JDBC options (see RFC 2396)");
-			LOGGER.error("URISyntaxException: " + e.getLocalizedMessage());
+			LOGGER.error("URISyntaxException: " + e.getLocalizedMessage(), e);
 			System.exit(1);
 		} catch ( ServerException e ) {
-			LOGGER.error("Maxwell couldn't find the requested binlog, exiting...");
+			LOGGER.error("Maxwell couldn't find the requested binlog, exiting...", e);
 			System.exit(2);
 		} catch ( Exception e ) {
 			e.printStackTrace();
+			LOGGER.error("Maxwell saw an exception and is exiting...", e);
 			System.exit(1);
 		}
 	}

--- a/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
+++ b/src/main/java/com/zendesk/maxwell/util/AbstractConfig.java
@@ -114,7 +114,9 @@ public abstract class AbstractConfig {
 				Properties properties = new Properties();
 				for (Map.Entry<String, Object> entry : stringMap.entrySet()) {
 					LOGGER.debug("Got env_config key: {}", entry.getKey());
-					properties.put(entry.getKey(), entry.getValue().toString());
+					if (entry.getKey() != null && entry.getValue() != null) {
+						properties.put(entry.getKey(), entry.getValue().toString());
+					}
 				}
 				return properties;
 			} catch (JsonProcessingException e) {

--- a/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -88,12 +89,14 @@ public class MaxwellConfigTest
 
 	@Test
 	public void testEnvJsonConfig() throws JsonProcessingException {
-		Map<String, String> configMap = ImmutableMap.<String, String>builder()
+		Map<String, String> nonNullconfigMap = ImmutableMap.<String, String>builder()
 				.put("user", "foo")
 				.put("password", "bar")
 				.put("host", "remotehost")
 				.put("kafka.retries", "100")
 				.build();
+		HashMap<String, String> configMap = new HashMap<>(nonNullconfigMap);
+		configMap.put("ignore.me", null);
 		ObjectMapper mapper = new ObjectMapper();
 		String jsonConfig = mapper.writeValueAsString(configMap);
 		environmentVariables.set("MAXWELL_JSON", "    " + jsonConfig);


### PR DESCRIPTION
Ran into this when the default config got a null value added to it.

1) It was hard to debug since it didn't show up in the regular logs, only in stderr.
2) Due to the way the configuration for our custom producers are setup, we don't have a good way to prevent these null values from getting added

Fix:
 - Don't add null values to the map. When we `get` them, it will come back as null anyway.
 - Add logging of the exception/stack trace and added stack traces to logs around it. If maxwell is going to shutdown the process, I'd rather have a stacktrace than not if I need to debug what's going on.

Add unit test for null value case.