### PR TITLE
refactor(mysql-status): Refined compatibility checks for MySQL and Ma…

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellMysqlStatus.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellMysqlStatus.java
@@ -34,11 +34,40 @@ public class MaxwellMysqlStatus {
 		}
 	}
 
+       /**
+       * Generates the appropriate SQL command to retrieve binary log status based on
+       * the database type and version.
+       *
+       * This method checks the database product name and version to determine
+       * the most suitable SQL command for retrieving binary log status information.
+       * It supports MySQL and MariaDB, with compatibility for recent version
+       * requirements:
+       * <ul>
+       * <li>MySQL 8.2 and above: uses "SHOW BINARY LOG STATUS"</li>
+       * <li>MariaDB 10.5 and above: uses "SHOW BINLOG STATUS"</li>
+       * <li>All other versions default to "SHOW MASTER STATUS"</li>
+       * </ul>
+       * If an error occurs during metadata retrieval, the method defaults to "SHOW
+       * MASTER STATUS".
+       *
+       * @return a SQL command string to check binary log status
+       */
 	public String getShowBinlogSQL() {
 		try {
 			DatabaseMetaData md = connection.getMetaData();
-			if ( md.getDatabaseMajorVersion() >= 8 ) {
+
+			String productName = md.getDatabaseProductVersion();
+
+			int majorVersion = md.getDatabaseMajorVersion();
+			int minorVersion = md.getDatabaseMinorVersion();
+
+			boolean isMariaDB = productName.toLowerCase().contains("mariadb");
+			boolean isMySQL = !isMariaDB;
+
+			if (isMySQL && (majorVersion > 8 || (majorVersion == 8 && minorVersion >= 2))) {
 				return "SHOW BINARY LOG STATUS";
+			} else if (isMariaDB && (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 5))) {
+				return "SHOW BINLOG STATUS";
 			}
 		} catch ( SQLException e ) {
 		}


### PR DESCRIPTION
…riaDB versions

This PR updates the getShowBinlogSQL method to enhance compatibility and accuracy in determining the correct SQL command for checking binary log status based on the database type and version.

MySQL 8.2+ uses SHOW BINARY LOG STATUS
MariaDB 10.5+ uses SHOW BINLOG STATUS
Older or unspecified versions default to SHOW MASTER STATUS