### PR TITLE
Support binlog_transaction_compression (MySQL 8.0.20+ compressed binlog)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,13 @@
       <artifactId>mysql-binlog-connector-java</artifactId>
       <version>0.30.1</version>
     </dependency>
+    <!-- used directly (transaction payload decompression); version matches the
+         binlog connector's transitive dependency -->
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <version>1.5.0-2</version>
+    </dependency>
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
@@ -4,9 +4,11 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Timer;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
 import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.GtidEventData;
 import com.github.shyiko.mysql.binlog.event.MariadbGtidEventData;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
 import com.zendesk.maxwell.monitoring.Metrics;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import org.slf4j.Logger;
@@ -52,6 +54,25 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener {
 		boolean trackMetrics = false;
 
 		EventType eventType = event.getHeader().getEventType();
+
+		// binlog_transaction_compression=ON delivers a transaction's events compressed inside a
+		// single TRANSACTION_PAYLOAD event. The binlog client never unwraps it, so surface each
+		// inner event (TABLE_MAP / rows / XID ...) through the normal path here. Inner events carry
+		// positions relative to the in-memory decompressed buffer, not real binlog offsets; re-stamp
+		// each with the payload event's on-disk position so downstream position tracking stays correct
+		// (getPosition() is derived as nextPosition - eventLength, so we set both fields to the
+		// payload's values, giving every inner event the payload's position and nextPosition).
+		if ( eventType == EventType.TRANSACTION_PAYLOAD ) {
+			EventHeaderV4 payloadHeader = event.getHeader();
+			TransactionPayloadEventData payloadData = event.getData();
+			for ( Event innerEvent : payloadData.getUncompressedEvents() ) {
+				EventHeaderV4 innerHeader = innerEvent.getHeader();
+				innerHeader.setEventLength(payloadHeader.getEventLength());
+				innerHeader.setNextPosition(payloadHeader.getNextPosition());
+				onEvent(innerEvent);
+			}
+			return;
+		}
 
 		if ( eventType == EventType.GTID) {
 			gtid = ((GtidEventData)event.getData()).getGtid();

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorEventListener.java
@@ -8,12 +8,12 @@ import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
 import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.GtidEventData;
 import com.github.shyiko.mysql.binlog.event.MariadbGtidEventData;
-import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
 import com.zendesk.maxwell.monitoring.Metrics;
 import com.zendesk.maxwell.producer.MaxwellOutputConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -57,15 +57,31 @@ class BinlogConnectorEventListener implements BinaryLogClient.EventListener {
 
 		// binlog_transaction_compression=ON delivers a transaction's events compressed inside a
 		// single TRANSACTION_PAYLOAD event. The binlog client never unwraps it, so surface each
-		// inner event (TABLE_MAP / rows / XID ...) through the normal path here. Inner events carry
-		// positions relative to the in-memory decompressed buffer, not real binlog offsets; re-stamp
-		// each with the payload event's on-disk position so downstream position tracking stays correct
+		// inner event (TABLE_MAP / rows / XID ...) through the normal path here, parsing lazily so
+		// only one un-queued inner event is in memory at a time. Inner events carry positions
+		// relative to the in-memory decompressed buffer, not real binlog offsets; re-stamp each
+		// with the payload event's on-disk position so downstream position tracking stays correct
 		// (getPosition() is derived as nextPosition - eventLength, so we set both fields to the
 		// payload's values, giving every inner event the payload's position and nextPosition).
 		if ( eventType == EventType.TRANSACTION_PAYLOAD ) {
 			EventHeaderV4 payloadHeader = event.getHeader();
-			TransactionPayloadEventData payloadData = event.getData();
-			for ( Event innerEvent : payloadData.getUncompressedEvents() ) {
+			MaxwellTransactionPayloadEventData payloadData = event.getData();
+			while ( true ) {
+				Event innerEvent;
+				try {
+					innerEvent = payloadData.nextInnerEvent();
+				} catch ( IOException | RuntimeException e ) {
+					// Same outcome as the binlog client's own handling of an undeserializable
+					// event (log it, continue at the next one), but visible in Maxwell's logs:
+					// inner events already surfaced stay surfaced, the rest of this transaction
+					// is skipped.
+					LOGGER.error("Failed to parse compressed transaction payload at {}:{}, skipping the rest of the transaction",
+						client.getBinlogFilename(), payloadHeader.getPosition(), e);
+					break;
+				}
+				if ( innerEvent == null )
+					break;
+
 				EventHeaderV4 innerHeader = innerEvent.getHeader();
 				innerHeader.setEventLength(payloadHeader.getEventLength());
 				innerHeader.setNextPosition(payloadHeader.getNextPosition());

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -214,6 +214,18 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 			EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY,
 			EventDeserializer.CompatibilityMode.INVALID_DATE_AND_TIME_AS_MIN_VALUE
 		);
+		// binlog_transaction_compression=ON wraps a transaction's events in a single zstd
+		// TRANSACTION_PAYLOAD event. The stock deserializer would parse the inner events without
+		// the compatibility modes above; register one that applies them so compressed and
+		// uncompressed transactions produce identical rows. (Unwrapped by BinlogConnectorEventListener.)
+		eventDeserializer.setEventDataDeserializer(
+			EventType.TRANSACTION_PAYLOAD,
+			new MaxwellTransactionPayloadDeserializer(
+				EventDeserializer.CompatibilityMode.DATE_AND_TIME_AS_LONG_MICRO,
+				EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY,
+				EventDeserializer.CompatibilityMode.INVALID_DATE_AND_TIME_AS_MIN_VALUE
+			)
+		);
 		this.client.setEventDeserializer(eventDeserializer);
 		this.binlogEventListener = new BinlogConnectorEventListener(client, queue, metrics, outputConfig);
 		this.client.setBlocking(!stopOnEOF);

--- a/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
+++ b/src/main/java/com/zendesk/maxwell/replication/BinlogConnectorReplicator.java
@@ -176,8 +176,9 @@ public class BinlogConnectorReplicator extends RunLoopProcess implements Replica
 		transactionRowCount = metrics.getRegistry().histogram(metrics.metricName("transaction", "row_count"));
 		transactionExecutionTime = metrics.getRegistry().histogram(metrics.metricName("transaction", "execution_time"));
 
-		/* setup binlog client */
-		this.client = new BinaryLogClient(mysqlConfig.host, mysqlConfig.port, mysqlConfig.user, mysqlConfig.password);
+		/* setup binlog client; the Maxwell subclass keeps gtid tracking working with
+		   binlog_transaction_compression=ON (see MaxwellBinaryLogClient) */
+		this.client = new MaxwellBinaryLogClient(mysqlConfig.host, mysqlConfig.port, mysqlConfig.user, mysqlConfig.password);
 		this.client.setSSLMode(mysqlConfig.sslMode);
 		this.client.setUseSendAnnotateRowsEvent(true);
 

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellBinaryLogClient.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellBinaryLogClient.java
@@ -1,0 +1,45 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.EventType;
+
+/**
+ * A {@link BinaryLogClient} whose GTID tracking keeps working when MySQL runs with
+ * {@code binlog_transaction_compression=ON}.
+ * <p>
+ * The stock client commits the pending gtid into its set when it sees the transaction's XID
+ * (or COMMIT query) event. With compression those events are inside a single TRANSACTION_PAYLOAD
+ * event that {@code updateGtidSet} has no case for, so the pending gtid is never committed:
+ * {@link #getGtidSet()} freezes at its initial value, every position Maxwell stamps on rows
+ * carries that frozen set, and {@code BinlogPosition.newerThan} (a gtid-set containment check)
+ * rejects every position update — Maxwell makes no durable progress and a restart replays
+ * everything since startup.
+ * <p>
+ * A transaction payload always wraps exactly one complete transaction, so its arrival <em>is</em>
+ * the commit: translate it into the XID event the stock bookkeeping expects. The XID branch of
+ * {@code updateGtidSet} never reads the event argument, so a bare synthetic event suffices.
+ */
+public class MaxwellBinaryLogClient extends BinaryLogClient {
+	private static final Event SYNTHETIC_XID_EVENT = syntheticXidEvent();
+
+	public MaxwellBinaryLogClient(String hostname, int port, String username, String password) {
+		super(hostname, port, username, password);
+	}
+
+	@Override
+	protected void updateGtidSet(Event event) {
+		if ( event.getHeader().getEventType() == EventType.TRANSACTION_PAYLOAD ) {
+			super.updateGtidSet(SYNTHETIC_XID_EVENT);
+		} else {
+			super.updateGtidSet(event);
+		}
+	}
+
+	private static Event syntheticXidEvent() {
+		EventHeaderV4 header = new EventHeaderV4();
+		header.setEventType(EventType.XID);
+		return new Event(header, null);
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadDeserializer.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadDeserializer.java
@@ -1,16 +1,13 @@
 package com.zendesk.maxwell.replication;
 
-import com.github.luben.zstd.Zstd;
-import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.luben.zstd.ZstdDecompressCtx;
+import com.github.luben.zstd.ZstdException;
 import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDataDeserializer;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 /**
  * Deserializes {@code TRANSACTION_PAYLOAD} events, emitted when MySQL is configured with
@@ -22,11 +19,13 @@ import java.util.Arrays;
  * and, worse, makes binary/non-utf8 columns decode incorrectly (a {@code byte[]} that Maxwell would
  * Base64/charset-decode arrives as an already-(mis)decoded {@code String}). This drop-in replacement
  * parses the inner events with the same compatibility modes Maxwell applies to uncompressed events,
- * so a compressed transaction yields the same RowMaps as an uncompressed one.
+ * so a compressed transaction yields the same RowMaps as an uncompressed one. It also defers the
+ * parsing: the returned {@link MaxwellTransactionPayloadEventData} exposes the inner events through
+ * a single-pass cursor instead of an eagerly-built list, bounding peak memory for large transactions.
  * <p>
  * Registered for {@link com.github.shyiko.mysql.binlog.event.EventType#TRANSACTION_PAYLOAD} in
- * {@link BinlogConnectorReplicator}. The inner events it produces are surfaced to the replication
- * queue by {@link BinlogConnectorEventListener#onEvent}, which the upstream client does not do.
+ * {@link BinlogConnectorReplicator}. The inner events are surfaced to the replication queue by
+ * {@link BinlogConnectorEventListener#onEvent}, which the upstream client does not do.
  */
 public class MaxwellTransactionPayloadDeserializer implements EventDataDeserializer<TransactionPayloadEventData> {
 	// On-the-wire payload header field types (MySQL's Transaction_payload_event format).
@@ -35,10 +34,17 @@ public class MaxwellTransactionPayloadDeserializer implements EventDataDeseriali
 	private static final int OTW_PAYLOAD_COMPRESSION_TYPE_FIELD = 2;
 	private static final int OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD = 3;
 
-	// MySQL currently defines only ZSTD (0) and NONE (255); zstd is the only compressed form.
+	// MySQL's transaction payload compression types.
 	private static final int COMPRESSION_TYPE_ZSTD = 0;
+	private static final int COMPRESSION_TYPE_NONE = 255;
 
 	private final EventDeserializer.CompatibilityMode[] compatibilityModes;
+
+	// Reused across payloads: the static Zstd helpers allocate and free a native ZSTD_DCtx on
+	// every call, which is pure overhead at one call per transaction. deserialize() only ever
+	// runs on the binlog client's single deserialization thread, so an unsynchronized shared
+	// context is safe; it stays allocated for the life of the replicator.
+	private final ZstdDecompressCtx zstdContext = new ZstdDecompressCtx();
 
 	public MaxwellTransactionPayloadDeserializer(EventDeserializer.CompatibilityMode... compatibilityModes) {
 		this.compatibilityModes = compatibilityModes;
@@ -46,7 +52,9 @@ public class MaxwellTransactionPayloadDeserializer implements EventDataDeseriali
 
 	@Override
 	public TransactionPayloadEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
-		TransactionPayloadEventData eventData = new TransactionPayloadEventData();
+		int payloadSize = 0;
+		int compressionType = COMPRESSION_TYPE_NONE;
+		int uncompressedSize = 0;
 
 		// Payload header: a sequence of (type, length, value) triplets terminated by an
 		// end-mark field. deserializeEventData() has already bounded inputStream to the event
@@ -59,13 +67,13 @@ public class MaxwellTransactionPayloadDeserializer implements EventDataDeseriali
 			int fieldLength = inputStream.readPackedInteger();
 			switch (fieldType) {
 				case OTW_PAYLOAD_SIZE_FIELD:
-					eventData.setPayloadSize(inputStream.readPackedInteger());
+					payloadSize = inputStream.readPackedInteger();
 					break;
 				case OTW_PAYLOAD_COMPRESSION_TYPE_FIELD:
-					eventData.setCompressionType(inputStream.readPackedInteger());
+					compressionType = inputStream.readPackedInteger();
 					break;
 				case OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD:
-					eventData.setUncompressedSize(inputStream.readPackedInteger());
+					uncompressedSize = inputStream.readPackedInteger();
 					break;
 				default:
 					inputStream.read(fieldLength);
@@ -73,45 +81,42 @@ public class MaxwellTransactionPayloadDeserializer implements EventDataDeseriali
 			}
 		}
 
-		if (eventData.getUncompressedSize() == 0) {
-			eventData.setUncompressedSize(eventData.getPayloadSize());
+		if (uncompressedSize == 0) {
+			uncompressedSize = payloadSize;
 		}
 
-		eventData.setPayload(inputStream.read(eventData.getPayloadSize()));
+		// The compressed bytes stay in this local only: storing them on the event data would
+		// keep them reachable for as long as the event itself.
+		byte[] payload = inputStream.read(payloadSize);
+		byte[] decompressed;
 
-		if (eventData.getCompressionType() != COMPRESSION_TYPE_ZSTD) {
-			throw new IOException("Unsupported binlog_transaction_compression type: "
-				+ eventData.getCompressionType() + " (only ZSTD is supported)");
+		switch (compressionType) {
+			case COMPRESSION_TYPE_ZSTD:
+				decompressed = new byte[uncompressedSize];
+				int decompressedBytes;
+				try {
+					decompressedBytes = zstdContext.decompressByteArray(decompressed, 0, decompressed.length, payload, 0, payload.length);
+				} catch (ZstdException e) {
+					// zstd-jni reports errors by throwing, not via an error-code return
+					throw new IOException("Failed to zstd-decompress binlog transaction payload: " + e.getMessage(), e);
+				}
+				if (decompressedBytes != uncompressedSize) {
+					throw new IOException("Truncated binlog transaction payload: expected "
+						+ uncompressedSize + " bytes, zstd produced " + decompressedBytes);
+				}
+				break;
+			case COMPRESSION_TYPE_NONE:
+				decompressed = payload;
+				break;
+			default:
+				throw new IOException("Unsupported binlog_transaction_compression type: "
+					+ compressionType + " (only ZSTD and NONE are supported)");
 		}
 
-		byte[] compressed = eventData.getPayload();
-		byte[] decompressed = ByteBuffer.allocate(eventData.getUncompressedSize()).array();
-		long rc = Zstd.decompressByteArray(decompressed, 0, decompressed.length, compressed, 0, compressed.length);
-		if (Zstd.isError(rc)) {
-			throw new IOException("Failed to zstd-decompress binlog transaction payload: " + Zstd.getErrorName(rc));
-		}
-
-		// Parse the decompressed inner events with Maxwell's compatibility modes. A single
-		// deserializer instance handles the whole payload so TABLE_MAP events register their
-		// column metadata before the row events that reference them. Inner events carry no
-		// checksum, which matches the default (NONE) on a fresh deserializer.
-		EventDeserializer eventDeserializer = new EventDeserializer();
-		if (compatibilityModes.length > 0) {
-			eventDeserializer.setCompatibilityMode(
-				compatibilityModes[0],
-				Arrays.copyOfRange(compatibilityModes, 1, compatibilityModes.length)
-			);
-		}
-
-		ArrayList<Event> events = new ArrayList<>();
-		ByteArrayInputStream uncompressedStream = new ByteArrayInputStream(decompressed);
-		for (Event event = eventDeserializer.nextEvent(uncompressedStream);
-			 event != null;
-			 event = eventDeserializer.nextEvent(uncompressedStream)) {
-			events.add(event);
-		}
-		eventData.setUncompressedEvents(events);
-
+		MaxwellTransactionPayloadEventData eventData = new MaxwellTransactionPayloadEventData(decompressed, compatibilityModes);
+		eventData.setPayloadSize(payloadSize);
+		eventData.setCompressionType(compressionType);
+		eventData.setUncompressedSize(uncompressedSize);
 		return eventData;
 	}
 }

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadDeserializer.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadDeserializer.java
@@ -1,0 +1,117 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.luben.zstd.Zstd;
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDataDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Deserializes {@code TRANSACTION_PAYLOAD} events, emitted when MySQL is configured with
+ * {@code binlog_transaction_compression=ON} (MySQL 8.0.20+).
+ * <p>
+ * The stock {@code com.github.shyiko...TransactionPayloadEventDataDeserializer} decompresses the
+ * zstd payload but parses the inner events with a <em>default</em> {@link EventDeserializer} that
+ * lacks Maxwell's compatibility modes. That makes datetime values lose sub-millisecond precision
+ * and, worse, makes binary/non-utf8 columns decode incorrectly (a {@code byte[]} that Maxwell would
+ * Base64/charset-decode arrives as an already-(mis)decoded {@code String}). This drop-in replacement
+ * parses the inner events with the same compatibility modes Maxwell applies to uncompressed events,
+ * so a compressed transaction yields the same RowMaps as an uncompressed one.
+ * <p>
+ * Registered for {@link com.github.shyiko.mysql.binlog.event.EventType#TRANSACTION_PAYLOAD} in
+ * {@link BinlogConnectorReplicator}. The inner events it produces are surfaced to the replication
+ * queue by {@link BinlogConnectorEventListener#onEvent}, which the upstream client does not do.
+ */
+public class MaxwellTransactionPayloadDeserializer implements EventDataDeserializer<TransactionPayloadEventData> {
+	// On-the-wire payload header field types (MySQL's Transaction_payload_event format).
+	private static final int OTW_PAYLOAD_HEADER_END_MARK = 0;
+	private static final int OTW_PAYLOAD_SIZE_FIELD = 1;
+	private static final int OTW_PAYLOAD_COMPRESSION_TYPE_FIELD = 2;
+	private static final int OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD = 3;
+
+	// MySQL currently defines only ZSTD (0) and NONE (255); zstd is the only compressed form.
+	private static final int COMPRESSION_TYPE_ZSTD = 0;
+
+	private final EventDeserializer.CompatibilityMode[] compatibilityModes;
+
+	public MaxwellTransactionPayloadDeserializer(EventDeserializer.CompatibilityMode... compatibilityModes) {
+		this.compatibilityModes = compatibilityModes;
+	}
+
+	@Override
+	public TransactionPayloadEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
+		TransactionPayloadEventData eventData = new TransactionPayloadEventData();
+
+		// Payload header: a sequence of (type, length, value) triplets terminated by an
+		// end-mark field. deserializeEventData() has already bounded inputStream to the event
+		// body (checksum excluded), so available() tracks the remaining header+payload bytes.
+		while (inputStream.available() > 0) {
+			int fieldType = inputStream.readPackedInteger();
+			if (fieldType == OTW_PAYLOAD_HEADER_END_MARK) {
+				break;
+			}
+			int fieldLength = inputStream.readPackedInteger();
+			switch (fieldType) {
+				case OTW_PAYLOAD_SIZE_FIELD:
+					eventData.setPayloadSize(inputStream.readPackedInteger());
+					break;
+				case OTW_PAYLOAD_COMPRESSION_TYPE_FIELD:
+					eventData.setCompressionType(inputStream.readPackedInteger());
+					break;
+				case OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD:
+					eventData.setUncompressedSize(inputStream.readPackedInteger());
+					break;
+				default:
+					inputStream.read(fieldLength);
+					break;
+			}
+		}
+
+		if (eventData.getUncompressedSize() == 0) {
+			eventData.setUncompressedSize(eventData.getPayloadSize());
+		}
+
+		eventData.setPayload(inputStream.read(eventData.getPayloadSize()));
+
+		if (eventData.getCompressionType() != COMPRESSION_TYPE_ZSTD) {
+			throw new IOException("Unsupported binlog_transaction_compression type: "
+				+ eventData.getCompressionType() + " (only ZSTD is supported)");
+		}
+
+		byte[] compressed = eventData.getPayload();
+		byte[] decompressed = ByteBuffer.allocate(eventData.getUncompressedSize()).array();
+		long rc = Zstd.decompressByteArray(decompressed, 0, decompressed.length, compressed, 0, compressed.length);
+		if (Zstd.isError(rc)) {
+			throw new IOException("Failed to zstd-decompress binlog transaction payload: " + Zstd.getErrorName(rc));
+		}
+
+		// Parse the decompressed inner events with Maxwell's compatibility modes. A single
+		// deserializer instance handles the whole payload so TABLE_MAP events register their
+		// column metadata before the row events that reference them. Inner events carry no
+		// checksum, which matches the default (NONE) on a fresh deserializer.
+		EventDeserializer eventDeserializer = new EventDeserializer();
+		if (compatibilityModes.length > 0) {
+			eventDeserializer.setCompatibilityMode(
+				compatibilityModes[0],
+				Arrays.copyOfRange(compatibilityModes, 1, compatibilityModes.length)
+			);
+		}
+
+		ArrayList<Event> events = new ArrayList<>();
+		ByteArrayInputStream uncompressedStream = new ByteArrayInputStream(decompressed);
+		for (Event event = eventDeserializer.nextEvent(uncompressedStream);
+			 event != null;
+			 event = eventDeserializer.nextEvent(uncompressedStream)) {
+			events.add(event);
+		}
+		eventData.setUncompressedEvents(events);
+
+		return eventData;
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadEventData.java
+++ b/src/main/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadEventData.java
@@ -1,0 +1,68 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * A {@link TransactionPayloadEventData} that holds the decompressed transaction and parses the
+ * inner events on demand instead of materializing them all up front.
+ * <p>
+ * A compressed transaction is bounded by the transaction size, not by any event-size limit, so
+ * parsing every inner event into a list before the first one is consumed puts the whole
+ * transaction's object graph on the heap at once — defeating the backpressure of the replicator's
+ * bounded event queue. {@link BinlogConnectorEventListener} pulls inner events one at a time via
+ * {@link #nextInnerEvent()} while it feeds that queue, so only one un-queued inner event (plus the
+ * raw decompressed bytes) is held here at any moment. Once the cursor reaches the end, the buffer
+ * and parser are released: the binlog client keeps a reference to the payload event until the next
+ * network event arrives, and after release that reference retains almost nothing.
+ * <p>
+ * {@link TransactionPayloadEventData#getUncompressedEvents()} is kept non-null-but-empty: the
+ * connector's EventDeserializer iterates it right after deserialization (to register inner
+ * TABLE_MAPs in its own table-map cache, which only events outside payloads ever need) and would
+ * NPE on null.
+ */
+public class MaxwellTransactionPayloadEventData extends TransactionPayloadEventData {
+	private EventDeserializer eventDeserializer;
+	private ByteArrayInputStream stream;
+
+	public MaxwellTransactionPayloadEventData(byte[] decompressed, EventDeserializer.CompatibilityMode... compatibilityModes) {
+		// A single deserializer instance handles the whole payload so TABLE_MAP events register
+		// their column metadata before the row events that reference them. It must be fresh per
+		// payload: a shared instance would accumulate table-map entries forever. Inner events
+		// carry no checksum, which matches the default (NONE) on a fresh deserializer.
+		this.eventDeserializer = new EventDeserializer();
+		if (compatibilityModes.length > 0) {
+			this.eventDeserializer.setCompatibilityMode(
+				compatibilityModes[0],
+				Arrays.copyOfRange(compatibilityModes, 1, compatibilityModes.length)
+			);
+		}
+		this.stream = new ByteArrayInputStream(decompressed);
+
+		setUncompressedEvents(new ArrayList<>());
+	}
+
+	/**
+	 * Parses and returns the next inner event of the transaction, or null once exhausted.
+	 * Single-pass: after the end is reached, the decompressed buffer and parser are dropped
+	 * and further calls return null.
+	 */
+	public Event nextInnerEvent() throws IOException {
+		if (stream == null) {
+			return null;
+		}
+
+		Event event = eventDeserializer.nextEvent(stream);
+		if (event == null) {
+			eventDeserializer = null;
+			stream = null;
+		}
+		return event;
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorEventListenerTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/BinlogConnectorEventListenerTest.java
@@ -1,0 +1,67 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.XidEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.zendesk.maxwell.monitoring.NoOpMetrics;
+import com.zendesk.maxwell.producer.MaxwellOutputConfig;
+import org.junit.Test;
+
+import java.util.concurrent.LinkedBlockingDeque;
+
+import static com.zendesk.maxwell.replication.MaxwellTransactionPayloadDeserializerTest.concat;
+import static com.zendesk.maxwell.replication.MaxwellTransactionPayloadDeserializerTest.xidEventBytes;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BinlogConnectorEventListenerTest {
+	private static final EventDeserializer.CompatibilityMode[] COMPAT_MODES = {
+		EventDeserializer.CompatibilityMode.DATE_AND_TIME_AS_LONG_MICRO,
+		EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY,
+		EventDeserializer.CompatibilityMode.INVALID_DATE_AND_TIME_AS_MIN_VALUE
+	};
+
+	@Test
+	public void testUnwrapRestampsInnerEventsWithPayloadPosition() throws Exception {
+		LinkedBlockingDeque<BinlogConnectorEvent> queue = new LinkedBlockingDeque<>(20);
+		MaxwellBinaryLogClient client = new MaxwellBinaryLogClient("127.0.0.1", 3306, "maxwell", "maxwell");
+		client.setBinlogFilename("mysql-bin.000123");
+		BinlogConnectorEventListener listener = new BinlogConnectorEventListener(
+			client,
+			queue,
+			new NoOpMetrics(),
+			new MaxwellOutputConfig()
+		);
+
+		EventHeaderV4 payloadHeader = new EventHeaderV4();
+		payloadHeader.setEventType(EventType.TRANSACTION_PAYLOAD);
+		payloadHeader.setEventLength(500L);
+		payloadHeader.setNextPosition(12345L);
+		payloadHeader.setTimestamp(99_000L);
+
+		byte[] decompressed = concat(xidEventBytes(111L, 1000), xidEventBytes(222L, 2000));
+		Event payloadEvent = new Event(payloadHeader, new MaxwellTransactionPayloadEventData(decompressed, COMPAT_MODES));
+
+		listener.onEvent(payloadEvent);
+
+		assertEquals(2, queue.size());
+
+		BinlogConnectorEvent first = queue.poll();
+		assertEquals(EventType.XID, first.getType());
+		assertEquals(111L, ((XidEventData) first.getEvent().getData()).getXid());
+		// every inner event reports the payload's on-disk [position, nextPosition]
+		assertEquals(12345L - 500L, first.getPosition().getOffset());
+		assertEquals(12345L, first.getNextPosition().getOffset());
+		assertTrue(first.isCommitEvent());
+
+		BinlogConnectorEvent second = queue.poll();
+		assertEquals(222L, ((XidEventData) second.getEvent().getData()).getXid());
+		assertEquals(12345L - 500L, second.getPosition().getOffset());
+		assertEquals(12345L, second.getNextPosition().getOffset());
+
+		// the payload event itself is never queued
+		assertEquals(0, queue.size());
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/replication/MaxwellBinaryLogClientTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/MaxwellBinaryLogClientTest.java
@@ -1,0 +1,54 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.GtidEventData;
+import com.github.shyiko.mysql.binlog.event.MySqlGtid;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaxwellBinaryLogClientTest {
+	private static final String SERVER_UUID = "24bc7850-2c16-11e6-a073-0242ac110002";
+
+	private Event gtidEvent(long transactionId) {
+		EventHeaderV4 header = new EventHeaderV4();
+		header.setEventType(EventType.GTID);
+		GtidEventData data = new GtidEventData(
+			MySqlGtid.fromString(SERVER_UUID + ":" + transactionId),
+			(byte) 0, 0L, 0L, 0L, 0L, 0L, 0, 0
+		);
+		return new Event(header, data);
+	}
+
+	private Event transactionPayloadEvent() {
+		EventHeaderV4 header = new EventHeaderV4();
+		header.setEventType(EventType.TRANSACTION_PAYLOAD);
+		return new Event(header, new TransactionPayloadEventData());
+	}
+
+	/* With binlog_transaction_compression=ON the XID/COMMIT events that normally commit the
+	   pending gtid into the client's set arrive inside the TRANSACTION_PAYLOAD event, which the
+	   stock client's gtid bookkeeping has no case for -- the set would freeze at its initial
+	   value and Maxwell's gtid-mode position would never advance. */
+	@Test
+	public void testGtidSetAdvancesAcrossCompressedTransactions() {
+		MaxwellBinaryLogClient client = new MaxwellBinaryLogClient("127.0.0.1", 3306, "maxwell", "maxwell");
+		client.setGtidSet(SERVER_UUID + ":1-5");
+
+		// the GTID event arrives uncompressed and only marks the gtid as pending
+		client.updateGtidSet(gtidEvent(6));
+		assertEquals(SERVER_UUID + ":1-5", client.getGtidSet());
+
+		// the compressed transaction is the commit the stock bookkeeping never sees
+		client.updateGtidSet(transactionPayloadEvent());
+		assertEquals(SERVER_UUID + ":1-6", client.getGtidSet());
+
+		// and it keeps advancing on subsequent transactions
+		client.updateGtidSet(gtidEvent(7));
+		client.updateGtidSet(transactionPayloadEvent());
+		assertEquals(SERVER_UUID + ":1-7", client.getGtidSet());
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadDeserializerTest.java
+++ b/src/test/java/com/zendesk/maxwell/replication/MaxwellTransactionPayloadDeserializerTest.java
@@ -1,0 +1,210 @@
+package com.zendesk.maxwell.replication;
+
+import com.github.luben.zstd.Zstd;
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
+import com.github.shyiko.mysql.binlog.event.XidEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MaxwellTransactionPayloadDeserializerTest {
+	private static final int COMPRESSION_TYPE_ZSTD = 0;
+	private static final int COMPRESSION_TYPE_NONE = 255;
+	private static final int XID_EVENT_TYPE_CODE = 16;
+	private static final int TRANSACTION_PAYLOAD_TYPE_CODE = 40;
+
+	private static final EventDeserializer.CompatibilityMode[] COMPAT_MODES = {
+		EventDeserializer.CompatibilityMode.DATE_AND_TIME_AS_LONG_MICRO,
+		EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY,
+		EventDeserializer.CompatibilityMode.INVALID_DATE_AND_TIME_AS_MIN_VALUE
+	};
+
+	/* a minimal, valid inner event: 19-byte v4 header + 8-byte xid, no checksum */
+	static byte[] xidEventBytes(long xid, int timestampSeconds) {
+		ByteBuffer buf = ByteBuffer.allocate(27).order(ByteOrder.LITTLE_ENDIAN);
+		buf.putInt(timestampSeconds);
+		buf.put((byte) XID_EVENT_TYPE_CODE);
+		buf.putInt(1);             // server id
+		buf.putInt(27);            // event length
+		buf.putInt(0);             // next position (buffer-relative, re-stamped by the listener)
+		buf.putShort((short) 0);   // flags
+		buf.putLong(xid);
+		return buf.array();
+	}
+
+	static byte[] concat(byte[]... arrays) {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		for (byte[] a : arrays)
+			out.write(a, 0, a.length);
+		return out.toByteArray();
+	}
+
+	/* net_field_length encoding, as readPackedInteger expects */
+	private static void writePacked(ByteArrayOutputStream out, int value) {
+		if (value < 251) {
+			out.write(value);
+		} else {
+			out.write(0xFC);
+			out.write(value & 0xFF);
+			out.write((value >> 8) & 0xFF);
+		}
+	}
+
+	private static int packedLength(int value) {
+		return value < 251 ? 1 : 3;
+	}
+
+	/* the body of a TRANSACTION_PAYLOAD event: (type, length, value) header triplets,
+	   end mark, then the payload bytes */
+	private static byte[] payloadEventBody(Integer compressionType, Integer uncompressedSize, byte[] payload) {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		if (compressionType != null) {
+			writePacked(out, 2); // OTW_PAYLOAD_COMPRESSION_TYPE_FIELD
+			writePacked(out, packedLength(compressionType));
+			writePacked(out, compressionType);
+		}
+		if (uncompressedSize != null) {
+			writePacked(out, 3); // OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD
+			writePacked(out, packedLength(uncompressedSize));
+			writePacked(out, uncompressedSize);
+		}
+		writePacked(out, 1); // OTW_PAYLOAD_SIZE_FIELD
+		writePacked(out, packedLength(payload.length));
+		writePacked(out, payload.length);
+		out.write(0); // end mark
+		out.write(payload, 0, payload.length);
+		return out.toByteArray();
+	}
+
+	@Test
+	public void testZstdRoundTrip() throws IOException {
+		byte[] inner = concat(xidEventBytes(111L, 1000), xidEventBytes(222L, 2000));
+		byte[] compressed = Zstd.compress(inner);
+		byte[] body = payloadEventBody(COMPRESSION_TYPE_ZSTD, inner.length, compressed);
+
+		MaxwellTransactionPayloadDeserializer deserializer = new MaxwellTransactionPayloadDeserializer(COMPAT_MODES);
+		TransactionPayloadEventData data = deserializer.deserialize(new ByteArrayInputStream(body));
+
+		assertThat(data, instanceOf(MaxwellTransactionPayloadEventData.class));
+		assertEquals(COMPRESSION_TYPE_ZSTD, data.getCompressionType());
+		assertEquals(inner.length, data.getUncompressedSize());
+		assertEquals(compressed.length, data.getPayloadSize());
+		assertNull("compressed bytes must not be retained", data.getPayload());
+		assertTrue("uncompressedEvents stays empty (lazy)", data.getUncompressedEvents().isEmpty());
+
+		MaxwellTransactionPayloadEventData lazy = (MaxwellTransactionPayloadEventData) data;
+
+		Event first = lazy.nextInnerEvent();
+		assertEquals(EventType.XID, first.getHeader().getEventType());
+		assertEquals(111L, ((XidEventData) first.getData()).getXid());
+		assertEquals(1000_000L, first.getHeader().getTimestamp());
+
+		Event second = lazy.nextInnerEvent();
+		assertEquals(222L, ((XidEventData) second.getData()).getXid());
+
+		assertNull(lazy.nextInnerEvent());
+		assertNull("cursor stays spent after the end", lazy.nextInnerEvent());
+	}
+
+	@Test
+	public void testFullEventDeserializerIntegration() throws IOException {
+		byte[] inner = xidEventBytes(333L, 1500);
+		byte[] body = payloadEventBody(COMPRESSION_TYPE_ZSTD, inner.length, Zstd.compress(inner));
+
+		/* a complete on-disk TRANSACTION_PAYLOAD event, parsed through the same outer
+		   EventDeserializer wiring BinlogConnectorReplicator sets up */
+		ByteBuffer header = ByteBuffer.allocate(19).order(ByteOrder.LITTLE_ENDIAN);
+		header.putInt(4242);
+		header.put((byte) TRANSACTION_PAYLOAD_TYPE_CODE);
+		header.putInt(1);
+		header.putInt(19 + body.length);
+		header.putInt(98765);
+		header.putShort((short) 0);
+
+		EventDeserializer outer = new EventDeserializer();
+		outer.setEventDataDeserializer(EventType.TRANSACTION_PAYLOAD, new MaxwellTransactionPayloadDeserializer(COMPAT_MODES));
+
+		Event event = outer.nextEvent(new ByteArrayInputStream(concat(header.array(), body)));
+		assertEquals(EventType.TRANSACTION_PAYLOAD, event.getHeader().getEventType());
+		assertThat(event.getData(), instanceOf(MaxwellTransactionPayloadEventData.class));
+
+		MaxwellTransactionPayloadEventData data = event.getData();
+		assertEquals(333L, ((XidEventData) data.nextInnerEvent().getData()).getXid());
+		assertNull(data.nextInnerEvent());
+	}
+
+	@Test
+	public void testUncompressedPayloadPassthrough() throws IOException {
+		byte[] inner = xidEventBytes(444L, 1600);
+		/* compression type NONE, no uncompressed-size field: defaults to the payload size */
+		byte[] body = payloadEventBody(COMPRESSION_TYPE_NONE, null, inner);
+
+		MaxwellTransactionPayloadDeserializer deserializer = new MaxwellTransactionPayloadDeserializer(COMPAT_MODES);
+		TransactionPayloadEventData data = deserializer.deserialize(new ByteArrayInputStream(body));
+
+		assertEquals(COMPRESSION_TYPE_NONE, data.getCompressionType());
+		assertEquals(inner.length, data.getUncompressedSize());
+
+		MaxwellTransactionPayloadEventData lazy = (MaxwellTransactionPayloadEventData) data;
+		assertEquals(444L, ((XidEventData) lazy.nextInnerEvent().getData()).getXid());
+		assertNull(lazy.nextInnerEvent());
+	}
+
+	@Test
+	public void testCorruptZstdPayloadThrows() {
+		byte[] junk = {1, 2, 3, 4, 5, 6, 7, 8};
+		byte[] body = payloadEventBody(COMPRESSION_TYPE_ZSTD, 27, junk);
+
+		MaxwellTransactionPayloadDeserializer deserializer = new MaxwellTransactionPayloadDeserializer(COMPAT_MODES);
+		try {
+			deserializer.deserialize(new ByteArrayInputStream(body));
+			fail("expected IOException for a corrupt zstd payload");
+		} catch (IOException e) {
+			assertThat(e.getMessage(), containsString("zstd"));
+		}
+	}
+
+	@Test
+	public void testTruncatedPayloadThrows() {
+		byte[] inner = xidEventBytes(555L, 1700);
+		byte[] compressed = Zstd.compress(inner);
+		/* declare twice the actual uncompressed size: zstd inflates less than promised */
+		byte[] body = payloadEventBody(COMPRESSION_TYPE_ZSTD, inner.length * 2, compressed);
+
+		MaxwellTransactionPayloadDeserializer deserializer = new MaxwellTransactionPayloadDeserializer(COMPAT_MODES);
+		try {
+			deserializer.deserialize(new ByteArrayInputStream(body));
+			fail("expected IOException for a truncated payload");
+		} catch (IOException e) {
+			assertThat(e.getMessage(), containsString("Truncated"));
+		}
+	}
+
+	@Test
+	public void testUnsupportedCompressionTypeThrows() {
+		byte[] body = payloadEventBody(42, 27, new byte[]{1, 2, 3});
+
+		MaxwellTransactionPayloadDeserializer deserializer = new MaxwellTransactionPayloadDeserializer(COMPAT_MODES);
+		try {
+			deserializer.deserialize(new ByteArrayInputStream(body));
+			fail("expected IOException for an unknown compression type");
+		} catch (IOException e) {
+			assertThat(e.getMessage(), containsString("Unsupported"));
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When the source MySQL is configured with `binlog_transaction_compression=ON` (MySQL 8.0.20+), Maxwell connects successfully, reports the binlog as connected, advances its binlog position, and emits **zero row events**. No error is logged.

## Root cause

With compression on, MySQL wraps each transaction's events (`TABLE_MAP`, `WRITE/UPDATE/DELETE_ROWS`, `XID`, ...) into a single zstd-compressed `TRANSACTION_PAYLOAD` event.

In `mysql-binlog-connector-java` (verified through the current `0.30.3`):

- `TransactionPayloadEventDataDeserializer` decompresses the payload and parses the inner events into `TransactionPayloadEventData.uncompressedEvents`, but
- `BinaryLogClient` never unwraps that list — it delivers the single `TRANSACTION_PAYLOAD` event to listeners and advances the position.

Maxwell's `BinlogConnectorEventListener` only handles `GTID`/`MARIADB_GTID`/`QUERY`/`XID` + row events, so the `TRANSACTION_PAYLOAD` event is silently ignored and the inner rows — sitting decompressed but un-surfaced — are dropped.

## Fix

Two changes, both Maxwell-side (no connector bump is sufficient, since even the latest connector doesn't surface the inner events):

1. **`MaxwellTransactionPayloadDeserializer`** — a drop-in `TRANSACTION_PAYLOAD` deserializer registered via `setEventDataDeserializer(...)`. It decompresses the zstd payload and parses the inner events with the **same compatibility modes Maxwell already applies** to uncompressed events (`DATE_AND_TIME_AS_LONG_MICRO`, `CHAR_AND_BINARY_AS_BYTE_ARRAY`, `INVALID_DATE_AND_TIME_AS_MIN_VALUE`).

   This matters for correctness: the stock deserializer parses the inner events with a default `EventDeserializer`, which returns `String`/`java.util.Date` instead of `byte[]`/`Long`. That silently corrupts binary/non-utf8 columns (Base64 path is skipped) and drops sub-millisecond datetime precision. With this deserializer, a compressed transaction yields byte-for-byte the same `RowMap`s as an uncompressed one.

2. **Unwrap `TRANSACTION_PAYLOAD` in `BinlogConnectorEventListener.onEvent`** — iterate the inner events and route each through `onEvent`. Inner events carry positions relative to the in-memory decompressed buffer, so each header is re-stamped with the payload event's on-disk position. Because `EventHeaderV4.getPosition()` is derived as `nextPosition - eventLength`, setting both `eventLength` and `nextPosition` to the payload's values reproduces the payload's `[position, nextPosition]` on every inner event.

   A compressed transaction occupies a single binlog offset range, so all inner events share the payload's `nextPosition`. Position is persisted only on the TX-commit row (`MaxwellContext.setPosition(RowMap)` gates on `isTXCommit()`), so the committed offset equals the payload end — identical to where an uncompressed `XID` would land.

## Follow-up commit: gtid tracking, memory behavior, zstd hardening

A second commit fixes issues found while reviewing the first one:

- **gtid mode made no durable progress with compression on.** `BinaryLogClient.updateGtidSet` has no `TRANSACTION_PAYLOAD` case, and the `XID`/`COMMIT` events that commit the pending gtid into the client's set are inside the payload — so `getGtidSet()` froze at its startup value, `BinlogPosition.newerThan` (a gtid-set containment check) rejected every position update, and a restart replayed everything since startup. New `MaxwellBinaryLogClient` translates each payload into the synthetic `XID` event the stock bookkeeping expects (a payload always wraps exactly one complete transaction; the XID branch never reads the event argument). File/offset positioning was unaffected. Long-term this belongs in the connector (`case TRANSACTION_PAYLOAD:` in `updateGtidSet`, as upstream osheroff has) — happy to PR that separately.
- **Peak memory is now bounded.** Inner events were parsed eagerly into a list, putting the whole transaction's object graph on the heap before the first event was consumed (and `BinaryLogClient` pins the payload event until the next network event arrives, so the last large transaction stayed fully retained on a quiet stream). New `MaxwellTransactionPayloadEventData` parses inner events on demand through a single-pass cursor and releases the buffer and parser at end-of-payload.
- **zstd hardening:** one reused `ZstdDecompressCtx` instead of a native context malloc/free per transaction; `ZstdException` is caught and wrapped (zstd-jni reports errors by throwing, so the previous `Zstd.isError(rc)` check was dead code); the decompressed length is validated so truncated payloads fail loudly; compression type `NONE` is supported as passthrough; the compressed bytes are no longer retained on the event data.
- Parse failures during unwrap log at ERROR with the binlog position and skip the rest of that transaction (same outcome as the client's own handling of undeserializable events, but visible in Maxwell's logs).
- `zstd-jni` is declared explicitly in the pom (used directly; version matches the connector's transitive dependency).

Unit tests added: zstd round-trip (including integration through the outer `EventDeserializer`), NONE passthrough, corrupt/truncated/unsupported payloads, gtid advancement across compressed transactions, and listener unwrap/re-stamp behavior.

## Verification

- `mvn compile` and `mvn test-compile` pass; the new unit tests pass.
- Behavior traced against the connector bytecode (the registered `TRANSACTION_PAYLOAD` deserializer is honored; `deserializeEventData` bounds the stream to the event body excluding the checksum) and against Maxwell's position-store flow.
- **Not yet exercised against a live MySQL with `binlog_transaction_compression=ON`** — I don't have that environment handy. A maintainer-side integration test (compressed source → assert datetime/binary fidelity + position advance) would be the ideal gate before merge, and I'm happy to add one with guidance on the preferred test harness.

## Known limitation

For users running a `--javascript` filter that calls `row.suppress()` **and** an async producer (Kafka/Kinesis/SQS/SNS/Pub-Sub/BigQuery): a suppressed row advances the persisted position to the end of the whole compressed transaction (rather than a mid-transaction offset as in the uncompressed case), which widens the existing suppressed-row crash window from one row to one transaction. It does not affect normal table/database filters or sync producers. Happy to close this window (stamp non-terminal inner events with the payload start) if maintainers prefer.

## Alternative

Operators who can't wait for this can set `binlog_transaction_compression=OFF` on the source (note: already-compressed transactions before the current position stay invisible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

