### PR TITLE
feat: allow configured MySQL versioned comments to be ignored during DDL parsing 

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -50,6 +50,10 @@ password=maxwell
 # enable this option Maxwell will periodically compact its tables.
 #max_schemas=10000
 
+# semicolon-separated, case-insensitive regular expressions matching the normalized content
+# inside MySQL version comments to remove before DDL parsing. Example: /*!99104 COMPRESSED */
+#ddl_versioned_comment_ignore_patterns=^COMPRESSED$;^VENDOR_ATTRIBUTE .*$
+
 # SSL/TLS options
 # To use VERIFY_CA or VERIFY_IDENTITY, you must set the trust store with Java opts:
 #   -Djavax.net.ssl.trustStore=<truststore> -Djavax.net.ssl.trustStorePassword=<password>

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -200,6 +200,7 @@ output_naming_strategy         | STRING   | naming strategy of field name of JSO
 option                         | argument                            | description                                         | default
 -------------------------------|-------------------------------------| --------------------------------------------------- | -------
 filter                         | STRING            | filter rules, eg `exclude: db.*, include: *.tbl, include: *./bar(bar)?/, exclude: foo.bar.col=val` |
+ddl_versioned_comment_ignore_patterns | STRING     | semicolon-separated, case-insensitive regular expressions matching version-comment contents to remove before DDL parsing | empty
 
 _See also:_ [filtering](/filtering)
 
@@ -290,7 +291,6 @@ The configuration priority is:
 ```
 command line options > scoped env vars > properties file > default values
 ```
-
 ## config.properties
 
 Maxwell can be configured via a java properties file, specified via `--config`
