### PR TITLE
[GO-2025]: Updated mysql-connector-j to 8.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
       <version>2.20.6</version>
     </dependency>
     <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>3.25.5</version>


### PR DESCRIPTION
**Description**: Updated mysql-connector-j to 8.3.0

**References**

JIRA: https://zendesk.atlassian.net/browse/GO-2025
Risks: NA

Level: Low
Notes for Rollback: NA