### PR TITLE
No longer clears currentQuery after making a change to the db.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -586,7 +586,6 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 								buffer.add(r);
 							}
 					}
-					currentQuery = null;
 					break;
 				case TABLE_MAP:
 					TableMapEventData data = event.tableMapData();


### PR DESCRIPTION
Some MySQL transactions are missing query data even though `output_row_query` is set to true, issue #1973. 

When Maxwell reads from the binlog, the `BinlogConnectorReplicator` class calls [getTransactionRows ](https://github.com/zendesk/maxwell/blob/56f458dd2eee3651a82cfbd1c365b6d24f937404/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java#L537-L637) for each transaction. The function enters a while (true) loop as it reads from the events, and when it receives a `ROWS_QUERY` event it sets the `currentQuery` local variable. When the it receives a database write operation such as `EXT_UPDATE_ROWS` it uses the `currentQuery` variable to get the query information, but then it clears the `currentQuery` variable. This causes a problem if there are any other write operations that occur before another `ROWS_QUERY` event does. Those events will have null query values. 
