### PR TITLE
Upgrade metrics-datadog to 2.0.0-RC4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
     <dependency>
       <groupId>com.viafoura</groupId>
       <artifactId>metrics-datadog</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0-RC4</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
- It used to be [2.0.0-RC3](https://github.com/zendesk/maxwell/compare/v1.42.3...v1.43.2#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R375) before the merging of 8 year old PRs, where it got reverted back to 2.0.0-RC2 which downgrades com.datadoghq:java-dogstatsd-client to 2.8.

metrics-datadog 2.0.0-RC4 -> dogstatsd-client 4.1
metrics-datadog 2.0.0-RC3 -> dogstatsd-client 4.0

It should be safe to use the RC4 version