### PR TITLE
add state object for scripting engine

### DIFF
--- a/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
+++ b/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
@@ -19,6 +19,8 @@ public class Scripting {
 
 	private final ScriptObjectMirror processRowFunc, processHeartbeatFunc, processDDLFunc;
 
+	private LinkedHashMap<String, Object> globalJavascriptState;
+
 	private ScriptObjectMirror getFunc(ScriptEngine engine, String fName, String filename) {
 		ScriptObjectMirror f = (ScriptObjectMirror) engine.get(fName);
 		if ( f == null )
@@ -43,6 +45,8 @@ public class Scripting {
 		processHeartbeatFunc = getFunc(engine, "process_heartbeat", filename);
 		processDDLFunc = getFunc(engine, "process_ddl", filename);
 
+		globalJavascriptState = new LinkedHashMap<String, Object>();
+
 		if ( processRowFunc == null && processHeartbeatFunc == null && processDDLFunc == null )
 			LOGGER.warn("expected " + filename + " to define at least one of: process_row,process_heartbeat,process_ddl");
 	}
@@ -53,7 +57,7 @@ public class Scripting {
 		else if ( row instanceof DDLMap && processDDLFunc != null )
 			processDDLFunc.call(null, new WrappedDDLMap((DDLMap) row));
 		else if ( row instanceof RowMap && processRowFunc != null )
-			processRowFunc.call(null, new WrappedRowMap(row));
+			processRowFunc.call(null, new WrappedRowMap(row), globalJavascriptState);
 	}
 
 	private static ThreadLocal<ScriptEngine> stringifyEngineThreadLocal = ThreadLocal.withInitial(() -> {

--- a/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
+++ b/src/main/java/com/zendesk/maxwell/scripting/Scripting.java
@@ -6,6 +6,7 @@ import javax.script.ScriptException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.LinkedHashMap;
 
 import com.zendesk.maxwell.row.HeartbeatRowMap;
 import com.zendesk.maxwell.row.RowMap;

--- a/src/test/java/com/zendesk/maxwell/scripting/FilterTest.java
+++ b/src/test/java/com/zendesk/maxwell/scripting/FilterTest.java
@@ -1,0 +1,163 @@
+package com.zendesk.maxwell.filtering;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class ScriptingTest {
+	private List<FilterPattern> filters;
+
+	private List<FilterPattern> runParserTest(String input) throws Exception {
+		return new FilterParser(input).parse();
+	}
+
+	@Test
+	public void TestParser() throws Exception {
+		filters = runParserTest("include:/foo.*/.bar");
+
+		assertEquals(1, filters.size());
+		assertEquals(FilterPatternType.INCLUDE, filters.get(0).getType());
+		assertEquals(Pattern.compile("foo.*").toString(), filters.get(0).getDatabasePattern().toString());
+		assertEquals(Pattern.compile("^bar$").toString(), filters.get(0).getTablePattern().toString());
+	}
+
+	@Test
+	public void TestBlacklists() throws Exception {
+		filters = runParserTest("blacklist:foo.*");
+		assertEquals(1, filters.size());
+		assertEquals(FilterPatternType.BLACKLIST, filters.get(0).getType());
+		assertEquals(Pattern.compile("^foo$").toString(), filters.get(0).getDatabasePattern().toString());
+	}
+
+	@Test
+	public void TestQuoting() throws Exception {
+		String tests[] = {
+			"include:`foo`.*",
+			"include:'foo'.*",
+			"include:\"foo\".*"
+		};
+		for ( String test : tests ) {
+			filters = runParserTest(test);
+			assertEquals(1, filters.size());
+			assertEquals(Pattern.compile("^foo$").toString(), filters.get(0).getDatabasePattern().toString());
+		}
+	}
+
+	@Test
+	public void TestOddNames() throws Exception {
+		runParserTest("include: 1foo.bar");
+		runParserTest("include: _foo._bar");
+
+	}
+
+	@Test
+	public void TestAdvancedRegexp() throws Exception {
+		String pattern = "\\w+ \\/[a-z]*1";
+		filters = runParserTest("include: /" + pattern + "/.*");
+		assertEquals(1, filters.size());
+		assertEquals(Pattern.compile(pattern).toString(), filters.get(0).getDatabasePattern().toString());
+	}
+
+	@Test
+	public void TestColumnFilterParse() throws Exception {
+		String input = "include: 1foo.bar.column=foo";
+		filters = runParserTest(input);
+		assertEquals(1, filters.size());
+		assertEquals(input, filters.get(0).toString());
+	}
+
+	@Test
+	public void TestExcludeAll() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar");
+		assertTrue(f.includes("foo", "bar"));
+		assertFalse(f.includes("anything", "else"));
+	}
+
+	@Test
+	public void TestBlacklist() throws Exception {
+		Filter f = new Filter("blacklist: seria.*");
+		assertTrue(f.includes("foo", "bar"));
+		assertFalse(f.includes("seria", "var"));
+		assertTrue(f.isDatabaseBlacklisted("seria"));
+		assertTrue(f.isTableBlacklisted("seria", "anything"));
+	}
+
+	@Test
+	public void TestColumnFiltersAreIgnoredByIncludes() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val");
+		assertFalse(f.includes("foo", "bar"));
+	}
+
+	@Test
+	public void TestColumnFilters() throws Exception {
+		Map<String, Object> map = new HashMap<>();
+		map.put("col", "val");
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=val");
+		assertFalse(f.includes("foo", "bar"));
+		assertTrue(f.includes("foo", "bar", map));
+	}
+
+	@Test
+	public void TestColumnFiltersFromOtherTables() throws Exception {
+		Map<String, Object> map = new HashMap<>();
+		map.put("col", "val");
+		Filter f = new Filter("exclude: *.*, include: no.go.col=val");
+		assertFalse(f.includes("foo", "bar"));
+		assertFalse(f.includes("foo", "bar", map));
+	}
+
+	@Test
+	public void TestNullValuesInData() throws Exception {
+		Map<String, Object> map = new HashMap<>();
+		map.put("col", null);
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
+		assertFalse(f.includes("foo", "bar"));
+		assertTrue(f.includes("foo", "bar", map));
+
+		map.put("col", "null");
+		assertTrue(f.includes("foo", "bar", map));
+
+		map.remove("col");
+		assertFalse(f.includes("foo", "bar", map));
+
+	}
+
+	@Test
+	public void TestSetValidFilter() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+		f.set("blacklist: seria.*");
+		assertEquals(f.toString(), "blacklist: seria.*");
+	}
+
+	@Test
+	public void TestSetInvalidFilter() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+		try {
+			f.set("bl: seria.*");
+		} catch (InvalidFilterException e) {
+			// do nothing
+		}
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+	}
+
+	@Test
+	public void TestToString() throws Exception {
+		Filter f = new Filter("exclude: *.*, include: foo.bar.col=null");
+		assertEquals(f.toString(), "exclude: *.*, include: foo.bar.col=null");
+	}
+
+	@Test
+	public void TestEmptyToString() throws Exception {
+		Filter f = new Filter("");
+		assertEquals(f.toString(), "");
+	}
+}
+