@@ -324,5 +324,3 @@ A get request will return the live config state
 	"filter": "exclude: noisy_db.*"
 }
 ```
-
-

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -70,6 +70,9 @@ public class MaxwellConfig extends AbstractConfig {
 	 */
 	public Filter filter;
 
+	/** Patterns for version-comment contents that should be removed before DDL parsing. */
+	public List<Pattern> ddlVersionedCommentIgnorePatterns = Collections.emptyList();
+
 	/**
 	 * Ignore any missing database / table schemas, unless they're
 	 * included as part of filters. Default false.  Don't use unless
@@ -800,6 +803,8 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.accepts( "ignore_missing_schema", "Ignore missing database and table schemas.  Only use running with limited permissions." )
 			.withOptionalArg().ofType(Boolean.class);
+		parser.accepts( "ddl_versioned_comment_ignore_patterns", "semicolon-separated regular expressions for version-comment contents to ignore while parsing DDL" )
+			.withRequiredArg();
 
 		parser.accepts( "javascript", "file containing per-row javascript to execute" ).withRequiredArg();
 
@@ -1214,6 +1219,9 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.filterList          = fetchStringOption("filter", options, properties, null);
 		this.ignoreMissingSchema          =  fetchBooleanOption("ignore_missing_schema", options, properties, false);
+		this.ddlVersionedCommentIgnorePatterns = parseDDLVersionedCommentIgnorePatterns(
+			fetchStringOption("ddl_versioned_comment_ignore_patterns", options, properties, null)
+		);
 
 		setupInitPosition(options);
 
@@ -1527,6 +1535,24 @@ public class MaxwellConfig extends AbstractConfig {
 		} else {
 			return Pattern.compile("^" + Pattern.quote(name) + "$");
 		}
+	}
+
+	private List<Pattern> parseDDLVersionedCommentIgnorePatterns(String value) {
+		if (value == null || value.trim().isEmpty())
+			return Collections.emptyList();
+
+		List<Pattern> patterns = new ArrayList<>();
+		for (String expression : value.split(";")) {
+			expression = expression.trim();
+			if (expression.isEmpty())
+				continue;
+			try {
+				patterns.add(Pattern.compile(expression, Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+			} catch (java.util.regex.PatternSyntaxException e) {
+				usageForOptions("Invalid ddl_versioned_comment_ignore_patterns expression '" + expression + "': " + e.getMessage(), "--ddl_versioned_comment_ignore_patterns");
+			}
+		}
+		return Collections.unmodifiableList(patterns);
 	}
 
 	private <T> T fetchFactory(OptionSet options, Properties properties, String name) {

--- a/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/AbstractSchemaStore.java
@@ -4,6 +4,8 @@ import java.sql.SQLException;
 import java.sql.Connection;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.regex.Pattern;
 
 import com.zendesk.maxwell.CaseSensitivity;
 import com.zendesk.maxwell.filtering.Filter;
@@ -22,15 +24,25 @@ public abstract class AbstractSchemaStore {
 	protected final ConnectionPool schemaConnectionPool;
 	protected final CaseSensitivity caseSensitivity;
 	private final Filter filter;
+	private final List<Pattern> ignoredDDLVersionedCommentPatterns;
 
 	protected AbstractSchemaStore(ConnectionPool replicationConnectionPool,
 								  ConnectionPool schemaConnectionPool,
 								  CaseSensitivity caseSensitivity,
 								  Filter filter) {
+		this(replicationConnectionPool, schemaConnectionPool, caseSensitivity, filter, Collections.emptyList());
+	}
+
+	protected AbstractSchemaStore(ConnectionPool replicationConnectionPool,
+								  ConnectionPool schemaConnectionPool,
+								  CaseSensitivity caseSensitivity,
+								  Filter filter,
+								  List<Pattern> ignoredDDLVersionedCommentPatterns) {
 		this.replicationConnectionPool = replicationConnectionPool;
 		this.schemaConnectionPool = schemaConnectionPool;
 		this.caseSensitivity = caseSensitivity;
 		this.filter = filter;
+		this.ignoredDDLVersionedCommentPatterns = ignoredDDLVersionedCommentPatterns;
 	}
 
 	protected AbstractSchemaStore(MaxwellContext context) throws SQLException {
@@ -46,7 +58,7 @@ public abstract class AbstractSchemaStore {
 	}
 
 	protected List<ResolvedSchemaChange> resolveSQL(Schema schema, String sql, String currentDatabase) throws InvalidSchemaError {
-		List<SchemaChange> changes = SchemaChange.parse(currentDatabase, sql);
+		List<SchemaChange> changes = SchemaChange.parse(currentDatabase, sql, ignoredDDLVersionedCommentPatterns);
 
 		if ( changes == null || changes.size() == 0 )
 			return new ArrayList<>();
@@ -68,5 +80,4 @@ public abstract class AbstractSchemaStore {
 		return resolvedSchemaChanges;
 	}
 }
-
 

--- a/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
+++ b/src/main/java/com/zendesk/maxwell/schema/MysqlSchemaStore.java
@@ -12,6 +12,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static com.zendesk.maxwell.schema.MysqlSavedSchema.restore;
 
@@ -31,7 +32,20 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 							CaseSensitivity caseSensitivity,
 							Filter filter,
 							boolean readOnly) {
-		super(replicationConnectionPool, schemaConnectionPool, caseSensitivity, filter);
+		this(maxwellConnectionPool, replicationConnectionPool, schemaConnectionPool, serverID,
+			initialPosition, caseSensitivity, filter, readOnly, Collections.emptyList());
+	}
+
+	public MysqlSchemaStore(ConnectionPool maxwellConnectionPool,
+							ConnectionPool replicationConnectionPool,
+							ConnectionPool schemaConnectionPool,
+							Long serverID,
+							Position initialPosition,
+							CaseSensitivity caseSensitivity,
+							Filter filter,
+							boolean readOnly,
+							List<Pattern> ignoredDDLVersionedCommentPatterns) {
+		super(replicationConnectionPool, schemaConnectionPool, caseSensitivity, filter, ignoredDDLVersionedCommentPatterns);
 		this.serverID = serverID;
 		this.maxwellConnectionPool = maxwellConnectionPool;
 		this.initialPosition = initialPosition;
@@ -47,7 +61,8 @@ public class MysqlSchemaStore extends AbstractSchemaStore implements SchemaStore
 			initialPosition,
 			context.getCaseSensitivity(),
 			context.getFilter(),
-			context.getReplayMode()
+			context.getReplayMode(),
+			context.getConfig().ddlVersionedCommentIgnorePatterns
 		);
 	}
 

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/DDLVersionedCommentFilter.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/DDLVersionedCommentFilter.java
@@ -1,0 +1,44 @@
+package com.zendesk.maxwell.schema.ddl;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Removes explicitly configured MySQL version comments before DDL parsing.
+ * Patterns are matched against the normalized content inside the comment, not
+ * against the complete SQL statement.
+ */
+public final class DDLVersionedCommentFilter {
+	private static final Pattern VERSIONED_COMMENT = Pattern.compile(
+		"/\\*!([0-9]*)\\s*(.*?)\\*/",
+		Pattern.DOTALL
+	);
+
+	private DDLVersionedCommentFilter() { }
+
+	public static String filter(String sql, List<Pattern> ignoredContentPatterns) {
+		if (sql == null || ignoredContentPatterns == null || ignoredContentPatterns.isEmpty())
+			return sql;
+
+		Matcher matcher = VERSIONED_COMMENT.matcher(sql);
+		StringBuffer result = new StringBuffer();
+		while (matcher.find()) {
+			String content = matcher.group(2).trim().replaceAll("\\s+", " ");
+			boolean ignored = false;
+			for (Pattern pattern : ignoredContentPatterns) {
+				if (pattern.matcher(content).matches()) {
+					ignored = true;
+					break;
+				}
+			}
+
+			matcher.appendReplacement(
+				result,
+				ignored ? "" : Matcher.quoteReplacement(matcher.group())
+			);
+		}
+		matcher.appendTail(result);
+		return result.toString();
+	}
+}

--- a/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/SchemaChange.java
@@ -106,9 +106,15 @@ public abstract class SchemaChange {
 	}
 
 	public static List<SchemaChange> parse(String currentDB, String sql) {
+		return parse(currentDB, sql, null);
+	}
+
+	public static List<SchemaChange> parse(String currentDB, String sql, List<Pattern> ignoredVersionedCommentPatterns) {
 		if ( matchesBlacklist(sql) ) {
 			return null;
 		}
+
+		sql = DDLVersionedCommentFilter.filter(sql, ignoredVersionedCommentPatterns);
 
 		while ( true ) {
 			try {

--- a/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
+++ b/src/test/java/com/zendesk/maxwell/MaxwellConfigTest.java
@@ -153,6 +153,25 @@ public class MaxwellConfigTest
 		assertEquals(config.pubsubRpcTimeoutMultiplier, 1.0f, 0.0f);
 	}
 
+	@Test
+	public void testDDLVersionedCommentIgnorePatterns() {
+		config = new MaxwellConfig(new String[] {
+			"--ddl_versioned_comment_ignore_patterns=^COMPRESSED$;^VENDOR ATTRIBUTE$"
+		});
+		assertEquals(2, config.ddlVersionedCommentIgnorePatterns.size());
+		assertTrue(config.ddlVersionedCommentIgnorePatterns.get(0).matcher("compressed").matches());
+		assertTrue(config.ddlVersionedCommentIgnorePatterns.get(1).matcher("vendor attribute").matches());
+	}
+
+	@Test
+	public void testDDLVersionedCommentIgnorePatternsFromConfigFile() {
+		String configPath = getTestConfigDir() + "ddl-versioned-comment-config.properties";
+		config = new MaxwellConfig(new String[] { "--config=" + configPath });
+		assertEquals(2, config.ddlVersionedCommentIgnorePatterns.size());
+		assertTrue(config.ddlVersionedCommentIgnorePatterns.get(0).matcher("compressed").matches());
+		assertTrue(config.ddlVersionedCommentIgnorePatterns.get(1).matcher("vendor attribute").matches());
+	}
+
 
 	private String getTestConfigDir() {
 		return System.getProperty("user.dir") + "/src/test/resources/config/";

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -11,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import com.zendesk.maxwell.schema.columndef.ColumnDef;
 
@@ -34,6 +36,34 @@ public class DDLParserTest {
 
 	private TableCreate parseCreate(String sql) {
 		return (TableCreate) parse(sql).get(0);
+	}
+
+	@Test
+	public void testConfiguredVersionedCommentsAreIgnored() {
+		List<Pattern> patterns = Arrays.asList(
+			Pattern.compile("^COMPRESSED$", Pattern.CASE_INSENSITIVE),
+			Pattern.compile("^VENDOR ATTRIBUTE$", Pattern.CASE_INSENSITIVE)
+		);
+		String sql = "CREATE TABLE step_instance ("
+			+ "id BIGINT NOT NULL, "
+			+ "target_servers LONGTEXT /*!99104 COMPRESSED */, "
+			+ "metadata LONGTEXT /*!99105 vendor   attribute */, "
+			+ "PRIMARY KEY (id), KEY idx_step (id)) ENGINE=InnoDB";
+
+		List<SchemaChange> changes = SchemaChange.parse("default_db", sql, patterns);
+		assertThat(changes, is(notNullValue()));
+		assertThat(changes.size(), is(1));
+		assertThat(((TableCreate) changes.get(0)).columns.size(), is(3));
+	}
+
+	@Test
+	public void testNonMatchingVersionedCommentsArePreserved() {
+		String sql = "CREATE TABLE test (id INT /*!80000 NOT NULL */)";
+		String filtered = DDLVersionedCommentFilter.filter(
+			sql,
+			Arrays.asList(Pattern.compile("^COMPRESSED$", Pattern.CASE_INSENSITIVE))
+		);
+		assertThat(filtered, is(sql));
 	}
 
 	@Test

--- a/src/test/resources/config/ddl-versioned-comment-config.properties
+++ b/src/test/resources/config/ddl-versioned-comment-config.properties
@@ -1,0 +1,1 @@
+ddl_versioned_comment_ignore_patterns=^COMPRESSED$;^VENDOR ATTRIBUTE$


### PR DESCRIPTION
## Summary

Add a configurable way to ignore selected MySQL versioned comments before Maxwell parses DDL statements.

This fixes schema parsing failures caused by vendor-specific table or column attributes that Maxwell's DDL grammar does not recognize.

## Problem

Some MySQL-compatible databases emit DDL containing versioned comments such as:

```sql
CREATE TABLE step_instance (
  id BIGINT NOT NULL,
  target_servers LONGTEXT /*!99104 COMPRESSED */,
  PRIMARY KEY (id)
);
``` 
Maxwell currently exposes the content of this comment to the DDL parser. Since COMPRESSED is not valid in this grammar position, schema processing fails and Maxwell exits.
A typical error is:
```
SchemaChange: Error parsing SQL
```
This can later leave Maxwell's stored schema inconsistent with the binlog.

Solution
Introduce a new configuration option:
```
ddl_versioned_comment_ignore_patterns=^COMPRESSED$
```
The option contains semicolon-separated regular expressions matched against the normalized content of MySQL versioned comments.
For example:
```
ddl_versioned_comment_ignore_patterns=^COMPRESSED$;^VENDOR_ATTRIBUTE .*$
```

fix:  #2259  