### PR TITLE
feat: add partitioner for sns and sqs

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -52,7 +52,7 @@ option                         | argument                            | descripti
 producer                       | [PRODUCER_TYPE](#producer_type)     | type of producer to use                             | stdout
 custom_producer.factory        | CLASS_NAME                          | fully qualified custom producer factory class, see [example](https://github.com/zendesk/maxwell/blob/master/src/example/com/zendesk/maxwell/example/producerfactory/CustomProducerFactory.java) |
 producer_ack_timeout           | [PRODUCER_ACK_TIMEOUT](#ack_timeout) | time in milliseconds before async producers consider a message lost |
-producer_partition_by          | [PARTITION_BY](#partition_by)       | input to kafka/kinesis partition function           | database
+producer_partition_by          | [PARTITION_BY](#partition_by)       | input to kafka/kinesis/sns/sqs partition function           | database
 producer_partition_columns     | STRING                              | if partitioning by 'column', a comma separated list of columns |
 producer_partition_by_fallback | [PARTITION_BY_FALLBACK](#partition_by_fallback) | required when producer_partition_by=column.  Used when the column is missing |
 ignore_producer_error          | BOOLEAN              | When false, Maxwell will terminate on kafka/kinesis/pubsub publish errors (aside from RecordTooLargeException). When true, errors are only logged. See also dead_letter_topic | true

--- a/docs/docs/producers.md
+++ b/docs/docs/producers.md
@@ -71,10 +71,10 @@ as a source of truth.
 # Partitioning
 ***
 
-Both Kafka and AWS Kinesis support the notion of partitioned streams.
+Kafka, AWS Kinesis/SNS/SQS support the notion of partitioned streams.
 Because they like to make our lives hard, Kafka calls its two units "topics"
-and "partitions", and Kinesis calls them "streams" and "shards.  They're the
-same thing, though.  Maxwell is generally configured to write to N
+and "partitions", Kinesis calls them "streams" and "shards", and SNS/SQS calls them "group id". 
+They're the same thing, though.  Maxwell is generally configured to write to N
 partitions/shards on one topic/stream, and how it distributes to those N
 partitions/shards can be controlled by `producer_partition_by`.
 

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellSNSPartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellSNSPartitioner.java
@@ -1,0 +1,15 @@
+package com.zendesk.maxwell.producer.partitioners;
+
+import com.zendesk.maxwell.row.RowMap;
+
+public class MaxwellSNSPartitioner extends AbstractMaxwellPartitioner {
+
+    public MaxwellSNSPartitioner(String partitionKey, String csvPartitionColumns, String partitionKeyFallback) {
+        super(partitionKey, csvPartitionColumns, partitionKeyFallback);
+    }
+
+    public String getSNSKey(RowMap r) {
+        String key = this.getHashString(r);
+        return key;
+    }
+}

--- a/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellSQSPartitioner.java
+++ b/src/main/java/com/zendesk/maxwell/producer/partitioners/MaxwellSQSPartitioner.java
@@ -1,0 +1,15 @@
+package com.zendesk.maxwell.producer.partitioners;
+
+import com.zendesk.maxwell.row.RowMap;
+
+public class MaxwellSQSPartitioner extends AbstractMaxwellPartitioner {
+
+    public MaxwellSQSPartitioner(String partitionKey, String csvPartitionColumns, String partitionKeyFallback) {
+        super(partitionKey, csvPartitionColumns, partitionKeyFallback);
+    }
+
+    public String getSQSKey(RowMap r) {
+        String key = this.getHashString(r);
+        return key;
+    }
+}


### PR DESCRIPTION
Add a parttioner for sns and sqs, so they can choose which key to used for GroupId (where is actually play as the role as partition key like kafka)