--- a/src/test/java/com/zendesk/maxwell/scripting/ScriptingTest.java
+++ b/src/test/java/com/zendesk/maxwell/scripting/ScriptingTest.java
@@ -1,0 +1,77 @@
+package com.zendesk.maxwell.scripting;
+
+import org.junit.Test;
+
+import com.zendesk.maxwell.replication.Position;
+import com.zendesk.maxwell.row.RowMap;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.*;
+
+public class ScriptingTest {
+	private <T> T getPrivateFieldOrFail(Object obj, String fieldName) throws Exception {
+		Class<?> scriptingHooked = obj.getClass();
+		Field field = scriptingHooked.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		Object value = field.get(obj);
+		if (value == null) {
+			fail(fieldName + " field is null");
+		}
+
+		return (T) field.get(obj);
+	}
+	@Test
+	public void TestScripting() throws Exception {
+		// Write a simple scripting file
+		Scripting scripting = new Scripting("src/test/resources/scripting/test.js");
+
+		// String type, String database, String table, Long timestampMillis, List<String> pkColumns, Position position, Position nextPosition, String rowQuery
+		RowMap row = new RowMap(
+			"insert", 
+			"mydatabase", 
+			"mytable", 
+			0L, new ArrayList<String>(), 
+			new Position(null, 0), 
+			new Position(null, 0), 
+			"SELECT 1"
+		);
+
+		scripting.invoke(row);
+
+		// Access the private globalJavascriptState field
+		LinkedHashMap<String, Object> globalJavascriptState = 
+			getPrivateFieldOrFail(scripting, "globalJavascriptState");
+		
+		assertEquals(globalJavascriptState.get("mykey"), "myvalue");
+	}
+
+	@Test
+	public void DontFailIfScriptHasNoStateParameter() throws Exception {
+		// Write a simple scripting file
+		Scripting scripting = new Scripting("src/test/resources/scripting/test-no-state.js");
+
+		// String type, String database, String table, Long timestampMillis, List<String> pkColumns, Position position, Position nextPosition, String rowQuery
+		RowMap row = new RowMap(
+			"insert", 
+			"mydatabase", 
+			"mytable", 
+			0L, new ArrayList<String>(), 
+			new Position(null, 0), 
+			new Position(null, 0), 
+			"SELECT 1"
+		);
+
+		scripting.invoke(row);
+
+		// Access the private suppressed field
+		boolean suppressed = 
+			getPrivateFieldOrFail(row, "suppressed");
+
+
+		assertEquals(suppressed, true);
+	}
+}
+

--- a/src/test/resources/scripting/test-no-state-suppress-row.js
+++ b/src/test/resources/scripting/test-no-state-suppress-row.js
@@ -1,0 +1,3 @@
+function process_row(r) {
+  r.suppress();
+}

--- a/src/test/resources/scripting/test-set-state.js
+++ b/src/test/resources/scripting/test-set-state.js
@@ -1,0 +1,3 @@
+function process_row(r, state) {
+  state.put("mykey", "myvalue");
+}


### PR DESCRIPTION
This is my first shot on tackling https://github.com/zendesk/maxwell/issues/2063

What this changes:
- it introduces a new state that can be carried over multiple calls of `process_row`
- It adds tests for scripting engine and the new changes