### PR TITLE
[GO-2025]: Updated google-cloud-bigquerystorage to 2.40.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquerystorage</artifactId>
-      <version>3.14.1</version>
+      <version>2.40.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
       <version>2.20.6</version>
     </dependency>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20231013</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>3.25.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquerystorage</artifactId>
-      <version>2.14.2</version>
+      <version>3.14.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -326,11 +326,6 @@
       <groupId>io.nats</groupId>
       <artifactId>jnats</artifactId>
       <version>2.20.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20231013</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
**Description**: 
Updating the `com.google.cloud:google-cloud-bigquerystorage` dependency to a newer version to ensure the transitive **org.json** library and **io.grpc:grpc-protobuf** is also updated, thereby addressing vulnerability [CVE-2022-45688](https://github.com/zendesk/zendesk_maxwell/security/dependabot/3) and [CVE-2023-1428](https://www.google.com/url?q=https%3A%2F%2Fgithub.com%2Fzendesk%2Fzendesk_maxwell%2Fsecurity%2Fdependabot%2F5) 

References

JIRA: https://zendesk.atlassian.net/browse/GO-2025
Risks: NA

Level: Low
Notes for Rollback: NA