### PR TITLE
Fix parsing of escaped backticks in quoted identifiers

### DIFF
--- a/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
+++ b/src/main/java/com/zendesk/maxwell/schema/ddl/MysqlParserListener.java
@@ -41,7 +41,10 @@ public class MysqlParserListener extends mysqlBaseListener {
 
 	private String unquote(String ident) {
 		if ( ident.startsWith("`") || ident.startsWith("\"")) {
-			return ident.substring(1, ident.length() - 1);
+			// mysql escapes the quote character inside a quoted identifier by
+			// doubling it, so `foo``bar` names the table  foo`bar
+			String quote = ident.substring(0, 1);
+			return ident.substring(1, ident.length() - 1).replace(quote + quote, quote);
 		} else
 			return ident;
 	}

--- a/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
+++ b/src/test/java/com/zendesk/maxwell/schema/ddl/DDLParserTest.java
@@ -478,6 +478,22 @@ public class DDLParserTest {
 	}
 
 	@Test
+	public void testEscapedBacktickInIdentifiers() {
+		// mysql escapes a backtick inside a quoted identifier by doubling it, so
+		// `otherdbcopy.``otherdbtable` names the table  otherdbcopy.`otherdbtable
+		List<SchemaChange> changes = parse("drop table actualdb.`otherdbcopy.``otherdbtable`");
+		TableDrop d = (TableDrop) changes.get(0);
+		assertThat(d.database, is("actualdb"));
+		assertThat(d.table, is("otherdbcopy.`otherdbtable"));
+
+		// the same unescaping applies to any quoted identifier, not just table names
+		TableCreate c = parseCreate("create table `db``1`.`tbl``1` (`col``1` int)");
+		assertThat(c.database, is("db`1"));
+		assertThat(c.table, is("tbl`1"));
+		assertThat(c.columns.get(0).getName(), is("col`1"));
+	}
+
+	@Test
 	public void testCreateDatabase() {
 		List<SchemaChange> changes = parse("CREATE DATABASE if not exists `foo` default character set='latin1'");
 		DatabaseCreate create = (DatabaseCreate) changes.get(0);


### PR DESCRIPTION
Fixes #2244.

## Problem

MySQL escapes a quote character inside a quoted identifier by doubling it, so ``` `otherdbcopy.``otherdbtable` ``` names the table ``otherdbcopy.`otherdbtable``. The lexer already accepts this (`QUOTED_IDENT: BACKTICK (('``') | ~('`'))+ BACKTICK`), but `unquote()` only stripped the outer pair:

```java
if ( ident.startsWith("`") || ident.startsWith("\"")) {
    return ident.substring(1, ident.length() - 1);
}
```

The doubled backtick survived into the resolved name, so the schema lookup searched for a table whose name contains two literal backticks and threw:

```
com.zendesk.maxwell.schema.ddl.InvalidSchemaError: Couldn't find table 'otherdbcopy.``otherdbtable' in database actualdb
	at com.zendesk.maxwell.schema.Database.findTableOrThrow(Database.java:55)
	at com.zendesk.maxwell.schema.ddl.ResolvedTableDrop.apply(ResolvedTableDrop.java:19)
```

That propagates out of `processQueryEvent`, so a single DDL statement referencing such a table stops replication.

`unquote()` is shared by db, table and column name handling, so the same truncation applied to any quoted identifier containing an escaped quote, not only the `DROP TABLE` in the issue.

## Fix

Collapse the doubled quote character after stripping the outer pair, using whichever quote character opened the identifier so double-quoted identifiers (`ANSI_QUOTES`) behave the same way.

## Testing

Added `DDLParserTest.testEscapedBacktickInIdentifiers`, covering the `DROP TABLE` from the issue plus a `CREATE TABLE` that exercises db, table and column names.

Against unmodified `master` it fails with exactly the symptom reported:

```
Expected: is "otherdbcopy.`otherdbtable"
     but: was "otherdbcopy.``otherdbtable"
```

and passes with the fix.

`DDLParserTest` is green (48 tests), as are the other suites that run without a MySQL server: `FilterTest`, `ColumnDefTest`, `RowMapTest`, `RowIdentityTest`, `RowMapDeserializerTest`, `MariaDBSyntaxTest`, `MaxwellMysqlConfigTest`, `MysqlVersionTest`, `ScriptingTest`, `TopicInterpolatorTest`.

I could not run the suites that boot an isolated MySQL (`DDLResolverTest`, `DDLSerializationTest`, and the other `MaxwellTestWithIsolatedServer` subclasses); `src/test/onetimeserver` will not execute on Windows. I confirmed those fail identically on an unmodified checkout, so they are environmental rather than related to this change. Worth a look from CI on those.
