### PR TITLE
Remove Kinesis producer's internal TTL by default

### DIFF
--- a/kinesis-producer-library.properties.example
+++ b/kinesis-producer-library.properties.example
@@ -258,7 +258,7 @@ RecordMaxBufferedTime = 100
 # Default: 30000
 # Minimum: 100
 # Maximum (inclusive): 9223372036854775807
-RecordTtl = 30000
+RecordTtl = 3600000
 
 # Which region to send records to.
 #

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -112,7 +112,12 @@ public class MaxwellKinesisProducer extends AbstractAsyncProducer {
 			KinesisProducerConfiguration config = KinesisProducerConfiguration.fromPropertiesFile(path.toString());
 			this.kinesisProducer = new KinesisProducer(config);
 		} else {
-			this.kinesisProducer = new KinesisProducer();
+			// The default 30 second record Ttl is too aggressive and prevents our own back-pressure
+			// logic from backing as needed off before the producer fails. Setting it to 1 hour
+			// instead.
+			KinesisProducerConfiguration config = new KinesisProducerConfiguration();
+			config.setRecordTtl(3600000);
+			this.kinesisProducer = new KinesisProducer(config);
 		}
 	}
 


### PR DESCRIPTION
By default the Kinesis producer implementation will time out records that cannot be delivered within 30 seconds. This interferes with Maxwell's back-pressure implementation as more than 30 seconds of records may buffer before Maxwell begins to throttle itself causing the whole daemon to exit.

I initially tried setting the Ttl to the max value mentioned in the Kinesis producer documentation, unfortunately this isn't actually supported by the Kinesis producer since it appears to cause overflow in the backend and makes the records timeout immediately. Opted for just changing the Ttl to 1 hour instead which I imagine is a reasonable compromise that let's Maxwell's back pressure do its thing while still surfacing an error if records long term continue to be undeliverable.

Tested the change and can confirm I'm not seeing failures in the timeout failures anymore / back pressure is working properly.

## Reference

See https://javadoc.io/doc/com.amazonaws/amazon-kinesis-producer/0.14.0/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.html#getRecordTtl--