### PR TITLE
bump common lang3 version to 3.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.11</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
bump common lang3 to fix the following vulnerability:

> Uncontrolled Recursion vulnerability in Apache Commons Lang.
>
>This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, and, from org.apache.commons:commons-lang3 3.0 before 3.18.0.
>
>The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. Because an Error is usually not handled by applications and libraries, a StackOverflowError could cause an application to stop.

