### PR TITLE
fix: strip SET STATEMENT wrapper before parsing ALTER TABLE in SchemaChange

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
@@ -110,6 +110,9 @@ public abstract class SchemaChange {
 			return null;
 		}
 
+		// Strip SET STATEMENT ... FOR wrapper before parsing
+		sql = SET_STATEMENT.matcher(sql).replaceAll("");
+
 		while ( true ) {
 			try {
 				return parseSQL(currentDB, sql);

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -327,6 +327,19 @@ public class DDLParserTest {
 	}
 
 	@Test
+	public void testSetStatementWithAlterTable() {
+		// Test that SET STATEMENT wrapper is properly stripped before parsing ALTER TABLE
+		String sql = "SET STATEMENT foreign_key_checks=0 FOR ALTER TABLE transaction " +
+			"ADD CONSTRAINT `fk_source_transaction_id` FOREIGN KEY (source_transaction_id) " +
+			"REFERENCES transaction (id)";
+		
+		List<SchemaChange> changes = SchemaChange.parse("test_db", sql);
+		assertThat(changes, is(notNullValue()));
+		assertThat(changes.size(), is(1));
+		assertThat(changes.get(0), instanceOf(TableAlter.class));
+	}
+
+	@Test
 	public void testChangeColumn() {
 		TableAlter a = parseAlter("alter table c CHANGE column `foo` bar int(20) unsigned default 'foo' not null");
 


### PR DESCRIPTION
The Problem

The migration SQL:

     SET STATEMENT foreign_key_checks=0 FOR
     ALTER TABLE transaction
     ADD CONSTRAINT `fk_source_transaction_id` FOREIGN KEY (source_transaction_id)
     REFERENCES transaction (id);

Maxwell had a regex pattern to strip the SET STATEMENT ... FOR wrapper, but it was only applied when checking the SQL blacklist, not before actual parsing.  This caused the ANTLR parser to fail since it didn't recognize the SET STATEMENT
syntax.

The Solution:
Modified: src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java

     - Added 3 lines to strip the SET STATEMENT ... FOR wrapper before parsing the
    SQL
     - This ensures the ANTLR parser receives clean ALTER TABLE SQL without the
   wrapper

Added: Test in src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java

     - Added testSetStatementWithAlterTable() to verify the fix works with foreign
    key constraints
     - Test confirms the SQL is parsed successfully and produces a TableAlter
   schema change

The reason that I did not need to make changes to the antlr files is because of maxwell's preprocessing architecture.

Maxwell processes SQL in this order:

     - Preprocessing (Java regex) - Line 114 in SchemaChange.java
       - Strips comments (/* */, --, #)
       - Strips version-specific wrappers (/*!50032 ... */)
       - Strips SET STATEMENT ... FOR wrapper (this fix)
     - Parsing (ANTLR grammar) - Line 118, calls parseSQL()
       - ANTLR lexer/parser gets the cleaned SQL
       - Only needs to understand core MySQL DDL syntax