### PR TITLE
Fix UNIQUE index IF NOT EXISTS grammar ordering for MariaDB

### DIFF
--- a/src/main/antlr4/imports/mysql_indices.g4
+++ b/src/main/antlr4/imports/mysql_indices.g4
@@ -15,7 +15,7 @@ index_type_pk:
   index_constraint? PRIMARY KEY if_not_exists? (index_type | index_name)* index_column_list index_options*;
 
 index_type_3:
-  index_constraint? UNIQUE if_not_exists? index_or_key? index_name? index_type? index_column_list index_options*;
+  index_constraint? UNIQUE index_or_key? if_not_exists? index_name? index_type? index_column_list index_options*;
 
 index_type_4:
   (FULLTEXT | SPATIAL) index_or_key? if_not_exists? index_name? index_column_list index_options*;

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLIntegrationTest.java
@@ -669,4 +669,14 @@ public class DDLIntegrationTest extends MaxwellTestWithIsolatedServer {
 		};
 		testIntegration(sql);
 	}
+
+	@Test
+	public void testUniqueKeyIfNotExists() throws Exception {
+		assumeTrue(MysqlIsolatedServer.getVersion().isMariaDB);
+		String sql[] = {
+			"CREATE TABLE unique_test (id INT, email VARCHAR(100))",
+			"ALTER TABLE unique_test ADD UNIQUE KEY IF NOT EXISTS uk_email (email)"
+		};
+		testIntegration(sql);
+	}
 }


### PR DESCRIPTION
Reorder tokens in index_type_3 so KEY/INDEX comes before IF NOT EXISTS, matching MariaDB's official syntax:
```
  UNIQUE [INDEX|KEY] [IF NOT EXISTS] [index_name] ...
```
  https://mariadb.com/kb/en/alter-table/

Previously Maxwell logged:
```
  ERROR MysqlParserListener - (index_type_3 UNIQUE (index_or_key KEY) IF NOT EXISTS
```
Add integration test guarded to MariaDB only.

Fixes #2204