### PR TITLE
bump binlog-connector-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>com.zendesk</groupId>
       <artifactId>mysql-binlog-connector-java</artifactId>
-      <version>0.27.4</version>
+      <version>0.30.1</version>
     </dependency>
     <dependency>
       <groupId>com.mchange</groupId>


### PR DESCRIPTION
this pulls in a fix around mariadb-gtid sets that a nice guy found.