### PR TITLE
Add automatic recovery from purged binlog files

### DIFF
--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -31,6 +31,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -80,6 +85,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 	private Histogram transactionExecutionTime;
 
 	private final Boolean gtidPositioning;
+	private final MaxwellMysqlConfig mysqlConfig;
 
 	private static Pattern createTablePattern =
 		Pattern.compile("^CREATE\\s+TABLE", Pattern.CASE_INSENSITIVE);
@@ -222,6 +228,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		this.client.setServerId(replicaServerID.intValue());
 
 		this.replicationReconnectionRetries = replicationReconnectionRetries;
+		this.mysqlConfig = mysqlConfig;
 	}
 
 	/**
@@ -499,6 +506,26 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 				// we like, so we don't have to bail out of the middle of an event.
 				LOGGER.warn("replicator stopped at position: {} -- restarting", client.getBinlogFilename() + ":" + client.getBinlogPosition());
 
+				// Check if the requested binlog file is still available before reconnecting
+				String currentBinlogFile = client.getBinlogFilename();
+				if (currentBinlogFile != null && !currentBinlogFile.isEmpty()) {
+					try {
+						if (!isBinlogFileAvailable(currentBinlogFile)) {
+							LOGGER.warn("Requested binlog file '{}' is not available. Attempting recovery.", currentBinlogFile);
+							if (attemptRecoverFromAvailableBinlogs()) {
+								LOGGER.info("Successfully recovered from available binlogs.");
+								throw new ClientReconnectedException();
+							} else {
+								LOGGER.error("Failed to recover from available binlogs.");
+								throw new Exception("Cannot recover: requested binlog file has been purged and no suitable replacement found.");
+							}
+						}
+					} catch (SQLException e) {
+						LOGGER.error("Error checking binlog file availability: {}", e.getMessage());
+						// Continue with normal reconnection attempt
+					}
+				}
+
 				Long oldMasterId = client.getMasterServerId();
 				tryReconnect();
 				if (client.getMasterServerId() != oldMasterId) {
@@ -509,7 +536,7 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		}
 	}
 
-	private void tryReconnect() throws TimeoutException {
+	private void tryReconnect() throws TimeoutException, Exception {
 		int reconnectionAttempts = 0;
 
 		while ((reconnectionAttempts += 1) <= this.replicationReconnectionRetries || this.replicationReconnectionRetries == 0) {
@@ -517,9 +544,106 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 				LOGGER.info(String.format("Reconnection attempt: %s of %s", reconnectionAttempts, replicationReconnectionRetries > 0 ? this.replicationReconnectionRetries : "unlimited"));
 				client.connect(5000);
 				return;
-			} catch (IOException | TimeoutException ignored) { }
+			} catch (IOException | TimeoutException e) {
+				// Check if this is a binlog file not found error (1236)
+				if (lastCommError != null && lastCommError.getErrorCode() == BAD_BINLOG_ERROR_CODE) {
+					LOGGER.warn("Detected binlog file not found error (1236). Attempting to recover from available binlogs.");
+					if (attemptRecoverFromAvailableBinlogs()) {
+						LOGGER.info("Successfully recovered from available binlogs.");
+						return;
+					} else {
+						LOGGER.error("Failed to recover from available binlogs.");
+						throw new Exception("Cannot recover: requested binlog file has been purged and no suitable replacement found.");
+					}
+				}
+			}
 		}
 		throw new TimeoutException("Maximum reconnection attempts reached.");
+	}
+
+	/**
+	 * Check if a binlog file is available on the server
+	 * @param binlogFile the binlog file name to check
+	 * @return true if the file exists, false otherwise
+	 * @throws SQLException if there's an error querying the server
+	 */
+	private boolean isBinlogFileAvailable(String binlogFile) throws SQLException {
+		try (Connection c = getReplicationConnection();
+		     Statement s = c.createStatement();
+		     ResultSet rs = s.executeQuery("SHOW BINARY LOGS")) {
+			while (rs.next()) {
+				if (rs.getString("Log_name").equals(binlogFile)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get a list of available binlog files on the server
+	 * @return list of binlog file names, ordered from oldest to newest
+	 * @throws SQLException if there's an error querying the server
+	 */
+	private List<String> getAvailableBinlogFiles() throws SQLException {
+		List<String> binlogFiles = new ArrayList<>();
+		try (Connection c = getReplicationConnection();
+		     Statement s = c.createStatement();
+		     ResultSet rs = s.executeQuery("SHOW BINARY LOGS")) {
+			while (rs.next()) {
+				binlogFiles.add(rs.getString("Log_name"));
+			}
+		}
+		return binlogFiles;
+	}
+
+	/**
+	 * Attempt to recover from available binlog files when the requested binlog has been purged
+	 * @return true if recovery was successful, false otherwise
+	 * @throws Exception if there's an error during recovery
+	 */
+	private boolean attemptRecoverFromAvailableBinlogs() throws Exception {
+		String currentBinlogFile = client.getBinlogFilename();
+		LOGGER.warn("Requested binlog file '{}' is not available. Attempting recovery.", currentBinlogFile);
+
+		List<String> availableBinlogs = getAvailableBinlogFiles();
+
+		if (availableBinlogs.isEmpty()) {
+			LOGGER.error("No binlog files available on the server.");
+			return false;
+		}
+
+		// Get the oldest available binlog file
+		String oldestBinlog = availableBinlogs.get(0);
+		LOGGER.info("Oldest available binlog file: {}", oldestBinlog);
+
+		// Try to connect starting from the oldest available binlog
+		LOGGER.warn("Resetting position to oldest available binlog: {} at position 4", oldestBinlog);
+		client.setBinlogFilename(oldestBinlog);
+		client.setBinlogPosition(4L);
+
+		try {
+			client.connect(5000);
+			LOGGER.info("Successfully connected to binlog: {}", oldestBinlog);
+			lastCommError = null; // Clear the error
+			return true;
+		} catch (IOException | TimeoutException e) {
+			LOGGER.error("Failed to connect to binlog {}: {}", oldestBinlog, e.getMessage());
+			return false;
+		}
+	}
+
+	/**
+	 * Get a replication connection for querying binlog information
+	 * @return a connection to the replication server
+	 * @throws SQLException if connection fails
+	 */
+	private Connection getReplicationConnection() throws SQLException {
+		return java.sql.DriverManager.getConnection(
+			"jdbc:mysql://" + mysqlConfig.host + ":" + mysqlConfig.port + "/",
+			mysqlConfig.user,
+			mysqlConfig.password
+		);
 	}
 
 	/**


### PR DESCRIPTION
 Summary

  This PR adds automatic recovery functionality when the requested binlog file has been purged from the MySQL server.
  Previously, when Maxwell attempted to reconnect to a binlog file that no longer existed on the server, it would fail
  with error code 1236 and require manual intervention.

  With this change, Maxwell can now detect when a binlog file is unavailable and automatically attempt to recover by
  connecting to the oldest available binlog file on the server.

  Problem Scenario

  Consider the following situation:

  1. MySQL binlog expiration is set to 7 days (binlog_expire_logs_seconds = 604800)
  2. However, due to low write traffic, the current binlog file takes 30 days to rotate to a new file
  3. When the binlog finally rotates, MySQL immediately purges the old file (since it's older than 7 days)
  4. Maxwell attempts to reconnect to the old binlog file that no longer exists
  5. Maxwell receives error 1236 (ER_MASTER_FATAL_ERROR_READING_BINLOG) and crashes
  6. Manual intervention is required to reset Maxwell's position

  This scenario is particularly problematic because:
  - It occurs unexpectedly after long periods of stable operation
  - The root cause (binlog rotation + immediate purge) is not obvious
  - Recovery requires manual inspection and position reset

  Changes

  - Added isBinlogFileAvailable() method to check if a binlog file exists on the server
  - Added getAvailableBinlogFiles() method to query all available binlog files
  - Added attemptRecoverFromAvailableBinlogs() method to handle recovery logic
  - Added getReplicationConnection() helper method for database queries
  - Modified tryReconnect() to handle binlog file not found errors (1236) and attempt recovery
  - Added pre-check in ensureReplicatorThread() to proactively detect unavailable binlogs

  Limitations & Known Risks

  ⚠️ Potential Data Loss: This recovery mechanism works by resetting Maxwell's position to the oldest available binlog
  file. Any events that existed between the original binlog position and the oldest available binlog will be permanently
   lost.

  Example:
  - Maxwell was reading binlog.000100 at position 12345
  - Server only has binlog.000150 through binlog.000200 available
  - Recovery will start from binlog.000150 position 4
  - All events from binlog.000100-000149 are lost

  Trade-off: This PR prioritizes service availability over data completeness. Maxwell will remain running and continue
  capturing new events, but there may be a gap in the data stream. Users should:

  - Monitor for recovery events in logs (search for "Attempting recovery" or "Successfully recovered")
  - Implement alerting when recovery occurs
  - Consider whether automatic recovery is appropriate for their use case
  - Potentially make this behavior configurable in a future PR

  Test Plan

  - Unit tests for new helper methods
  - Integration test simulating binlog purge scenario
  - Manual testing with a MySQL instance where binlogs are purged
  - Verify normal reconnection still works when binlogs are available

  Breaking Changes

  - tryReconnect() now throws Exception in addition to TimeoutException. Callers may need to handle the additional
  exception type.