### PR TITLE
Include .env in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config/*.yml
 .vscode/
 .factorypath
 .sts4-cache/
+.env


### PR DESCRIPTION
Hi! I think it's a good practice ignoring .env files, considering they are such a common way to store sensible data.