### PR TITLE
Proposal for a custom maxwell health check factory

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -236,6 +236,7 @@ metrics_datadog_apikey   | STRING | the datadog api key to use when metrics_data
 metrics_datadog_site     | STRING | the site to publish metrics to when metrics_datadog_type = `http` | us
 metrics_datadog_host     | STRING | the host to publish metrics to when metrics_datadog_type = `udp` | localhost
 metrics_datadog_port     | INT | the port to publish metrics to when metrics_datadog_type = `udp` | 8125
+custom_health.factory	| CLASS_NAME                          | fully qualified maxwell health check factory class, see [example](https://github.com/zendesk/maxwell/blob/master/src/example/com/zendesk/maxwell/example/maxwellhealthcheckfactory/CustomMaxwellHealthCheckFactory.java) |
 
 _See also:_ [Monitoring](/monitoring)
 

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -36,6 +36,12 @@ When the HTTP server is enabled the following endpoints are exposed:
 | `/healthcheck` | run Maxwell's healthchecks.  Considered unhealthy if &gt;0 messages have failed in the last 15 minutes. |
 | `/ping`        | a simple ping test, responds with `pong`                                       |
 
+## Custom Health Check
+Similar to the custom producer, developers can provide their own implementation of a health check.
+
+In order to register your custom health check, you must implement the `MaxwellHealthCheckFactory` interface, which is responsible for creating your custom `MaxwellHealthCheck`. Next, set the `custom_health.factory` configuration property to your `MaxwellHealthCheckFactory`'s fully qualified class name. Then add the custom `MaxwellHealthCheckFactory` JAR and all its dependencies to the $MAXWELL_HOME/lib directory.
+
+Custom health check factory and health check examples can be found here: [https://github.com/zendesk/maxwell/tree/master/src/example/com/zendesk/maxwell/example/maxwellhealthcheckfactory](https://github.com/zendesk/maxwell/tree/master/src/example/com/zendesk/maxwell/example/maxwellhealthcheckfactory)
 
 # JMX Configuration
 ***

--- a/src/example/com/zendesk/maxwell/example/maxwellhealthcheckfactory/CustomMaxwellHealthCheck.java
+++ b/src/example/com/zendesk/maxwell/example/maxwellhealthcheckfactory/CustomMaxwellHealthCheck.java
@@ -1,0 +1,15 @@
+package com.zendesk.maxwell.example.maxwellhealthcheckfactory;
+
+import com.zendesk.maxwell.monitoring.MaxwellHealthCheck;
+import com.zendesk.maxwell.producer.AbstractProducer;
+
+public class CustomMaxwellHealthCheck extends MaxwellHealthCheck {
+	public CustomMaxwellHealthCheck(AbstractProducer producer) {
+		super(producer);
+	}
+
+	@Override
+	protected Result check() throws Exception {
+		return Result.unhealthy("I am always unhealthy");
+	}
+}

--- a/src/example/com/zendesk/maxwell/example/maxwellhealthcheckfactory/CustomMaxwellHealthCheckFactory.java
+++ b/src/example/com/zendesk/maxwell/example/maxwellhealthcheckfactory/CustomMaxwellHealthCheckFactory.java
@@ -1,0 +1,14 @@
+package com.zendesk.maxwell.example.maxwellhealthcheckfactory;
+
+import com.zendesk.maxwell.monitoring.MaxwellHealthCheck;
+import com.zendesk.maxwell.monitoring.MaxwellHealthCheckFactory;
+import com.zendesk.maxwell.producer.AbstractProducer;
+
+public class CustomMaxwellHealthCheckFactory implements MaxwellHealthCheckFactory
+{
+	@Override
+	public MaxwellHealthCheck createHealthCheck(AbstractProducer producer)
+	{
+		return new CustomMaxwellHealthCheck(producer);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHTTPServer.java
@@ -51,7 +51,11 @@ public class MaxwellHTTPServer {
 		MaxwellConfig config = context.getConfig();
 		String reportingType = config.metricsReportingType;
 		if (reportingType != null && reportingType.contains(reportingTypeHttp)) {
-			context.healthCheckRegistry.register("MaxwellHealth", new MaxwellHealthCheck(context.getProducer()));
+			if (config.customHealthFactory != null) {
+				context.healthCheckRegistry.register("MaxwellHealth", config.customHealthFactory.createHealthCheck(context.getProducer()));
+			} else {
+				context.healthCheckRegistry.register("MaxwellHealth", new MaxwellHealthCheck(context.getProducer()));
+			}
 			return new MaxwellMetrics.Registries(context.metricRegistry, context.healthCheckRegistry);
 		} else {
 			return null;

--- a/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHealthCheckFactory.java
+++ b/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHealthCheckFactory.java
@@ -1,0 +1,8 @@
+package com.zendesk.maxwell.monitoring;
+
+import com.zendesk.maxwell.monitoring.MaxwellHealthCheck;
+import com.zendesk.maxwell.producer.AbstractProducer;
+
+public interface MaxwellHealthCheckFactory {
+	MaxwellHealthCheck createHealthCheck(AbstractProducer producer);
+}


### PR DESCRIPTION
Right now users are not able to tailor a healthcheck to their individual needs. At my company we have tried running checks through a shell script alongside the health check, but it seems that this code execution is much slower in some cases and not as reliable as native java.

This is a proposal based on this longstanding TODO
https://github.com/zendesk/maxwell/blob/master/src/main/java/com/zendesk/maxwell/monitoring/MaxwellHealthCheck.java#L17

and uses the same strategy employed for custom producers.