### PR TITLE
fix: bump jdk version in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8-jdk-11 as builder
+FROM maven:3.9.9-eclipse-temurin-23 AS builder
 ENV MAXWELL_VERSION=1.42.0 KAFKA_VERSION=1.0.0
 
 RUN apt-get update \
@@ -19,7 +19,7 @@ RUN cd /workspace \
     && echo "$MAXWELL_VERSION" > /REVISION
 
 # Build clean image with non-root priveledge
-FROM openjdk:11-jdk-slim
+FROM openjdk:23-jdk-slim
 
 RUN apt-get update \
     && apt-get -y upgrade

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
       <artifactId>jedis</artifactId>
       <version>3.5.1</version>
     </dependency>
-    
+
     <!-- metrics -->
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -462,7 +462,6 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.3.1</version>
         <configuration>
-            <additionalOptions>--no-module-directories</additionalOptions>
             <source>11</source>
         </configuration>
         <executions>


### PR DESCRIPTION
https://github.com/zendesk/maxwell/issues/2098

use eclipse because it's easy part of the maven image

remove deprecated flag/option