### PR TITLE
feat(datetime): enhance datetime parsing and validation

### DIFF
--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -14,6 +14,7 @@ import com.zendesk.maxwell.schema.Table;
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 import com.zendesk.maxwell.schema.columndef.ColumnDefCastException;
 import com.zendesk.maxwell.schema.columndef.DateColumnDef;
+import com.zendesk.maxwell.schema.columndef.DateTimeColumnDef;
 import com.zendesk.maxwell.schema.columndef.TimeColumnDef;
 import com.zendesk.maxwell.scripting.Scripting;
 import org.slf4j.Logger;
@@ -266,6 +267,8 @@ public class SynchronousBootstrapper {
 			if (columnDefinition instanceof TimeColumnDef)
 				columnValue = getTimestamp(resultSet, columnIndex);
 			else if ( columnDefinition instanceof DateColumnDef)
+				columnValue = resultSet.getString(columnIndex);
+			else if ( columnDefinition instanceof DateTimeColumnDef)
 				columnValue = resultSet.getString(columnIndex);
 			else
 				columnValue = resultSet.getObject(columnIndex);

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateColumnDef.java
@@ -32,15 +32,19 @@ public class DateColumnDef extends ColumnDef {
 		if ( value instanceof String ) {
 			String dateString = (String) value;
 
-			if ( config.zeroDatesAsNull && "0000-00-00".equals(dateString) )
-				return null;
+			if ("0000-00-00".equals(dateString)) {
+				if ( config.zeroDatesAsNull  )
+					return null;
+				else
+					return "0000-00-00";
+			} else {
+				if ( !DateValidator.isValidDateTime(dateString) )
+					return null;
 
-			if ( !DateValidator.isValidDateTime(dateString) )
-				return null;
-
-			value = parseDate(dateString);
-			if (value == null) {
-				return null;
+				value = parseDate(dateString);
+				if (value == null) {
+					return null;
+				}
 			}
 		} else if ( value instanceof Long && (Long) value == Long.MIN_VALUE ) {
 			if ( config.zeroDatesAsNull )

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateFormatter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateFormatter.java
@@ -1,6 +1,7 @@
 package com.zendesk.maxwell.schema.columndef;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -23,6 +24,9 @@ public class DateFormatter {
 		} else if ( value instanceof Date ) {
 			Long time = ((Date) value).getTime();
 			return new Timestamp(time);
+		} else if ( value instanceof LocalDate ) {
+			LocalDateTime startOfDay = ((LocalDate) value).atStartOfDay();
+			return Timestamp.valueOf(startOfDay);
 		}  else if ( value instanceof LocalDateTime) {
 			return Timestamp.valueOf((LocalDateTime) value);
 		} else

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateTimeColumnDef.java
@@ -26,15 +26,19 @@ public class DateTimeColumnDef extends ColumnDefWithLength {
 		if ( value instanceof String) {
 			String dateString = (String) value;
 
-			if ( config.zeroDatesAsNull && "0000-00-00 00:00:00".equals(dateString) )
-				return null;
+			if ( "0000-00-00 00:00:00".equals(dateString) ) {
+				if ( config.zeroDatesAsNull )
+					return null;
+				else 
+					return appendFractionalSeconds("0000-00-00 00:00:00", 0, getColumnLength());
+			} else {
+				if ( !DateValidator.isValidDateTime(dateString) )
+					return null;
 
-			if ( !DateValidator.isValidDateTime(dateString) )
-				return null;
-
-			value = parseDateTime(dateString);
-			if (value == null) {
-				return null;
+				value = parseDateTime(dateString);
+				if (value == null) {
+					return null;
+				}
 			}
 		} else if ( value instanceof Long ) {
 			Long v = (Long) value;

--- a/src/main/java/com/zendesk/maxwell/schema/columndef/DateValidator.java
+++ b/src/main/java/com/zendesk/maxwell/schema/columndef/DateValidator.java
@@ -1,0 +1,11 @@
+package com.zendesk.maxwell.schema.columndef;
+
+public class DateValidator {
+    private static final String DATE_TIME_REGEX = 
+    "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" +
+    "( (0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]))?$";
+
+    public static boolean isValidDateTime(String dateString) {
+        return dateString.matches(DATE_TIME_REGEX);
+    }
+}

--- a/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/columndef/ColumnDefTest.java
@@ -291,6 +291,46 @@ public class ColumnDefTest extends TestWithNameLogging {
 	}
 
 	@Test
+	public void TestDateBadMonth() throws ColumnDefCastException {
+		ColumnDef d = build("date", true);
+
+		MaxwellOutputConfig config = new MaxwellOutputConfig();
+		config.zeroDatesAsNull = true;
+
+		assertEquals(null, d.asJSON("2020-00-01", config));
+	}
+
+	@Test
+	public void TestDateBadDay() throws ColumnDefCastException {
+		ColumnDef d = build("date", true);
+
+		MaxwellOutputConfig config = new MaxwellOutputConfig();
+		config.zeroDatesAsNull = true;
+
+		assertEquals(null, d.asJSON("2020-01-00", config));
+	}
+
+	@Test
+	public void TestDatetimeBadDay() throws ColumnDefCastException {
+		ColumnDef d = build("datetime", true);
+
+		MaxwellOutputConfig config = new MaxwellOutputConfig();
+		config.zeroDatesAsNull = true;
+
+		assertEquals(null, d.asJSON("2020-01-00 00:00:00", config));
+	}
+
+	@Test
+	public void TestDatetimeBadMonth() throws ColumnDefCastException {
+		ColumnDef d = build("datetime", true);
+
+		MaxwellOutputConfig config = new MaxwellOutputConfig();
+		config.zeroDatesAsNull = true;
+
+		assertEquals(null, d.asJSON("2020-00-01 00:00:00", config));
+	}
+
+	@Test
 	public void TestDateTimeWithTimestamp() throws ParseException, ColumnDefCastException {
 		ColumnDef d = build("datetime", true);
 		assertThat(d, instanceOf(DateTimeColumnDef.class));


### PR DESCRIPTION
Add validation and parsing for DateColumnDef and DateTimeColumnDef to handle invalid date formats and zero dates as null. Introduce a DateValidator with regex matching for date formats. Extend tests to cover invalid dates and malformed datetime strings.

MySQL and MariaDB allow invalid dates by default unless strict SQL mode is on, enabling entries like 2020-00-01 to be stored without error, which can lead to data processing issues. In older systems, data may be in poor condition, making it difficult to switch to strict mode, so these cases often need handling when using CDC.