### PR TITLE
[GO-1996]: Updated kafka-clients to 3.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,19 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>kafka-3.7.1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+          <version>3.7.1</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <dependencies>


### PR DESCRIPTION
**Description**
Updated kafka-clients to 3.7.1

**References**

> https://github.com/zendesk/maxwell/security/dependabot/59

> JIRA: https://zendesk.atlassian.net/browse/GO-1996

**Risks: NA**

> Level: Low
> Notes for Rollback: NA