### PR TITLE
[GO-2025]: Updated protobuf-java to 4.31.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
+      <version>4.31.0</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
Description: Updated protobuf-java to 4.31.0 thereby addressing vulnerability [CVE-2024-7254](https://www.google.com/url?q=https%3A%2F%2Fgithub.com%2Fzendesk%2Fzendesk_maxwell%2Fsecurity%2Fdependabot%2F17)

References

JIRA: https://zendesk.atlassian.net/browse/GO-2025
Risks: NA

Level: Low
Notes for Rollback: NA