### PR TITLE
Fix lz4 security vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,9 +231,9 @@
       <version>1.13</version>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
-      <version>1.3.0</version>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>me.tongfei</groupId>


### PR DESCRIPTION
net.jpountz.lz4 is not a registered domain and
is a theoritical security issue

https://blog.oversecured.com/Introducing-MavenGate-a-supply-chain-attack-method-for-Java-and-Android-applications