### PR TITLE
Docker required packages to add an health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ FROM openjdk:11-jdk-slim
 RUN apt-get update \
     && apt-get -y upgrade
 
+# Add curl, required to add an healthcheck as a docker command
+RUN apt-get -y install --no-install-recommends curl jq
+
 COPY --from=builder /app /app
 COPY --from=builder /REVISION /REVISION
 


### PR DESCRIPTION
With these extra packages is possible to add an healthcheck command using something like:

```
curl -s http://127.0.0.1:8080/healthcheck | jq '.MaxwellHealth.healthy' | grep -E "^true$"
```

Test it by using docker-compose, here an example:

```
mysql:
    image: mysql:latest
    environment:
      - MYSQL_ROOT_PASSWORD=root
      - MYSQL_DATABASE=test
      
maxwell:
    image: zendesk/maxwell:latest
    command: "bin/maxwell --user=root --password=root --host=mysql --http_diagnostic=true --metrics_type=http --http_port=8080"
    healthcheck:
      test: ["CMD", "curl", "-s", "http://127.0.0.1:8080/healthcheck", "|", "jq", "'.MaxwellHealth.healthy'", "|", "grep", "-E", "\"^true$\""]
      timeout: 20s
      retries: 10
```