### PR TITLE
[GO-1996]: Upgrade jackson-databind from 2.12.1 to 2.12.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.1</version>
+      <version>2.12.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION

**Description**: Upgrade jackson-databind from 2.12.1 to 2.12.7.1

**References**

> https://github.com/zendesk/maxwell/security/dependabot/54

>  JIRA: https://zendesk.atlassian.net/browse/GO-1996

**Risks: NA**

>  Level: Low

> Notes for Rollback: NA
