### PR TITLE
[GO-1996]: Upgrade commons-io from 2.7 to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.14.0</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
**Description**
 Upgrade commons-io from 2.7 to 2.15.0

**References**

> https://github.com/zendesk/maxwell/security/dependabot/113

> JIRA: https://zendesk.atlassian.net/browse/GO-1996

**Risks: NA**

> Level: Low
> Notes for Rollback: NA