### PR TITLE
Upgrade jetty-server from 10.0.14 to 10.0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>10.0.14</version>
+      <version>10.0.24</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
**Description**
Upgrade jetty-server from 10.0.14 to 10.0.24

**References**

> https://github.com/zendesk/maxwell/security/dependabot/108

> JIRA: https://zendesk.atlassian.net/browse/GO-1996

**Risks: NA**

> Level: Low
> Notes for Rollback: NA