### PR TITLE
Bump mysql-connector-java to 8.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,9 +187,9 @@
       <version>2.15.0</version>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.28</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Bumping to address security vuln noise on our end. Bumped to the latest 8.x version, tests seem green.