### PR TITLE
Rename pk bugfix

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSavedSchema.java
@@ -156,7 +156,7 @@ public class MysqlSavedSchema {
 			try {
 				deltaString = mapper.writerFor(listOfResolvedSchemaChangeType).writeValueAsString(deltas);
 			} catch ( JsonProcessingException e ) {
-				throw new RuntimeException("Couldn't serialize " + deltas + " to JSON.");
+				throw new RuntimeException("Couldn't serialize " + deltas + " to JSON.", e);
 			}
 			BinlogPosition binlogPosition = position.getBinlogPosition();
 

--- a/src/main/java/com/zendesk/maxwell/schema/Table.java
+++ b/src/main/java/com/zendesk/maxwell/schema/Table.java
@@ -250,6 +250,9 @@ public class Table {
 	}
 
 	public void renameColumn(int idx, String name) throws InvalidSchemaError {
+		ColumnDef oldColumn = columns.get(idx);
+		renamePKColumn(oldColumn.getName(), name);
+
 		ColumnDef column = columns.get(idx).withName(name);
 		columns.replace(idx, column);
 	}

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -200,16 +200,14 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testPKs() throws Exception {
 		String sql[] = {
-			"create TABLE `test_pks` ( id int(11) unsigned primary KEY, str varchar(255) )",
-			"create TABLE `test_pks_2` ( id int(11) unsigned, str varchar(255), primary key(id, str) )",
-			"create TABLE `test_pks_3` ( id int(11) unsigned primary KEY, str varchar(255) )",
-			"create TABLE `test_pks_4` ( id int(11) unsigned primary KEY, str varchar(255) )",
-			"create TABLE `test_pks_5` ( id int(11) unsigned primary KEY, str varchar(255) )",
-			"alter TABLE `test_pks_3` drop primary key, add primary key(str)",
-			"alter TABLE `test_pks_4` drop primary key",
-			"alter TABLE `test_pks` change id renamed_id int(11) unsigned",
-			"alter TABLE `test_pks` drop column renamed_id",
-			"alter TABLE `test_pks_5` rename column id to new_id"
+		   "create TABLE `test_pks` ( id int(11) unsigned primary KEY, str varchar(255) )",
+		   "create TABLE `test_pks_2` ( id int(11) unsigned, str varchar(255), primary key(id, str) )",
+		   "create TABLE `test_pks_3` ( id int(11) unsigned primary KEY, str varchar(255) )",
+		   "create TABLE `test_pks_4` ( id int(11) unsigned primary KEY, str varchar(255) )",
+		   "alter TABLE `test_pks_3` drop primary key, add primary key(str)",
+		   "alter TABLE `test_pks_4` drop primary key",
+		   "alter TABLE `test_pks` change id renamed_id int(11) unsigned",
+		   "alter TABLE `test_pks` drop column renamed_id"
 		};
 
 		testIntegration(sql);
@@ -448,10 +446,13 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		requireMinimumVersion(8,0);
 		String sql[] = {
 			"CREATE TABLE foo ( i int )",
-			"ALTER TABLE foo rename column i to j"
+			"ALTER TABLE foo rename column i to j",
+			"CREATE TABLE foo_pk ( id int(11) unsigned primary KEY )",
+			"ALTER TABLE foo_pk rename column id to new_id"
 		};
 		testIntegration(sql);
 	}
+
 
 	@Test
 	public void testTableCreate() throws Exception {

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -200,14 +200,16 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 	@Test
 	public void testPKs() throws Exception {
 		String sql[] = {
-		   "create TABLE `test_pks` ( id int(11) unsigned primary KEY, str varchar(255) )",
-		   "create TABLE `test_pks_2` ( id int(11) unsigned, str varchar(255), primary key(id, str) )",
-		   "create TABLE `test_pks_3` ( id int(11) unsigned primary KEY, str varchar(255) )",
-		   "create TABLE `test_pks_4` ( id int(11) unsigned primary KEY, str varchar(255) )",
-		   "alter TABLE `test_pks_3` drop primary key, add primary key(str)",
-		   "alter TABLE `test_pks_4` drop primary key",
-		   "alter TABLE `test_pks` change id renamed_id int(11) unsigned",
-		   "alter TABLE `test_pks` drop column renamed_id"
+			"create TABLE `test_pks` ( id int(11) unsigned primary KEY, str varchar(255) )",
+			"create TABLE `test_pks_2` ( id int(11) unsigned, str varchar(255), primary key(id, str) )",
+			"create TABLE `test_pks_3` ( id int(11) unsigned primary KEY, str varchar(255) )",
+			"create TABLE `test_pks_4` ( id int(11) unsigned primary KEY, str varchar(255) )",
+			"create TABLE `test_pks_5` ( id int(11) unsigned primary KEY, str varchar(255) )",
+			"alter TABLE `test_pks_3` drop primary key, add primary key(str)",
+			"alter TABLE `test_pks_4` drop primary key",
+			"alter TABLE `test_pks` change id renamed_id int(11) unsigned",
+			"alter TABLE `test_pks` drop column renamed_id",
+			"alter TABLE `test_pks_5` rename column id to new_id"
 		};
 
 		testIntegration(sql);


### PR DESCRIPTION
Bugfix renaming pk column

Renaming a primary key column yielded the following error:

```
java.lang.RuntimeException: Couldn't serialize [com.zendesk.maxwell.schema.ddl.ResolvedTableAlter@29a69a35] to JSON.
```

The issue was that the renamed column wasn't reflected in the internal
data structure of primary keys.

This commit updates the internal primary key data structure when RenameColumnMod
is applied in the same way it is updated when a ChangeColumnMod is applied.
