### PR TITLE
[GO-1996]: Upgrade protobuf-java from 3.21.7 to 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.7</version>
+      <version>3.25.5</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
**Description**
Upgrade protobuf-java from 3.21.7 to 3.25.5

**References**

https://github.com/zendesk/maxwell/security/dependabot/107

> JIRA: https://zendesk.atlassian.net/browse/GO-1996

**Risks: NA**

> Level: Low
> Notes for Rollback: NA