### PR TITLE
Allow 'STATS_SAMPLE_PAGES=DEFAULT' in alter table

### DIFF
--- a/src/main/antlr4/imports/mysql_create_table.g4
+++ b/src/main/antlr4/imports/mysql_create_table.g4
@@ -70,7 +70,7 @@ creation_compression: COMPRESSION '='? string_literal;
 creation_row_format: ROW_FORMAT '='? (DEFAULT | DEFAULT | DYNAMIC | FIXED | COMPRESSED | REDUNDANT | COMPACT);
 creation_stats_auto_recalc: STATS_AUTO_RECALC '='? (DEFAULT | INTEGER_LITERAL);
 creation_stats_persistent: STATS_PERSISTENT '='? (DEFAULT | INTEGER_LITERAL);
-creation_stats_sample_pages: STATS_SAMPLE_PAGES '='? INTEGER_LITERAL;
+creation_stats_sample_pages: STATS_SAMPLE_PAGES '='? (DEFAULT | INTEGER_LITERAL);
 creation_storage_option: STORAGE (DISK | MEMORY | DEFAULT);
 creation_tablespace: TABLESPACE '='? string;
 creation_union: UNION '='? '(' name (',' name)* ')';

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -49,6 +49,7 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 			"create table shard_1.testDrop ( id int(11) )",
 			"drop table shard_1.testDrop",
 			"create table test.c ( v varchar(255) charset ascii )",
+			"alter table test.c ALGORITHM=COPY, STATS_SAMPLE_PAGES=DEFAULT"
 		};
 		testIntegration(sql);
 	}


### PR DESCRIPTION
When trying to alter a table where `STATS_SAMPLE_PAGES` is set to an `INTEGER_LITERAL`, back to `DEFAULT`, the following exception is thrown:

```
Error parsing SQL: 'ALTER TABLE `MYTABLE` ALGORITHM=COPY, DROP FOREIGN KEY `SOME_FK`, STATS_SAMPLE_PAGES=DEFAULT'
```

```
maxwell encountered an exceptioncom.zendesk.maxwell.schema.ddl.MaxwellSQLSyntaxError: <missing INTEGER_LITERAL>
	at com.zendesk.maxwell.schema.ddl.MysqlParserListener.visitErrorNode(MysqlParserListener.java:93)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:17)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
	at org.antlr.v4.runtime.tree.ParseTreeWalker.walk(ParseTreeWalker.java:28)
	at com.zendesk.maxwell.schema.ddl.SchemaChange.parseSQL(SchemaChange.java:101)
	at com.zendesk.maxwell.schema.ddl.SchemaChange.parse(SchemaChange.java:115)
	at com.zendesk.maxwell.schema.AbstractSchemaStore.resolveSQL(AbstractSchemaStore.java:49)
	at com.zendesk.maxwell.schema.MysqlSchemaStore.processSQL(MysqlSchemaStore.java:102)
	at com.zendesk.maxwell.replication.BinlogConnectorReplicator.processQueryEvent(BinlogConnectorReplicator.java:385)
	at com.zendesk.maxwell.replication.BinlogConnectorReplicator.processQueryEvent(BinlogConnectorReplicator.java:407)
	at com.zendesk.maxwell.replication.BinlogConnectorReplicator.getRow(BinlogConnectorReplicator.java:735)
	at com.zendesk.maxwell.replication.BinlogConnectorReplicator.work(BinlogConnectorReplicator.java:235)
	at com.zendesk.maxwell.util.RunLoopProcess.runLoop(RunLoopProcess.java:34)
	at com.zendesk.maxwell.Maxwell.startInner(Maxwell.java:302)
	at com.zendesk.maxwell.Maxwell.start(Maxwell.java:227)
	at com.zendesk.maxwell.Maxwell.run(Maxwell.java:57)
	at com.lightspeedhq.lshk.config.change.services.MaxwellServiceImpl.lambda$start$0(MaxwellServiceImpl.java:38)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```