### PR TITLE
Remove abandoned dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,11 +231,6 @@
       <version>1.13</version>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
-      <version>1.3.0</version>
-    </dependency>
-    <dependency>
       <groupId>me.tongfei</groupId>
       <artifactId>progressbar</artifactId>
       <version>0.6.0</version>


### PR DESCRIPTION
This dependency has been abandoned and is vulnerable to attack. It looks like it's not being used anymore.
```
    <dependency>
      <groupId>net.jpountz.lz4</groupId>
      <artifactId>lz4</artifactId>
      <version>1.3.0</version>
    </dependency>
```

https://blog.oversecured.com/Introducing-MavenGate-a-supply-chain-attack-method-for-Java-and-Android-applications